### PR TITLE
Validate C7/C6 benchmark correction and live metrics sink

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,73 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install -e '.[test]' build
+      - run: ruff check .
+      - run: ruff format --check .
+      - run: pytest
+      - run: python -m compileall -q .
+      - run: python -m build
+      - name: Validate built wheel in an isolated environment
+        run: |
+          WHEEL="$(pwd)/$(ls dist/*.whl | head -n 1)"
+          python -m venv --system-site-packages /tmp/h3-flow-wheel
+          /tmp/h3-flow-wheel/bin/python -m pip install --upgrade pip
+          /tmp/h3-flow-wheel/bin/python -m pip install --no-deps "$WHEEL"
+          (cd /tmp && /tmp/h3-flow-wheel/bin/python -c "import h3_flow_regenerate; assert h3_flow_regenerate.H3FlowTrajectory.api_version == 1")
+
+  source-contracts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Fetch pinned integration sources
+        run: |
+          git clone --filter=blob:none https://github.com/Comfy-Org/ComfyUI.git .contracts/ComfyUI
+          git -C .contracts/ComfyUI checkout 1af040bf022569d7a890241c8dd79b296cda483f
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3.git .contracts/Spectrum
+          git -C .contracts/Spectrum checkout beb32dd210ef9e95520453107f158241d4f2ecf3
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-H3-Continuum.git .contracts/Continuum
+          git -C .contracts/Continuum checkout bf25353d8bec44afea22c89717c4301ce13c2036
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-DiffAid-Patches.git .contracts/DiffAid
+          git -C .contracts/DiffAid checkout ba9d9efbcf7e64c755e068cb76547d8cc85481eb
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-MiniMax-H3-RefDelta-Solver.git .contracts/RefDelta
+          git -C .contracts/RefDelta checkout 034e4c4c14c56bf76813cee4765e7164b0c7e0db
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-Untwisting-RoPE.git .contracts/Untwist
+          git -C .contracts/Untwist checkout 299d4c56a3f057a97b3140d2136189bcd1e7d6bb
+          git clone --filter=blob:none https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler.git .contracts/Upscaler
+          git -C .contracts/Upscaler checkout 2c707492084962f7ed665e8817a05a11b14dab27
+      - name: Validate native and sibling contracts
+        run: >-
+          python tools/check_source_contracts.py
+          --comfy .contracts/ComfyUI
+          --spectrum .contracts/Spectrum
+          --continuum .contracts/Continuum
+          --diffaid .contracts/DiffAid
+          --refdelta .contracts/RefDelta
+          --untwist .contracts/Untwist
+          --upscaler .contracts/Upscaler

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,9 @@
+__pycache__/
+*.py[cod]
+.pytest_cache/
+.ruff_cache/
+.venv/
+build/
+dist/
+*.egg-info/
+.contracts/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,228 @@
 # MiniMax H3 Flow-Aligned Regenerate
 
-Research repository for H3-native coarse-to-fine and progressive-resolution generation in ComfyUI.
+Research-grade ComfyUI nodes for H3-native coarse-to-fine generation: transactional
+low-resolution trajectory capture, time-aligned high-resolution guidance, and a true
+in-flight spatial-resolution handoff.
 
-Implementation is under active development. No release is available yet.
+> [!IMPORTANT]
+> This project is an independent, training-free approximation informed by public
+> research. It does **not** reproduce MiniMax's closed H3-Regenerate-2K model or its
+> unreleased sparse-attention topology. Every semantics-changing mode is experimental
+> until matched decoded-media validation is complete.
+
+## Why this exists
+
+In the motivating workflow, native H3 generation near 0.8 MP was visibly weaker than
+generation on a 54x40 video-latent grid (864x640 pixels), followed by a learned latent
+upscale and low-sigma H3 refinement on a 64x48 grid (1024x768 pixels). The latter repeats
+part of the denoising trajectory and costs extra H3 evaluations.
+
+This package tests three narrower hypotheses:
+
+1. an additional resolution-dependent flow coordinate may improve native high-resolution scheduling;
+2. intermediate low-resolution clean-state estimates may guide a high-resolution pass;
+3. early low-resolution steps can transition grids without replaying the late trajectory.
+
+H3 is treated as its actual joint AV model: 24-channel video, 32-channel two-track audio,
+16x spatial VAE compression, a `(1, 2, 2)` DiT patch, video/audio shifts 12/3, and a packed
+`text | conditioning/reference | audio | video` transformer sequence.
+
+## Status
+
+The architecture, guards, instrumentation, and synthetic test suite are implemented.
+Decoded-media comparison is still required before recommending non-native settings. The
+safe default for the schedule, reference budget, and attention lab is `off`/`native`.
+
+## Install
+
+From `ComfyUI/custom_nodes`:
+
+```bash
+git clone https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate.git
+```
+
+Restart ComfyUI. PyTorch is supplied by ComfyUI; no sibling custom node is required to
+import this package. The learned LBH upscaler remains an optional, separately installed
+component and is used upstream when desired.
+
+## Nodes
+
+| Node | Purpose | Default posture |
+|---|---|---|
+| MiniMax H3 Flow Trajectory | Explicit `H3_FLOW_TRAJECTORY` handle with RAM/VRAM policy | RAM |
+| MiniMax H3 Trajectory Capture | Transactionally records exact denoised estimates | Stable infrastructure |
+| MiniMax H3 Flow-Aligned Regenerate | Time-matched low-frequency guidance for an explicit second-pass MODEL | Conservative direction term |
+| MiniMax H3 Flow-Aligned Refine State | Patches Continuum V3.4 per-chunk refine_state for the integrated learned-upscale/refine node | Conservative direction term |
+| MiniMax H3 Progressive Handoff | Low-grid input grows to the target grid during one full schedule | Experimental |
+| MiniMax H3 Progressive Handoff (Target Input) | Keeps the workflow/session on the final grid but runs the early H3 stage internally on a smaller grid | Experimental; Continuum-compatible topology |
+| MiniMax H3 Resolution-Aware Sigmas | Composed resolution/H3 flow shift | Off |
+| MiniMax H3 Reference Budget | Token diagnostics and direct-reference-only cap | Native |
+| MiniMax H3 Attention Lab | Sampled diagnostics and guarded H3-local attention | Native |
+| MiniMax H3 Metrics JSON | Structured counters/events for benchmark capture | On demand |
+
+### Two-pass flow-aligned use
+
+1. Create one **Flow Trajectory** handle.
+2. Patch the low-resolution H3 model with **Trajectory Capture** and run the base sample.
+3. Perform the existing learned latent upscale, or another explicit initialization step.
+4. Patch the high-resolution H3 model with **Flow-Aligned Regenerate**, using the same trajectory.
+   If that initialization path resizes/rebuilds H3 conditioning (for example target keyframes), connect
+   the **low-pass positive CONDITIONING** to the optional **source_conditioning** input and, when the
+   guider used classifier-free negative conditioning, connect the matching low-pass negative to
+   **source_negative**. This binds trajectory identity to the conditioning that actually produced pass
+   one instead of comparing it against resized high-pass conditioning.
+5. For one combined benchmark log, also feed the **Trajectory Capture** metrics output into the
+   downstream regenerate/refine adapter's optional `metrics` input.
+6. Keep pass-one audio locked in the surrounding workflow.
+
+Trajectory conditioning identity remains strict. The standalone regenerate node therefore accepts an
+optional **source_conditioning** identity input, plus **source_negative** when the low guider used a
+negative branch, for workflows whose high-pass conditioning legitimately changes geometry after the low
+pass. If source conditioning is omitted, the high guider's live conditioning is used and must match the
+captured run. The Continuum refine-state adapter already derives its positive-only BasicGuider identity
+from sampler 1's exact captured positive conditioning.
+
+The high-resolution model call is guided only in low spatial frequencies. Its control schedule is
+normalized to the first coordinate of that high-resolution invocation, so low-sigma refinement starts
+at the configured guidance strength and then weakens toward zero. Exact H3 model evaluations are
+preferred as trajectory anchors; Spectrum forecasts retain their provenance
+and are excluded from trustworthy anchors by default. The regenerate patch reads the supplied
+trajectory but does not append the high-resolution pass back into it, so the low-resolution
+source run cannot be silently replaced by its own guided output. HiFlow-style initialization
+alignment is not exposed as a two-pass guidance mode: its published operation changes the
+high-resolution sampler's starting state, whereas this node modifies denoised predictions.
+Use the explicit upstream initialization/refine step or the progressive handoff path instead.
+
+### Continuum V3.4 integrated-refine use
+
+**Flow Trajectory** is prompt-local mutable state and deliberately bypasses Comfy's reusable node-output cache, so every queued prompt starts with a fresh trajectory/metrics dependency graph rather than silently inheriting runs from an earlier prompt. Keep **Flow Trajectory → max_runs** at least as large as the number of physical chunks that will be refined; the node default is 16 to cover Continuum's current maximum sequence length. Downstream refinement happens after the base sampler has emitted its chunk list, so a smaller history can evict early chunk trajectories before their matching refine item executes. Keep Continuum **Run Storage off** for the initial two-pass validation: a reused base chunk does not replay this node's trajectory-capture sampler lifetime, so cached media alone is not a valid source trajectory for a fresh refine pass.
+
+For the current integrated **MiniMax H3 Latent Upscaler + Refine (3D)** path, do not look for a
+MODEL output from the learned upscaler. Enable Continuum's `emit_refine_conditioning`, pass each
+chunk's `refine_state` through **Flow-Aligned Refine State**, and connect that patched state to the
+integrated upscaler/refine node. Patch the MODEL entering Continuum with **Trajectory Capture**
+after the normal DiffAid/Untwist/Spectrum patches. The refine-state adapter preserves the exact
+chunk positive conditioning and any opaque refine-state fields while changing only its fresh per-chunk
+MODEL clone. Continuum V3.4 internally captures the sampler-boundary `noise_mask`, but its public
+`H3_CONTINUUM_REFINE_STATE` emits only API + MODEL + positive conditioning; the captured mask is
+instead restored onto the parallel video/audio LATENT outputs. The integrated upscaler/refine resolves
+MODEL + positive from `refine_state` and its actual refinement denoise mask from those LATENT inputs,
+so the LATENT wires remain connected directly and unmodified.
+
+Target-grid `minimax_keyframes` are expected to be spatially resized by the learned-refine node.
+The refine-state adapter therefore records the sampler-1 conditioning signature before that resize
+and binds sampler 2 to it explicitly. There is no keyframe-specific geometry exemption in the
+trajectory identity check: keyframe latents/shape, Qwen/context tensors, and independent
+`minimax_refs` all pass through the same bounded deterministic content fingerprint. The fingerprint
+samples tensor positions instead of reading every tensor byte back from the accelerator, so it is a
+practical drift fence rather than a cryptographic proof of full tensor equality.
+
+### Progressive handoff use
+
+Both progressive nodes require a complete H3 1-to-0 sigma schedule, split it at the closest valid
+unshifted coordinate, invoke the selected native sampler for the low stage, perform one explicit H3
+clean-state probe, create the target-grid conditional state, and start a fresh sampler invocation on
+the high grid. Partial low-sigma refinement schedules are rejected because their absolute flow origin
+is ambiguous for a progressive split.
+
+Use **Progressive Handoff** when the sampler input itself is the low grid and changing the workflow's
+output latent geometry is acceptable. Use **Progressive Handoff (Target Input)** for Continuum V3.4:
+configure Continuum at the final 1024x768 target, set the progressive source to 864x640, and patch the
+MODEL entering Continuum. The wrapper derives a fresh low-grid video noise tensor, downsizes the
+target-grid latent/mask/keyframes for the low and probe stages, then returns to the untouched target
+latent/mask/keyframe contract for the high stage. In masked target-input mode, protected regions also
+keep Continuum's original target-grid noise because native H3 uses that noise in its 0.999 visual
+conditioning injection. Continuum therefore always receives and stores
+64x48 output chunks, so native masked continuation and session geometry remain target-sized across
+multiple chunks.
+
+The split invocation is the reset contract: SA/PECE Adams history and Spectrum hidden-feature
+history cannot cross the geometry boundary. The exact probe and high stage advertise
+`h3_refinement` API v1 with a full-schedule sigma reference; the high stage additionally requests
+a mandatory actual prefix. Audio is never spatially transformed. In target-input mode the original
+audio noise/latent/mask are preserved while only the early video grid is reduced. Handoff and
+low-grid source noise use isolated documented CPU generators derived from the graph seed.
+
+All source/target latent H/W are normalized to even values. H3's native circular padding is never
+used as an alignment mechanism; this prevents the known odd-grid flashing-border failure.
+
+## Compatibility
+
+- **ComfyUI:** targets current native H3 and fails closed if the 24/32-channel, `(1,2,2)`,
+  shift-12/3 contract is absent.
+- **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** downstream sampler objects are preserved. The
+  progressive split creates independent solver lifetimes. Unclassified calls remain explicit.
+- **Spectrum:** no import dependency. Actual/forecast, solver-phase, and outer-step metadata are
+  consumed when present. A new downstream outer-sample execution is used per geometry.
+- **Continuum:** trajectory selection uses the available chunk identity plus the bounded conditioning
+  signature (and a session namespace when one is present). Current Continuum V3.4 interop does not
+  expose a unique sequence/session ID, so use a separate trajectory handle for each independent
+  Continuum sequence. Conditioning identity adds a strong drift/cross-talk fence but cannot uniquely
+  distinguish two independent sequences whose relevant conditioning fingerprints are identical.
+  Multi-chunk progressive use must use the Target Input node so Continuum's latent/session geometry
+  remains on the final grid.
+- **DiffAid / Untwisting RoPE:** patches stay in the downstream path. The `h3_refinement` exact-anchor
+  contract is published during the high stage.
+- **Other attention overrides:** experimental sparse attention delegates to the existing provider.
+
+## Experimental controls
+
+`direction+acceleration` is an experimental first-difference trajectory proxy. It needs adjacent exact
+trajectory support and is bounded by an RMS guard; it is not an implementation of HiFlow's published
+acceleration-alignment equations. Progressive nodes expose the acceleration, consistency, and
+low-frequency controls needed by their selectable guidance modes; a selected mode is never left with
+an inaccessible mode-specific weight.
+`downsample_consistency` is an independent alternative. The direct reference cap changes only H3's
+direct latent-reference rows; already encoded Qwen3-VL tokens are measured and left unchanged.
+Sparse attention retains global text/reference/audio paths and global temporal video reach, but is
+an investigative implementation rather than a reconstruction of MiniMax internals. Resolution-aware
+sigmas move H3's shared AV flow coordinate, so they also change the derived audio sigma schedule;
+the probe is not a video-only schedule modifier and requires decoded-audio validation.
+
+## Metrics and benchmarking
+
+Runtime events distinguish H3 transformer calls from Spectrum forecasts and record sigma, the
+unshifted coordinate, sampler topology, progressive low/probe/high stage, packed layout rows,
+trajectory transactions, guidance correction magnitude/time, handoff decisions, exact probes,
+reset/re-anchor evidence, and attention fallbacks. Use the
+[benchmark protocol](docs/BENCHMARKS.md) and [machine-readable matrix](workflows/benchmark-matrix.json)
+for matched runs. The `workflows/` directory also includes two-pass and progressive graph overlays.
+Decoded video and audio—not preview frames or logs—are the quality gate.
+
+## Development
+
+```bash
+python -m pip install -e '.[test]'
+ruff check .
+ruff format --check .
+pytest
+python -m compileall -q .
+python -m build
+```
+
+See [architecture and derivations](docs/ARCHITECTURE.md), [research transfer notes](docs/RESEARCH.md),
+and [benchmark instructions](docs/BENCHMARKS.md).
+
+## Limitations
+
+- No decoded-media claim is made yet.
+- The progressive probe intentionally costs one visible exact H3 NFE at the transition.
+- Target-input progressive mode intentionally derives its private low-grid **video** noise from a
+  documented standard-Gaussian CPU generator keyed by the graph seed; it cannot preserve the semantics
+  of an arbitrary custom/non-Gaussian video-noise node at that private grid. The caller's audio noise
+  and target-grid protected-region noise remain preserved.
+- Progressive handoff rejects sampler objects with an explicit `noise_sampler`. Standard native
+  SA/SEEDS/ER-SDE samplers create their seed-derived noise sampler inside each independent invocation;
+  reusing an opaque caller-supplied noise-sampler closure could carry mutable RNG/history across the
+  low/high reset boundary, so that contract fails closed.
+- Progressive handoff carries ComfyUI denoise-mask semantics across the grid transition by resizing
+  ComfyUI's prepared packed video mask, preserving the audio mask, spatially transferring the sampler
+  `latent_image`, and reconstructing the exact noise argument against that preserved latent state.
+  This path is synthetic-tested but still requires real masked Continuum media validation.
+- Reference decoupling cannot retroactively change Qwen3-VL tokens.
+- Trajectory capture, trajectory-guided regeneration, and progressive handoff currently fail closed
+  when ComfyUI dispatches parallel multi-GPU model calls. Their mutable transaction/guidance/split-stage
+  state is intentionally not shared across concurrent device calls until a reviewed multi-GPU ordering
+  contract exists.
+- The sparse path uses bounded query chunks and may not improve wall time on every backend.
+- Model assets, the optional learned upscaler, and sibling custom nodes are not bundled.

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,6 @@
+try:
+    from .h3_flow_regenerate.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+except ImportError:  # Direct-file import used by packaging and test smoke checks.
+    from h3_flow_regenerate.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+
+__all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,271 @@
+# Architecture and derivations
+
+## Verified native H3 contract
+
+Current ComfyUI implements MiniMax H3 as a joint audio/video flow model. Video is
+`B x 24 x T x H x W`; audio is `B x 32 x 2 x Ta`. The sampler flattens both streams into
+one state and scales audio by `12/3 = 4` so the packed state follows video sigma. Inside
+the DiT, audio sigma is reconstructed through the common unshifted coordinate.
+
+The DiT patch is `(1,2,2)`, so video latent H/W must be even. The VAE spatial factor is 16.
+A pixel dimension aligned to 32 maps cleanly through VAE and DiT patching. The transformer packs
+text, keyframe/direct reference rows, audio, then video, and derives area-normalized MM-RoPE
+coordinates from the current layout.
+
+## Flow coordinates and joint AV law
+
+Define
+
+\[
+f_s(t)=\frac{s t}{1+(s-1)t},\qquad
+f_s^{-1}(\sigma)=\frac{\sigma}{s+(1-s)\sigma}.
+\]
+
+H3 video uses `sigma_v = f_12(t)` and derives
+
+\[
+\sigma_a=f_3(f_{12}^{-1}(\sigma_v)).
+\]
+
+Trajectory matching and handoff selection use `t = f_12^-1(sigma_v)`. This retains one
+full-trajectory coordinate for both streams and avoids matching different samplers by step index.
+
+### Resolution-aware schedule probe
+
+SD3 derives `alpha = sqrt(m/n)` for target/source observations under a constant-image assumption
+and uses `f_alpha(t)`. That assumption does not establish an optimal H3 video mapping, so the node
+is off by default. Since `f_a(f_b(t)) = f_ab(t)`, an already H3-shifted schedule maps as
+
+\[
+\sigma'_v=f_{12}(f_\alpha(f_{12}^{-1}(\sigma_v))).
+\]
+
+H3 still inverts video to the new base coordinate and applies `f_3` for audio. Therefore this
+SIGMAS-only experiment moves the shared AV coordinate and changes the derived audio sigma schedule
+as well; it is not a video-only schedule modifier. Analytic tests cover endpoints, monotonicity,
+inverse/composition behavior, and AV invariants, while decoded audio remains part of the media gate.
+
+## Transactional trajectory schema
+
+`H3_FLOW_TRAJECTORY` owns immutable committed runs and at most one pending transaction. A run has
+API version, run/session/chunk IDs, sampler and schedule signatures, latent/pixel/padded geometry,
+audio shape, AV latent-layout and conditioning signatures, storage policy, timestamps, and samples. Each
+sample records unshifted coordinate, both stream sigmas, outer/call index, phase, actual/forecast
+provenance, and video denoised estimate.
+
+Capture wraps ComfyUI `PREDICT_NOISE`; current ComfyUI's sampling function returns the CFG-combined
+denoised estimate at that wrapper point, not raw H3 velocity. The flow PREDICT wrapper is deliberately
+inside Spectrum's PREDICT wrapper, so Spectrum's call-local copied model options carrying
+`spectrum_h3_actual`, solver phase, and outer-step identity reach capture before Spectrum finalizes the
+step. Failed outer sampling records a bounded incomplete diagnostic run. Only complete runs are
+selectable. CPU storage detaches, copies as fp32, and pins when CUDA is available; VRAM storage clones.
+
+Trajectory selection is newest-attempt strict within the requested session/chunk/conditioning identity:
+an aborted or invalidated run for that identity blocks fallback to an older successful run. Conditioning
+is part of selection rather than only a post-selection assertion. Current Continuum interop metadata
+does not expose a unique sequence/session identifier, so independent Continuum sequences should use
+separate trajectory handles. The conditioning filter prevents ordinary same-index cross-talk when their
+fingerprints differ, but it cannot disambiguate two independent sequences with identical relevant
+conditioning fingerprints. Newest-attempt strictness also prevents a failed regeneration attempt from
+silently reactivating stale low-resolution guidance state.
+
+A sampler may finish while a diagnostic trajectory contains only Spectrum forecasts. Such a run remains
+recorded as complete sampling telemetry, but it is not selectable as a guidance source: selection requires
+at least one provenance=`actual` anchor and fails before the target sampler begins otherwise.
+
+ComfyUI's `ModelPatcher.clone()` recursively copies dict/list containers but leaves arbitrary objects
+shared by reference. The flow binding therefore installs an `ON_CLONE` callback: clones share only the
+intentional trajectory handle, immutable guidance config, and metrics sink, while receiving fresh
+capture transaction, selected-guidance-run, and guidance-state fields. This prevents downstream model
+branching (including Continuum's per-chunk MODEL clones) from sharing mutable execution state.
+
+Capture is an explicit binding capability rather than a side effect of holding a trajectory handle.
+The capture node and progressive handoff enable writes; the two-pass regenerate node is read-only so
+a guided target pass cannot become the next source trajectory by accident. Forecast calls advance
+topology but are stored only when explicitly requested. Exact anchors drive guidance. At duplicate
+SA-Solver-PECE coordinates, corrected exact endpoints take precedence over predicted endpoints; a
+dedicated handoff probe takes precedence at the split coordinate.
+
+Standalone two-pass workflows may legitimately rebuild target-grid conditioning between sampler 1
+and sampler 2 (the learned H3 upscaler resizes target keyframes). The trajectory fingerprint is not
+weakened to accommodate that geometry change. Instead, **Flow-Aligned Regenerate** accepts an optional
+`source_conditioning` input and optional `source_negative` input, then stores the exact guider-key
+shape (`positive`, and `negative` when supplied) in the bounded signature expected from sampler 1.
+A negative without source positive is rejected. When source conditioning is absent, selection uses
+sampler 2's live guider conditioning and therefore requires true conditioning parity. Continuum's
+refine-state adapter uses a positive-only BasicGuider and obtains that source identity directly from
+the exact sampler-1 positive conditioning captured in `H3_CONTINUUM_REFINE_STATE`.
+
+## Two-pass flow guidance
+
+HiFlow's published initialization alignment changes the high-resolution sampler state before the
+guided trajectory begins. This package does not label a PREDICT_NOISE correction as initialization
+alignment. The two-pass node therefore exposes only direction, the experimental acceleration proxy,
+and downsample-consistency guidance; sampler initialization remains an explicit upstream workflow
+operation. Progressive handoff uses the rectified-flow conditional-state law described below.
+
+Exact low-grid clean estimates bracket and interpolate the high call's coordinate. A cheap spatial
+map `U` transfers the reference. The conservative direction update is
+
+\[
+\hat x^{HR}_0 \leftarrow \hat x^{HR}_0 +
+\lambda(t)L\left(U(\hat x^{LR}_0(t))-\hat x^{HR}_0\right),
+\]
+
+where `L` is an explicit average-pool low-frequency projection. The schedule weight is normalized
+to the first coordinate of the current high-resolution invocation, i.e. `(t / tau)^p` clamped to
+`[0,1]`, rather than to the full 1-to-0 trajectory. This preserves the intended weakening schedule
+when a refine pass begins at low sigma. A per-sample RMS bound limits the correction. The optional
+acceleration term compares adjacent low/high denoised-estimate changes and
+stays inactive until prior exact state exists. This is an experimental first-difference proxy; it does
+not reproduce HiFlow's acceleration formulation, which is derived from changes in the reference-flow
+velocity field. Downsample consistency forms the low-grid residual before lifting it.
+
+### Continuum integrated-refine adapter
+
+The public trajectory node returns an always-changed Comfy cache fingerprint because its output is mutable execution state. Each queued prompt therefore receives a fresh handle, while all nodes inside that prompt still share the same object. This prevents old completed/aborted runs and accumulated metrics from leaking into later prompt executions through Comfy's intermediate-node cache.
+
+The trajectory history is a delayed-consumer buffer in this topology: Continuum samples its base chunk list before downstream list-mapped refinement consumes the matching runs. `max_runs` therefore must be at least the number of physical refine items; the public node default is 16, matching Continuum's current maximum configured chunk count. Eviction remains bounded and deterministic. Initial validation keeps Continuum Run Storage off because cache reuse can return a previously sampled chunk without executing the current capture wrapper, leaving no fresh trajectory transaction corresponding to that refine item.
+
+Current Continuum V3.4 internally captures MODEL, positive conditioning, and the sampler-boundary
+`noise_mask` for every freshly sampled chunk. Its public `H3_CONTINUUM_REFINE_STATE` deliberately
+emits only API + a fresh per-chunk MODEL + exact positive conditioning; the captured mask is split and
+reattached to the parallel video/audio LATENT outputs instead. The learned H3 upscaler/refine consumes
+MODEL + positive from the refine state and derives its refinement `denoise_mask` from the LATENT
+input. There is therefore no external high-resolution MODEL wire to patch, and the LATENT mask path
+must remain intact. The **Flow-Aligned Refine State** node shallow-copies the public state, patches only
+its MODEL with read-only trajectory guidance, and preserves positive plus any future/opaque fields.
+
+The learned refine path legitimately resizes target-grid `minimax_keyframes` before sampler 2.
+The adapter computes the same content signature as CFGGuider conversion from the exact sampler-1
+`positive` object and stores it on the read-only guidance binding. Sampler 2 is checked against that
+source signature rather than against its resized conditioning. There is no keyframe-specific
+geometry/content exemption: keyframe tensors/shape, Qwen/context tensors, and independent
+`minimax_refs` all pass through the same bounded deterministic fingerprint. That fingerprint samples
+tensor positions to avoid full accelerator readback; it is intended to reject ordinary conditioning
+drift, not to prove byte-for-byte tensor identity.
+
+## Progressive handoff law
+
+The flow wrapper is first in ComfyUI's outer-sample chain. Progressive mode accepts only a complete
+1-to-0 H3 sigma schedule and invokes the downstream chain three times, creating fresh Spectrum and
+multistep lifetimes:
+
+1. low-grid native sampler over the early schedule;
+2. one exact denoised probe at the nonterminal handoff sigma;
+3. high-grid native sampler over the remaining schedule.
+
+ComfyUI's flow sampler returns an inverse-scaled state at nonterminal sigma. The wrapper reverses
+that output transform to recover packed `x_sigma`. The probe feeds that exact state through the normal
+guider/model path and compensates terminal inverse scaling, yielding `x0_hat` with one visible NFE.
+
+The target video state uses the rectified-flow conditional law
+
+\[
+x^{HR}_\sigma=(1-\sigma)U(\hat x^{LR}_0)+\sigma\epsilon^{HR},
+\qquad \epsilon^{HR}\sim\mathcal N(0,I).
+\]
+
+This supplies high-frequency stochastic degrees of freedom without an arbitrary texture coefficient.
+It is a training-free conditional state, not RALU's nearest-neighbor correlated-noise formula, whose
+specific assumptions do not transfer unchanged to arbitrary H3 geometry and packed AV state.
+
+Audio's packed sampler slice is copied exactly. Source-input mode mutates the caller's final shape
+metadata at the handoff. Target-input mode instead starts with final-grid metadata, creates a private
+low-grid AV shape for the early invocation, and returns to the caller's original final-grid shape for
+the high invocation. This second topology is required for Continuum: its session and native-masked
+continuation contracts validate spatial geometry across chunks and therefore must never observe a
+54x40 output chunk when the sequence is configured for 64x48.
+
+Caller callback geometry is also fenced at the target-input boundary. ComfyUI creates its packed AV
+callback closure against the caller-visible target shapes before OUTER_SAMPLE wrappers execute, so
+private low-stage callback tensors are spatially lifted back to the target video grid before that
+closure is invoked. This keeps previews and any callback consumer from trying to unpack a private
+source-grid tensor with target-grid metadata.
+
+Before each independent low/probe/high inner sampling invocation, conditioning is reconstructed from
+a pristine snapshot of `guider.conds` taken at progressive-wrapper entry. Current ComfyUI has already
+run `preprocess_conds_hooks` and `filter_registered_hooks_on_conds` before entering OUTER_SAMPLE, so
+rebuilding directly from `guider.original_conds` here would silently discard ControlNet/registered-hook
+preprocessing. The preserved snapshot is still pre-`process_conds`, allowing each geometry lifetime to
+resolve percentage areas, masks, and other
+shape-dependent conditions against that stage's live geometry. Source-input mode resizes target
+keyframes on the high stage. Target-input mode does the inverse: it temporarily downsizes
+`minimax_keyframes` for low/probe and restores the original target-grid conditioning for high.
+Independent `minimax_refs` retain their own geometry. H3 rebuilds layout and MM-RoPE when the
+signature changes.
+
+Target-input mode also cannot reuse the caller's target-grid video noise directly as a lower-grid
+Gaussian sample without changing its distribution. It therefore derives a separate deterministic
+standard-Gaussian low-grid video tensor from the graph seed while preserving the caller's audio noise.
+The handoff high-frequency video noise uses a separate domain offset. Both generators are isolated
+from the sampler RNG.
+
+`auto_compute` is a deterministic, bounded handoff heuristic that moves the base coordinate later
+as the target/source area ratio grows. It uses no model calls and is reported in metrics. It is a
+compute-allocation probe, not a learned quality criterion; fixed `0.35` remains the reproducible
+benchmark setting until decoded runs establish a better policy.
+
+Progressive model-call telemetry is stage-scoped. The live transformer options carry a temporary
+`h3_flow_stage` marker for `low`, `probe`, and `high`; because the flow PREDICT wrapper is
+inside Spectrum, Spectrum's call-local model-options copy preserves that marker alongside actual/
+forecast provenance. Counters therefore expose low/probe/high logical calls and actual/forecast
+counts separately. The wrapper also counts the three downstream sampler invocations and the two
+fresh-lifetime boundaries instead of reporting an unverified solver-reset boolean.
+
+### Reset and exact-anchor contracts
+
+- **SA/PECE/SEEDS:** separate sampler invocations prevent old-grid history crossing.
+- **Inpaint sampler options:** the exact probe preserves the selected sampler's KSampler-level
+  `inpaint_options` (including deterministic `random` inpaint noise), so masked-state evaluation
+  uses the same native inpaint policy as the low stage rather than silently reverting to defaults.
+- **Spectrum:** separate outer executions end the low runtime and create the high runtime.
+  Explicit Spectrum provenance is authoritative: an exact handoff probe that is reported as a forecast
+  fails closed rather than being relabeled as an actual anchor.
+  `h3_refinement` API v1 supplies the full-trajectory sigma reference; the high stage requests
+  an actual prefix.
+- **External patches:** exact calls traverse the normal guider/model patch chain. A pre-existing
+  `h3_refinement` dictionary is preserved when compatible, including opaque provider fields; a
+  conflicting API/prefix/sigma/source contract fails closed rather than being overwritten. The probe also
+  publishes the full-trajectory refinement reference so sigma-sensitive patches such as DiffAid
+  do not renormalize the split coordinate to the probe invocation's first sigma.
+- **Continuum:** selection includes the available session/chunk namespace and a bounded content
+  fingerprint of raw conditioning. Current V3.4 interop exposes chunk index but no unique sequence
+  session ID; independent sequences should therefore use separate trajectory handles. Conditioning
+  identity additionally separates same-index runs when their fingerprints differ. The fingerprint
+  samples deterministic tensor positions rather than reading entire
+  Qwen/reference tensors back from the GPU. Multi-chunk progressive operation uses the
+  target-input topology so Continuum's output/session/native-mask geometry stays final-sized.
+- **Failure:** low/probe failure aborts the active trajectory transaction. The low run must be committed
+  before same-invocation high guidance can select it; if transfer or the high stage then fails, that
+  committed run is immediately invalidated and becomes ineligible for future trajectory selection.
+  Guidance state clears in `finally`.
+- **Denoise masks:** current ComfyUI prepares each user mask to full latent-channel AV geometry before
+  OUTER_SAMPLE wrappers run. Progressive mode resizes only the prepared video portion, preserves the
+  audio portion, spatially transfers the external latent image, converts it through H3's normal latent-in
+  transform, and solves `noise = (x_sigma - (1-sigma) * latent_image) / (sigma * noise_scale)` so
+  the next sampler invocation starts from the exact carried state. In target-input mode, mask-protected
+  regions retain the caller's original target-grid sampler noise because MiniMax H3's
+  `scale_latent_inpaint` explicitly mixes that noise into preserved video context at timestep 0.999.
+
+## Reference budget
+
+Qwen3-VL context and direct H3 reference rows are separate. Native mode returns the exact input.
+Experimental direct decoupling shallow-copies conditioning and caps each direct video latent by patch
+rows while preserving aspect ratio and even H/W. Already encoded Qwen tokens remain unchanged.
+
+Direct-reference budgeting updates the resized reference latent and its native `latent_h`/`latent_w`
+(and existing `latent_t`) metadata atomically. MiniMax H3's `PackedLayout` consumes those metadata
+fields to allocate reference rows and positions, so leaving source-grid metadata attached to a resized
+latent would make the packed reference contract inconsistent.
+
+## Attention lab
+
+Diagnostics sample selected heads/queries and report entropy and modality mass without retaining full
+matrices. Experimental sparse layers keep text/reference/audio global. Video queries retain non-video
+keys and all temporal positions inside a spatial patch window; configured heads remain fully global.
+Query-local restrictions are passed to ComfyUI attention backends as numeric QxK additive masks,
+because Core's boolean-mask path is a batch/key mask and cannot represent per-query sparsity.
+Unsupported mask backends fall back to native attention. Query chunking avoids a sequence-square mask.
+RoPE is untouched and block replacements are chained. If another optimized attention override exists,
+the experiment records a fallback and delegates to it.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -1,0 +1,68 @@
+# Decoded-media benchmark protocol
+
+## Fixed inventory
+
+Duplicate the current two-chunk Continuum graph and keep seed, prompt, Qwen/direct references,
+LoRAs, DiffAid, Untwist, sampler, scheduler, base frames, audio behavior, chunk boundaries, crop,
+and decode settings identical. Record exact git revisions for ComfyUI and every custom node.
+
+Attach **MiniMax H3 Metrics JSON** to each experimental path. The output node writes a unique
+`.json` file under ComfyUI's normal `output/` directory using its optional `filename_prefix`
+(default: `h3_flow_regenerate/metrics`) while also preserving the JSON string output for downstream
+nodes. In the two-pass path, route the Trajectory Capture metrics object into the Flow-Aligned
+Regenerate/Refine State optional `metrics` input so low-pass capture and high-pass guidance share
+one sink. Capture sampler-only wall time around KSampler and node time around upscaler/handoff; total
+prompt time is secondary.
+
+## Primary matrix
+
+| ID | Path | Base/final grid | Refine outer steps | Denoise |
+|---|---|---:|---:|---:|
+| A | Native direct | final 64x48 (~1024x768) | base schedule | n/a |
+| B | Existing learned upscale baseline | 54x40 -> 64x48 | 6 | 0.25 |
+| C6 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 6 | 0.25 |
+| C5 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 5 | 0.25 |
+| C4 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 4 | 0.25 |
+| D | Progressive target-input handoff | workflow stays 64x48; early stage internally 54x40 | one split schedule | n/a |
+| E | Resolution-shift-only native | shift reference 54x40 -> generation 64x48 | base schedule | n/a |
+
+The machine-readable matrix fixes the seed set to `0, 1, 2` and expands every applicable row across
+four required content scenarios. The primary learned-refine comparison remains denoise 0.25; the same
+B/C rows are also repeated at 0.30. Two patch-safe base regimes are explicit: 54x40 latent
+(864x640, 0.553 MP) and 62x44 latent (992x704, 0.698 MP), both evaluated against the 64x48
+(1024x768) target. The scenarios cover difficult motion/scene changes, small people/faces, fine text,
+and reference-heavy conditioning. Prompts and reference assets may differ between scenarios but must
+remain identical across rows within one scenario/area/denoise/seed slice.
+
+Row D must use **Progressive Handoff (Target Input)** in the two-chunk Continuum graph: Continuum is configured at 64x48 while the wrapper's internal source is 54x40. This preserves target-sized session and native-mask geometry between chunks. The source-input progressive node is a standalone control and is not the Continuum benchmark topology.
+
+Row E does not generate a low-resolution first pass. Its `shift_reference_grid` is the active area
+regime's source grid (54x40 or 62x44), while H3 itself samples directly on the 64x48 target grid.
+The source and target observations therefore differ in both regimes, keeping the resolution mapping
+non-identity while isolating it from trajectory guidance and progressive handoff.
+
+## Required metrics
+
+- actual pixels and video latent T/H/W; padded H/W and whether padding occurred;
+- Qwen, direct-reference, audio, video, and total packed rows;
+- actual H3 transformer NFEs and Spectrum forecasts;
+- sampler logical calls and SA/PECE outer/phase topology;
+- effective shifts and unshifted coordinates;
+- low/high sampler, upscaler, handoff/probe, and guidance time;
+- trajectory storage; resets, exact anchors, and fallbacks;
+- peak VRAM and host RAM from the same profiler.
+
+## Human review
+
+Decode final media identically. Review synchronized playback plus audio. Score composition,
+prompt/reference fidelity, motion, temporal stability, detail, faces, small objects, scene changes,
+borders, audio, and Continuum seams. Full clips are required; preview frames are insufficient.
+
+The machine-readable plan is [`workflows/benchmark-matrix.json`](../workflows/benchmark-matrix.json).
+Store each workflow, metrics JSON, decoded checksum, timing log, and review sheet together.
+
+The two configuration overlays are
+[`flow-aligned-two-pass.overlay.json`](../workflows/flow-aligned-two-pass.overlay.json) and
+[`progressive-handoff.overlay.json`](../workflows/progressive-handoff.overlay.json). They deliberately
+describe the new nodes and graph insertion points instead of embedding model filenames, prompts, or
+third-party node IDs that would silently diverge from the user's canonical Continuum workflow.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -11,7 +11,8 @@ Attach **MiniMax H3 Metrics JSON** to each experimental path. The output node al
 (default: `h3_flow_regenerate/metrics`), writes the current snapshot immediately, and keeps that
 same file registered as a live sink. Each later sampler completion refreshes it atomically, so a
 node that executes before the learned-refine sampler still ends with the post-refine guidance/counter
-state. The JSON string output remains available for downstream nodes. In the two-pass path, route the
+state. The file is therefore the authoritative final artifact; the node's STRING output is the
+registration-time snapshot retained for compatibility. In the two-pass path, route the
 Trajectory Capture metrics object into the Flow-Aligned Regenerate/Refine State optional `metrics`
 input so low-pass capture and high-pass guidance share one sink. Capture sampler-only wall time around
 KSampler and node time around upscaler/handoff; total prompt time is secondary.

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -6,29 +6,35 @@ Duplicate the current two-chunk Continuum graph and keep seed, prompt, Qwen/dire
 LoRAs, DiffAid, Untwist, sampler, scheduler, base frames, audio behavior, chunk boundaries, crop,
 and decode settings identical. Record exact git revisions for ComfyUI and every custom node.
 
-Attach **MiniMax H3 Metrics JSON** to each experimental path. The output node writes a unique
+Attach **MiniMax H3 Metrics JSON** to each experimental path. The output node allocates a unique
 `.json` file under ComfyUI's normal `output/` directory using its optional `filename_prefix`
-(default: `h3_flow_regenerate/metrics`) while also preserving the JSON string output for downstream
-nodes. In the two-pass path, route the Trajectory Capture metrics object into the Flow-Aligned
-Regenerate/Refine State optional `metrics` input so low-pass capture and high-pass guidance share
-one sink. Capture sampler-only wall time around KSampler and node time around upscaler/handoff; total
-prompt time is secondary.
+(default: `h3_flow_regenerate/metrics`), writes the current snapshot immediately, and keeps that
+same file registered as a live sink. Each later sampler completion refreshes it atomically, so a
+node that executes before the learned-refine sampler still ends with the post-refine guidance/counter
+state. The JSON string output remains available for downstream nodes. In the two-pass path, route the
+Trajectory Capture metrics object into the Flow-Aligned Regenerate/Refine State optional `metrics`
+input so low-pass capture and high-pass guidance share one sink. Capture sampler-only wall time around
+KSampler and node time around upscaler/handoff; total prompt time is secondary.
 
 ## Primary matrix
 
-| ID | Path | Base/final grid | Refine outer steps | Denoise |
+| ID | Path | First-pass outer steps | Refine outer steps | Denoise |
 |---|---|---:|---:|---:|
-| A | Native direct | final 64x48 (~1024x768) | base schedule | n/a |
-| B | Existing learned upscale baseline | 54x40 -> 64x48 | 6 | 0.25 |
-| C6 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 6 | 0.25 |
-| C5 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 5 | 0.25 |
-| C4 | Flow-aligned learned-upscale refine | 54x40 -> 64x48 | 4 | 0.25 |
-| D | Progressive target-input handoff | workflow stays 64x48; early stage internally 54x40 | one split schedule | n/a |
-| E | Resolution-shift-only native | shift reference 54x40 -> generation 64x48 | base schedule | n/a |
+| A | Native direct at final 64x48 (~1024x768) | base schedule | n/a | n/a |
+| B | Existing learned upscale baseline, 54x40 -> 64x48 | 7 | 7 | 0.25 |
+| C7 | Flow-aligned learned-upscale refine, 54x40 -> 64x48 | 7 | 7 | 0.25 |
+| C6 | Flow-aligned learned-upscale refine, 54x40 -> 64x48 | 7 | 6 | 0.25 |
+| C5 | Flow-aligned learned-upscale refine, 54x40 -> 64x48 | 7 | 5 | 0.25 |
+| D | Progressive target-input handoff; workflow stays 64x48, early stage internally 54x40 | split schedule | split schedule | n/a |
+| E | Resolution-shift-only native; shift reference 54x40 -> generation 64x48 | base schedule | n/a | n/a |
 
 The machine-readable matrix fixes the seed set to `0, 1, 2` and expands every applicable row across
-four required content scenarios. The primary learned-refine comparison remains denoise 0.25; the same
-B/C rows are also repeated at 0.30. Two patch-safe base regimes are explicit: 54x40 latent
+four required content scenarios. The actual working workflow uses **7 first-pass steps and 7 refine
+steps**. Keep the first pass fixed at 7 throughout the learned-refine comparison. C7 is the
+flow-aligned parity smoke baseline; test C6 next and test C5 only if C6 decoded video/audio remains
+acceptable. Further refine-step reductions are exploratory rather than a required gate. The primary
+learned-refine comparison remains denoise 0.25; the same B/C rows are also repeated at 0.30. Two
+patch-safe base regimes are explicit: 54x40 latent
 (864x640, 0.553 MP) and 62x44 latent (992x704, 0.698 MP), both evaluated against the 64x48
 (1024x768) target. The scenarios cover difficult motion/scene changes, small people/faces, fine text,
 and reference-heavy conditioning. Prompts and reference assets may differ between scenarios but must

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -1,0 +1,51 @@
+# Research transfer notes
+
+This design uses public work as evidence and inspiration while keeping H3 assumptions explicit.
+
+| Source | Useful transfer | Boundary for H3 |
+|---|---|---|
+| [HiFlow](https://arxiv.org/abs/2504.06232) | A low-resolution flow trajectory contains time-varying structure; its separate initialization, direction, and acceleration alignments motivate the experiments here. | Published experiments are image models. H3 two-pass guidance operates on video denoised estimates and preserves packed audio. It does not expose a prediction-space correction as HiFlow initialization alignment, and the current acceleration option is a first-difference proxy rather than HiFlow's Eq. 9-13 construction. |
+| [FrescoDiffusion](https://arxiv.org/abs/2603.17555) | Video high-resolution generation benefits from a global low-resolution prior and separately testable consistency constraints. | Its tiled/posterior mechanics are not copied into H3's packed transformer. |
+| [RALU](https://arxiv.org/abs/2507.08422) | Naively resizing noisy state causes distribution/timestep mismatch; transitions need explicit noise semantics. | Its correlated-noise/JSD result assumes a particular upsampler and schedule. H3 uses a conditional RF state plus native exact probe. |
+| [CineScale](https://arxiv.org/abs/2508.15774) | Self-cascade video regeneration and high-resolution attention/position degradation are relevant hypotheses. | Wan-specific position methods are not transferred to H3 MM-RoPE. |
+| [FreeSwim](https://arxiv.org/abs/2511.14712) | Local-detail and global-semantic paths motivate selective spatial locality. | H3 is one multimodal stream; non-video and temporal paths remain global. |
+| [HRDiT](https://arxiv.org/abs/2608.07003) | Per-head/layer heterogeneous scopes and position diagnostics are worthwhile. | No head policy is recommended before H3 measurements. |
+| [Just-in-Time](https://arxiv.org/abs/2603.10744) | Fine spatial compute can be deferred while structure forms. | JiT micro-flow token activation is not an arbitrary latent-resize license. |
+| [Self-Cascade Diffusion](https://arxiv.org/abs/2402.10491) | Semantic pivots and staged resolution adaptation support coarse-to-fine design. | Trained/model-specific modules are outside this plugin. |
+| [simple diffusion](https://arxiv.org/abs/2301.11093) | Resolution changes the appropriate signal-to-noise relationship. | Its argument is not reduced to an unexplained H3 sigma multiplier. |
+| [SD3 / Scaling Rectified Flow Transformers](https://arxiv.org/abs/2403.03206) | The constant-observation derivation yields `alpha=sqrt(m/n)` and a fractional-linear map. | The constant-image assumption is unrealistic, as the paper notes; H3 composition is only a probe. |
+
+## Source implementations
+
+- [MiniMax-H3](https://github.com/MiniMax-AI/MiniMax-H3) describes a progressive 2K product path
+  and sparse-attention capability. H3-Regenerate-2K and its sparse topology are not public.
+- [ComfyUI](https://github.com/Comfy-Org/ComfyUI) supplies the executable H3 contract for packing,
+  shifts, sampling, layout, padding, and wrapper lifecycle.
+- [Spectrum](https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3),
+  [RefDelta](https://github.com/xmarre/ComfyUI-MiniMax-H3-RefDelta-Solver),
+  [Continuum](https://github.com/xmarre/ComfyUI-H3-Continuum),
+  [the latent upscaler](https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler),
+  [DiffAid](https://github.com/xmarre/ComfyUI-DiffAid-Patches), and
+  [Untwisting RoPE](https://github.com/xmarre/ComfyUI-Untwisting-RoPE) informed integration contracts.
+  No implementation was copied from repositories with unclear licensing.
+
+## Claims deliberately withheld
+
+- No quality or speed improvement is claimed without matched decoded-media runs.
+- Progressive handoff is a defensible local approximation, not MiniMax's trained regenerate model.
+- The attention mask is an experiment, not MiniMax's proprietary sparse attention.
+- A direct-reference row cap is not inferred from PAB or generic token-pruning results.
+
+## Validated source revisions
+
+CI checks the executable contracts at ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`,
+Spectrum `beb32dd210ef9e95520453107f158241d4f2ecf3`, Continuum
+`bf25353d8bec44afea22c89717c4301ce13c2036`, DiffAid
+`ba9d9efbcf7e64c755e068cb76547d8cc85481eb`, RefDelta
+`034e4c4c14c56bf76813cee4765e7164b0c7e0db`, Untwisting RoPE
+`299d4c56a3f057a97b3140d2136189bcd1e7d6bb`, and the integrated H3 latent upscaler/refine
+`2c707492084962f7ed665e8817a05a11b14dab27`. The audit also inspected current MiniMax-H3 main
+`d21241f0a4b3acbb34c97dae47fa417b7065e438`. Spectrum PR #98 and its companion Untwist PR #5
+were reviewed as open compatibility work; this package does not make either unmerged PR a dependency.
+ The only upstream delta from the previous audited ComfyUI pin was a compositor-node/test change; no H3, sampler, model-sampling, or ModelPatcher contract file changed.
+Updating a pin requires re-running the source audit and decoded-media compatibility matrix.

--- a/h3_flow_regenerate/__init__.py
+++ b/h3_flow_regenerate/__init__.py
@@ -1,0 +1,16 @@
+"""MiniMax H3 flow-aligned regeneration primitives and ComfyUI nodes."""
+
+from .contracts import H3FlowTrajectory, TrajectoryRun, TrajectorySample
+from .geometry import H3Geometry, normalize_target_geometry
+from .sigma import audio_sigma, flow_shift, inverse_flow_shift
+
+__all__ = [
+    "H3FlowTrajectory",
+    "H3Geometry",
+    "TrajectoryRun",
+    "TrajectorySample",
+    "audio_sigma",
+    "flow_shift",
+    "inverse_flow_shift",
+    "normalize_target_geometry",
+]

--- a/h3_flow_regenerate/attention.py
+++ b/h3_flow_regenerate/attention.py
@@ -1,0 +1,261 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from .metrics import H3FlowMetrics
+
+
+@dataclass(frozen=True, slots=True)
+class AttentionConfig:
+    mode: str = "native"
+    layers: tuple[int, ...] = (8, 16, 24, 32, 40)
+    diagnostic_head: int = 0
+    diagnostic_queries: int = 8
+    sparse_window: int = 4
+    global_heads: int = 8
+    query_chunk: int = 64
+    max_sequence: int = 8192
+
+    def __post_init__(self) -> None:
+        if self.mode not in {"native", "diagnostic", "experimental_sparse"}:
+            raise ValueError(f"unsupported H3 attention mode {self.mode!r}")
+        if any(layer < 0 for layer in self.layers):
+            raise ValueError("H3 diagnostic/sparse layers must be non-negative")
+        if self.diagnostic_head < 0 or self.diagnostic_queries < 1:
+            raise ValueError("attention diagnostic selectors must be non-negative")
+        if self.sparse_window < 1 or self.global_heads < 0 or self.query_chunk < 1:
+            raise ValueError("sparse attention controls must be positive")
+        if self.max_sequence < 1:
+            raise ValueError("max_sequence must be positive")
+
+
+def layout_summary(layout: Any) -> dict[str, Any]:
+    segments = tuple((int(a), int(b), str(kind)) for a, b, kind in layout.segments)
+    counts: dict[str, int] = {}
+    for start, stop, kind in segments:
+        counts[kind] = counts.get(kind, 0) + (stop - start)
+    signature = tuple(int(v) for v in layout.signature)
+    return {
+        "signature": signature,
+        "segments": segments,
+        "text_rows": counts.get("text", 0),
+        "reference_rows": sum(counts.get(k, 0) for k in ("cond", "cond_audio", "ref_img", "ref_audio")),
+        "audio_rows": counts.get("audio", 0),
+        "video_rows": counts.get("video", 0),
+        "sequence_rows": int(layout.seq_len),
+    }
+
+
+def video_local_mask(
+    layout: Any,
+    query_indices: torch.Tensor,
+    *,
+    radius: int,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build a query-chunk mask with global non-video and temporal video reach.
+
+    Video-to-video keys are spatially local on H3's 2x2 patch grid while all
+    temporal positions inside the local spatial column remain visible. Text,
+    reference and audio keys remain global in both directions.
+    """
+    if radius < 1:
+        raise ValueError("video attention radius must be positive")
+    seq_len = int(layout.seq_len)
+    query_indices = query_indices.to(device=device, dtype=torch.long)
+    if bool((query_indices < 0).any()) or bool((query_indices >= seq_len).any()):
+        raise IndexError("attention query index is outside the packed sequence")
+    mask = torch.ones((query_indices.numel(), seq_len), dtype=torch.bool, device=device)
+    va, vb, _ = next(segment for segment in layout.segments if segment[2] == "video")
+    video_queries = (query_indices >= va) & (query_indices < vb)
+    if not bool(video_queries.any()):
+        return mask
+    _, latent_t, latent_h, latent_w, _ = map(int, layout.signature)
+    patch_h, patch_w = latent_h // 2, latent_w // 2
+    expected = latent_t * patch_h * patch_w
+    if vb - va != expected:
+        raise ValueError("H3 video segment does not match the layout signature")
+    query_local = query_indices[video_queries] - va
+    q_spatial = query_local.remainder(patch_h * patch_w)
+    qh = torch.div(q_spatial, patch_w, rounding_mode="floor")
+    qw = q_spatial.remainder(patch_w)
+    keys = torch.arange(expected, device=device)
+    key_spatial = keys.remainder(patch_h * patch_w)
+    kh = torch.div(key_spatial, patch_w, rounding_mode="floor")
+    kw = key_spatial.remainder(patch_w)
+    local = (qh[:, None] - kh[None, :]).abs().le(radius) & (qw[:, None] - kw[None, :]).abs().le(radius)
+    mask[video_queries, va:vb] = local
+    return mask
+
+
+def _call_backend(backend, q, k, v, heads: int, kwargs: dict[str, Any], *, mask=None):
+    call_kwargs = dict(kwargs)
+    call_kwargs["_inside_attn_wrapper"] = True
+    call_kwargs["mask"] = mask
+    call_kwargs["skip_reshape"] = True
+    return backend(q, k, v, heads, **call_kwargs)
+
+
+def _sparse_attention(backend, q, k, v, heads, layout, config, kwargs):
+    sequence = int(q.shape[-2])
+    global_heads = min(config.global_heads, heads)
+    pieces: list[torch.Tensor] = []
+    if global_heads:
+        global_out = _call_backend(
+            backend,
+            q[:, :global_heads],
+            k[:, :global_heads],
+            v[:, :global_heads],
+            global_heads,
+            kwargs,
+        )
+        pieces.append(global_out.reshape(q.shape[0], sequence, global_heads, q.shape[-1]))
+    sparse_heads = heads - global_heads
+    sparse_chunks: list[torch.Tensor] = []
+    for start in range(0, sequence, config.query_chunk):
+        stop = min(sequence, start + config.query_chunk)
+        indices = torch.arange(start, stop, device=q.device)
+        allowed = video_local_mask(layout, indices, radius=config.sparse_window, device=q.device)
+        mask_value = -torch.finfo(q.dtype).max
+        local_mask = torch.zeros(allowed.shape, dtype=q.dtype, device=q.device)
+        local_mask.masked_fill_(~allowed, mask_value)
+        out = _call_backend(
+            backend,
+            q[:, global_heads:, start:stop],
+            k[:, global_heads:],
+            v[:, global_heads:],
+            sparse_heads,
+            kwargs,
+            mask=local_mask,
+        )
+        sparse_chunks.append(out.reshape(q.shape[0], stop - start, sparse_heads, q.shape[-1]))
+    pieces.append(torch.cat(sparse_chunks, dim=1))
+    return torch.cat(pieces, dim=2).reshape(q.shape[0], sequence, heads * q.shape[-1])
+
+
+def make_attention_override(
+    config: AttentionConfig,
+    metrics: H3FlowMetrics,
+    *,
+    previous_override=None,
+):
+    def override(backend, q, k, v, heads, mask=None, skip_reshape=False, **kwargs):
+        transformer = kwargs.get("transformer_options") or {}
+        context = transformer.get("h3_flow_attention_context")
+        if context is None or mask is not None or not skip_reshape:
+            if previous_override is not None:
+                return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=skip_reshape, **kwargs)
+            return backend(q, k, v, heads, mask=mask, skip_reshape=skip_reshape, **kwargs)
+        layer = int(context["layer"])
+        layout = context["layout"]
+        if layer not in config.layers or q.shape[-2] != int(layout.seq_len):
+            if previous_override is not None:
+                return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+            return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        if config.mode == "diagnostic":
+            _record_attention_diagnostic(q, k, layout, layer, config, metrics)
+            if previous_override is not None:
+                return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+            return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        if config.mode != "experimental_sparse":
+            return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        if previous_override is not None:
+            metrics.event("attention_fallback", layer=layer, reason="existing_attention_override")
+            return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        sequence = int(q.shape[-2])
+        if sequence > config.max_sequence or config.global_heads >= heads:
+            reason = "sequence_guard" if sequence > config.max_sequence else "all_heads_global"
+            metrics.event("attention_fallback", layer=layer, reason=reason)
+            return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        try:
+            result = _sparse_attention(backend, q, k, v, heads, layout, config, kwargs)
+        except (RuntimeError, TypeError, ValueError) as exc:
+            metrics.event(
+                "attention_fallback",
+                layer=layer,
+                reason="backend_rejected_sparse_mask",
+                error=type(exc).__name__,
+            )
+            return backend(q, k, v, heads, mask=None, skip_reshape=True, **kwargs)
+        metrics.event(
+            "attention_sparse",
+            layer=layer,
+            sequence=sequence,
+            global_heads=min(config.global_heads, heads),
+            local_heads=heads - min(config.global_heads, heads),
+            window=config.sparse_window,
+        )
+        return result
+
+    override._h3_flow_attention_override = True
+    override._h3_flow_previous_override = previous_override
+    override._h3_flow_attention_config = config
+    override._h3_flow_metrics = metrics
+    return override
+
+
+def _record_attention_diagnostic(q, k, layout, layer, config, metrics) -> None:
+    head = min(config.diagnostic_head, q.shape[1] - 1)
+    sequence = q.shape[-2]
+    count = min(config.diagnostic_queries, sequence)
+    indices = torch.linspace(0, sequence - 1, count, device=q.device).round().long()
+    logits = torch.matmul(q[0, head, indices].float(), k[0, head].float().transpose(0, 1)) / math.sqrt(q.shape[-1])
+    probabilities = logits.softmax(dim=-1)
+    entropy = -(probabilities.clamp_min(1e-12).log() * probabilities).sum(dim=-1).mean()
+    masses: dict[str, float] = {}
+    for a, b, kind in layout.segments:
+        masses[kind] = masses.get(kind, 0.0) + float(probabilities[:, a:b].sum(dim=-1).mean().item())
+    metrics.event(
+        "attention_diagnostic",
+        layer=layer,
+        head=head,
+        queries=count,
+        entropy=float(entropy.item()),
+        modality_mass=masses,
+    )
+
+
+def make_layout_block_wrapper(
+    layer: int,
+    metrics: H3FlowMetrics,
+    previous=None,
+    *,
+    record_layout: bool = True,
+):
+    def wrapper(args, extra):
+        transformer = args["transformer_options"]
+        old = transformer.get("h3_flow_attention_context")
+        transformer["h3_flow_attention_context"] = {"layout": args["layout"], "layer": layer}
+        if layer == 0 and record_layout:
+            metrics.event("packed_layout", **layout_summary(args["layout"]))
+        try:
+            if previous is not None:
+                return previous(args, extra)
+            return extra["original_block"](args)
+        finally:
+            if old is None:
+                transformer.pop("h3_flow_attention_context", None)
+            else:
+                transformer["h3_flow_attention_context"] = old
+
+    return wrapper
+
+
+def mark_layout_wrapper(
+    wrapper,
+    *,
+    metrics: H3FlowMetrics,
+    previous=None,
+    scope: str = "layout",
+):
+    if scope not in {"layout", "attention"}:
+        raise ValueError(f"unsupported H3 flow layout-wrapper scope {scope!r}")
+    wrapper._h3_flow_layout_wrapper = True
+    wrapper._h3_flow_layout_scope = scope
+    wrapper._h3_flow_metrics = metrics
+    wrapper._h3_flow_previous = previous
+    return wrapper

--- a/h3_flow_regenerate/comfy_compat.py
+++ b/h3_flow_regenerate/comfy_compat.py
@@ -1,0 +1,247 @@
+from __future__ import annotations
+
+import copy
+from dataclasses import replace
+from typing import Any
+
+from .attention import AttentionConfig, make_attention_override, make_layout_block_wrapper, mark_layout_wrapper
+from .contracts import H3FlowTrajectory
+from .guidance import GuidanceConfig
+from .handoff import ProgressiveHandoffConfig, ProgressiveTargetInputConfig
+from .metrics import H3FlowMetrics
+from .runtime import (
+    CLONE_CALLBACK_KEY,
+    FLOW_BINDING_KEY,
+    OUTER_WRAPPER_KEY,
+    PREDICT_WRAPPER_KEY,
+    PROGRESSIVE_KEY,
+    FlowBinding,
+    flow_model_clone_callback,
+    flow_outer_wrapper,
+    flow_predict_wrapper,
+)
+
+
+def validate_h3_model(model: Any) -> Any:
+    try:
+        diffusion = model.model.diffusion_model
+        base = model.model
+    except AttributeError as exc:
+        raise TypeError("expected a ComfyUI MODEL containing native MiniMax H3") from exc
+    facts = {
+        "patch_size": tuple(getattr(diffusion, "patch_size", ())),
+        "latents_dim": int(getattr(diffusion, "latents_dim", -1)),
+        "audio_latents_dim": int(getattr(diffusion, "audio_latents_dim", -1)),
+        "sigma_shift_video": float(getattr(diffusion, "sigma_shift_video", -1.0)),
+        "sigma_shift_audio": float(getattr(diffusion, "sigma_shift_audio", -1.0)),
+    }
+    expected = {
+        "patch_size": (1, 2, 2),
+        "latents_dim": 24,
+        "audio_latents_dim": 32,
+        "sigma_shift_video": 12.0,
+        "sigma_shift_audio": 3.0,
+    }
+    if facts != expected or base.__class__.__name__ != "MiniMaxH3":
+        raise TypeError(f"model does not match the supported native MiniMax H3 contract: {facts}")
+    return diffusion
+
+
+def _copy_model_options(model: Any) -> None:
+    model.model_options = dict(model.model_options)
+    transformer = dict(model.model_options.get("transformer_options") or {})
+    model.model_options["transformer_options"] = transformer
+
+
+def _put_wrapper_first(model: Any, wrapper_type: str, key: str, wrapper) -> None:
+    model.remove_wrappers_with_key(wrapper_type, key)
+    existing = model.wrappers.get(wrapper_type, {})
+    model.wrappers[wrapper_type] = {key: [wrapper], **existing}
+
+
+def _put_wrapper_last(model: Any, wrapper_type: str, key: str, wrapper) -> None:
+    model.remove_wrappers_with_key(wrapper_type, key)
+    existing = model.wrappers.get(wrapper_type, {})
+    model.wrappers[wrapper_type] = {**existing, key: [wrapper]}
+
+
+def patch_flow_model(
+    model: Any,
+    *,
+    trajectory: H3FlowTrajectory | None = None,
+    guidance: GuidanceConfig | None = None,
+    progressive: ProgressiveHandoffConfig | ProgressiveTargetInputConfig | None = None,
+    clear_progressive: bool = False,
+    attention: AttentionConfig | None = None,
+    capture_enabled: bool | None = None,
+    capture_forecasts: bool | None = None,
+    guidance_conditioning_signature: str | None = None,
+    clear_guidance_conditioning_signature: bool = False,
+    guidance_run_id: str | None = None,
+    clear_guidance_run_id: bool = False,
+    metrics: H3FlowMetrics | None = None,
+) -> tuple[Any, FlowBinding]:
+    validate_h3_model(model)
+    prior = model.model_options.get(FLOW_BINDING_KEY)
+    if not isinstance(prior, FlowBinding):
+        prior = None
+    patched = model.clone()
+    _copy_model_options(patched)
+    binding = FlowBinding(
+        trajectory=trajectory if trajectory is not None else (prior.trajectory if prior else None),
+        guidance=guidance if guidance is not None else (prior.guidance if prior else None),
+        metrics=metrics or (prior.metrics if prior else H3FlowMetrics()),
+        capture_enabled=(
+            prior.capture_enabled if capture_enabled is None and prior is not None else bool(capture_enabled)
+        ),
+        capture_forecasts=(
+            prior.capture_forecasts if capture_forecasts is None and prior is not None else bool(capture_forecasts)
+        ),
+        guidance_conditioning_signature=(
+            None
+            if clear_guidance_conditioning_signature
+            else (
+                guidance_conditioning_signature
+                if guidance_conditioning_signature is not None
+                else (prior.guidance_conditioning_signature if prior else None)
+            )
+        ),
+        captured_run_id=prior.captured_run_id if prior else None,
+        guidance_run_id=(
+            None
+            if clear_guidance_run_id
+            else (guidance_run_id if guidance_run_id is not None else (prior.guidance_run_id if prior else None))
+        ),
+    )
+    if clear_guidance_conditioning_signature and guidance_conditioning_signature is not None:
+        raise ValueError("cannot set and clear guidance conditioning signature in the same model patch")
+    if clear_guidance_run_id and guidance_run_id is not None:
+        raise ValueError("cannot set and clear guidance run id in the same model patch")
+    patched.model_options[FLOW_BINDING_KEY] = binding
+    if clear_progressive and progressive is not None:
+        raise ValueError("cannot set and clear progressive handoff in the same model patch")
+    if clear_progressive:
+        patched.model_options.pop(PROGRESSIVE_KEY, None)
+    elif progressive is not None:
+        patched.model_options[PROGRESSIVE_KEY] = progressive
+
+    import comfy.patcher_extension
+
+    _put_wrapper_first(patched, comfy.patcher_extension.WrappersMP.OUTER_SAMPLE, OUTER_WRAPPER_KEY, flow_outer_wrapper)
+    # OUTER_SAMPLE must remain outside Spectrum so progressive low/probe/high
+    # invocations each traverse Spectrum independently. PREDICT_NOISE must be
+    # inside Spectrum so it receives Spectrum's per-call copied model_options
+    # containing exact/forecast provenance.
+    _put_wrapper_last(
+        patched,
+        comfy.patcher_extension.WrappersMP.PREDICT_NOISE,
+        PREDICT_WRAPPER_KEY,
+        flow_predict_wrapper,
+    )
+    callback_type = comfy.patcher_extension.CallbacksMP.ON_CLONE
+    patched.remove_callbacks_with_key(callback_type, CLONE_CALLBACK_KEY)
+    patched.add_callback_with_key(callback_type, CLONE_CALLBACK_KEY, flow_model_clone_callback)
+    _install_layout_metrics(patched, binding.metrics)
+    if attention is not None and attention.mode != "native":
+        _install_attention(patched, attention, binding.metrics)
+    return patched, binding
+
+
+def _install_attention(model: Any, config: AttentionConfig, metrics: H3FlowMetrics) -> None:
+    diffusion = validate_h3_model(model)
+    blocks = getattr(diffusion, "blocks", None)
+    if blocks is None:
+        raise TypeError("native MiniMax H3 diffusion model does not expose transformer blocks")
+    num_layers = len(blocks)
+    invalid = tuple(layer for layer in config.layers if layer >= num_layers)
+    if invalid:
+        raise ValueError(f"H3 attention layers are outside the loaded model's {num_layers} blocks: {invalid}")
+    transformer = model.model_options["transformer_options"]
+    previous_override = transformer.get("optimized_attention_override")
+    while getattr(previous_override, "_h3_flow_attention_override", False):
+        previous_override = getattr(previous_override, "_h3_flow_previous_override", None)
+    transformer["optimized_attention_override"] = make_attention_override(
+        config,
+        metrics,
+        previous_override=previous_override,
+    )
+    existing = ((transformer.get("patches_replace") or {}).get("dit") or {}).copy()
+    for layer in range(num_layers):
+        previous = existing.get(("double_block", layer))
+        while getattr(previous, "_h3_flow_layout_wrapper", False):
+            previous = getattr(previous, "_h3_flow_previous", None)
+        wrapper = make_layout_block_wrapper(
+            layer,
+            metrics,
+            previous,
+            record_layout=layer == 0,
+        )
+        wrapper = mark_layout_wrapper(
+            wrapper,
+            metrics=metrics,
+            previous=previous,
+            scope="attention",
+        )
+        model.set_model_patch_replace(
+            wrapper,
+            "dit",
+            "double_block",
+            layer,
+        )
+
+
+def _install_layout_metrics(model: Any, metrics: H3FlowMetrics) -> None:
+    transformer = model.model_options["transformer_options"]
+    existing = ((transformer.get("patches_replace") or {}).get("dit") or {}).get(("double_block", 0))
+    if (
+        getattr(existing, "_h3_flow_layout_wrapper", False)
+        and getattr(existing, "_h3_flow_layout_scope", "layout") == "layout"
+        and getattr(existing, "_h3_flow_metrics", None) is metrics
+    ):
+        return
+    while (
+        getattr(existing, "_h3_flow_layout_wrapper", False)
+        and getattr(existing, "_h3_flow_layout_scope", "layout") == "layout"
+    ):
+        existing = getattr(existing, "_h3_flow_previous", None)
+    wrapper = make_layout_block_wrapper(0, metrics, existing)
+    marked = mark_layout_wrapper(
+        wrapper,
+        metrics=metrics,
+        previous=existing,
+        scope="layout",
+    )
+    model.set_model_patch_replace(marked, "dit", "double_block", 0)
+
+
+def reconfigure_binding(binding: FlowBinding, **changes: Any) -> FlowBinding:
+    allowed = {
+        "trajectory",
+        "guidance",
+        "capture_enabled",
+        "capture_forecasts",
+        "guidance_conditioning_signature",
+        "captured_run_id",
+        "guidance_run_id",
+    }
+    unknown = set(changes) - allowed
+    if unknown:
+        raise TypeError(f"unknown binding fields: {sorted(unknown)}")
+    values = {
+        "trajectory": binding.trajectory,
+        "guidance": binding.guidance,
+        "metrics": binding.metrics,
+        "capture_enabled": binding.capture_enabled,
+        "capture_forecasts": binding.capture_forecasts,
+        "guidance_conditioning_signature": binding.guidance_conditioning_signature,
+        "captured_run_id": binding.captured_run_id,
+        "guidance_run_id": binding.guidance_run_id,
+    }
+    values.update(changes)
+    return FlowBinding(**values)
+
+
+def clone_config(config: Any, **changes: Any) -> Any:
+    if hasattr(config, "__dataclass_fields__"):
+        return replace(config, **changes)
+    return copy.copy(config)

--- a/h3_flow_regenerate/contracts.py
+++ b/h3_flow_regenerate/contracts.py
@@ -1,0 +1,264 @@
+from __future__ import annotations
+
+import threading
+import time
+import uuid
+from dataclasses import dataclass, field, replace
+from typing import Literal
+
+import torch
+
+from .geometry import H3Geometry
+
+SCHEMA_VERSION = 1
+StoragePolicy = Literal["system_ram", "vram"]
+SampleProvenance = Literal["actual", "forecast"]
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectorySample:
+    coordinate: float
+    video_sigma: float
+    audio_sigma: float
+    outer_step: int
+    call_index: int
+    phase: str
+    provenance: SampleProvenance
+    video_x0: torch.Tensor
+    timestamp_ns: int = field(default_factory=time.time_ns)
+
+    @property
+    def canonical(self) -> bool:
+        return self.provenance == "actual" and self.phase in {"predicted", "corrected", "single"}
+
+
+@dataclass(frozen=True, slots=True)
+class TrajectoryRun:
+    schema_version: int
+    run_id: str
+    session_id: str
+    chunk_id: str
+    sampler: str
+    scheduler: str
+    geometry: H3Geometry
+    audio_shape: tuple[int, ...]
+    layout_signature: str
+    conditioning_signature: str
+    storage: StoragePolicy
+    samples: tuple[TrajectorySample, ...]
+    started_ns: int
+    completed_ns: int
+    complete: bool
+    abort_reason: str | None = None
+
+    def exact_samples(self) -> tuple[TrajectorySample, ...]:
+        return tuple(sample for sample in self.samples if sample.provenance == "actual")
+
+
+@dataclass(slots=True)
+class _PendingRun:
+    run_id: str
+    session_id: str
+    chunk_id: str
+    sampler: str
+    scheduler: str
+    geometry: H3Geometry
+    audio_shape: tuple[int, ...]
+    layout_signature: str
+    conditioning_signature: str
+    storage: StoragePolicy
+    started_ns: int
+    samples: list[TrajectorySample] = field(default_factory=list)
+
+
+class H3FlowTrajectory:
+    """Transactional trajectory handle passed through ComfyUI as H3_FLOW_TRAJECTORY."""
+
+    api_version = SCHEMA_VERSION
+
+    def __init__(self, *, storage: StoragePolicy = "system_ram", max_runs: int = 16):
+        if storage not in {"system_ram", "vram"}:
+            raise ValueError("trajectory storage must be system_ram or vram")
+        if max_runs < 1:
+            raise ValueError("max_runs must be positive")
+        self.storage = storage
+        self.max_runs = int(max_runs)
+        self._lock = threading.RLock()
+        self._pending: _PendingRun | None = None
+        self._runs: tuple[TrajectoryRun, ...] = ()
+
+    @property
+    def runs(self) -> tuple[TrajectoryRun, ...]:
+        with self._lock:
+            return self._runs
+
+    @property
+    def latest(self) -> TrajectoryRun:
+        with self._lock:
+            if not self._runs:
+                raise RuntimeError("trajectory has no runs")
+            run = self._runs[-1]
+            if not run.complete:
+                raise RuntimeError("latest trajectory run is incomplete")
+            return run
+
+    @property
+    def bytes(self) -> int:
+        return sum(
+            sample.video_x0.numel() * sample.video_x0.element_size() for run in self.runs for sample in run.samples
+        )
+
+    def begin(
+        self,
+        *,
+        session_id: str,
+        chunk_id: str,
+        sampler: str,
+        scheduler: str,
+        geometry: H3Geometry,
+        audio_shape: tuple[int, ...],
+        layout_signature: str,
+        conditioning_signature: str,
+    ) -> str:
+        with self._lock:
+            if self._pending is not None:
+                raise RuntimeError("trajectory already has an active transaction")
+            run_id = uuid.uuid4().hex
+            self._pending = _PendingRun(
+                run_id=run_id,
+                session_id=str(session_id),
+                chunk_id=str(chunk_id),
+                sampler=str(sampler),
+                scheduler=str(scheduler),
+                geometry=geometry,
+                audio_shape=tuple(audio_shape),
+                layout_signature=str(layout_signature),
+                conditioning_signature=str(conditioning_signature),
+                storage=self.storage,
+                started_ns=time.time_ns(),
+            )
+            return run_id
+
+    def append(self, run_id: str, sample: TrajectorySample) -> None:
+        with self._lock:
+            pending = self._require_pending(run_id)
+            if sample.provenance not in {"actual", "forecast"}:
+                raise ValueError("trajectory provenance must be actual or forecast")
+            tensor = sample.video_x0.detach()
+            if self.storage == "system_ram":
+                tensor = tensor.to(device="cpu", dtype=torch.float32, copy=True)
+                if torch.cuda.is_available():
+                    tensor = tensor.pin_memory()
+            else:
+                tensor = tensor.clone()
+            pending.samples.append(replace(sample, video_x0=tensor))
+
+    def commit(self, run_id: str) -> TrajectoryRun:
+        with self._lock:
+            pending = self._require_pending(run_id)
+            run = TrajectoryRun(
+                schema_version=SCHEMA_VERSION,
+                run_id=pending.run_id,
+                session_id=pending.session_id,
+                chunk_id=pending.chunk_id,
+                sampler=pending.sampler,
+                scheduler=pending.scheduler,
+                geometry=pending.geometry,
+                audio_shape=pending.audio_shape,
+                layout_signature=pending.layout_signature,
+                conditioning_signature=pending.conditioning_signature,
+                storage=pending.storage,
+                samples=tuple(pending.samples),
+                started_ns=pending.started_ns,
+                completed_ns=time.time_ns(),
+                complete=True,
+            )
+            self._runs = (*self._runs, run)[-self.max_runs :]
+            self._pending = None
+            return run
+
+    def abort(self, run_id: str, reason: str) -> TrajectoryRun:
+        with self._lock:
+            pending = self._require_pending(run_id)
+            run = TrajectoryRun(
+                schema_version=SCHEMA_VERSION,
+                run_id=pending.run_id,
+                session_id=pending.session_id,
+                chunk_id=pending.chunk_id,
+                sampler=pending.sampler,
+                scheduler=pending.scheduler,
+                geometry=pending.geometry,
+                audio_shape=pending.audio_shape,
+                layout_signature=pending.layout_signature,
+                conditioning_signature=pending.conditioning_signature,
+                storage=pending.storage,
+                samples=tuple(pending.samples),
+                started_ns=pending.started_ns,
+                completed_ns=time.time_ns(),
+                complete=False,
+                abort_reason=str(reason),
+            )
+            self._runs = (*self._runs, run)[-self.max_runs :]
+            self._pending = None
+            return run
+
+    def invalidate(self, run_id: str, reason: str) -> TrajectoryRun:
+        """Make a previously committed run unavailable to future guidance selection."""
+        with self._lock:
+            for index in range(len(self._runs) - 1, -1, -1):
+                run = self._runs[index]
+                if run.run_id != str(run_id):
+                    continue
+                if not run.complete:
+                    return run
+                invalid = replace(
+                    run,
+                    complete=False,
+                    abort_reason=str(reason),
+                    completed_ns=time.time_ns(),
+                )
+                runs = list(self._runs)
+                runs[index] = invalid
+                self._runs = tuple(runs)
+                return invalid
+            raise RuntimeError("cannot invalidate an unknown trajectory run")
+
+    def select(
+        self,
+        *,
+        run_id: str | None = None,
+        chunk_id: str | None = None,
+        session_id: str | None = None,
+        conditioning_signature: str | None = None,
+    ) -> TrajectoryRun:
+        with self._lock:
+            candidates = [
+                run
+                for run in self._runs
+                if (run_id is None or run.run_id == str(run_id))
+                and (chunk_id is None or run.chunk_id == str(chunk_id))
+                and (session_id is None or run.session_id == str(session_id))
+                and (conditioning_signature is None or run.conditioning_signature == str(conditioning_signature))
+            ]
+            if not candidates:
+                if run_id is not None:
+                    raise RuntimeError(f"no trajectory matches requested run_id={run_id}")
+                raise RuntimeError("no trajectory matches the requested session/chunk/conditioning")
+            run = candidates[-1]
+            if not run.complete:
+                raise RuntimeError("latest matching trajectory is incomplete")
+            if not any(sample.provenance == "actual" for sample in run.samples):
+                raise RuntimeError("latest matching trajectory has no exact anchors")
+            return run
+
+    def clear(self) -> None:
+        with self._lock:
+            if self._pending is not None:
+                raise RuntimeError("cannot clear a trajectory during an active transaction")
+            self._runs = ()
+
+    def _require_pending(self, run_id: str) -> _PendingRun:
+        pending = self._pending
+        if pending is None or pending.run_id != run_id:
+            raise RuntimeError("stale or missing trajectory transaction")
+        return pending

--- a/h3_flow_regenerate/geometry.py
+++ b/h3_flow_regenerate/geometry.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+H3_VIDEO_CHANNELS = 24
+H3_AUDIO_CHANNELS = 32
+H3_AUDIO_TRACKS = 2
+H3_VAE_SPATIAL_DOWNSAMPLE = 16
+H3_PATCH_H = 2
+H3_PATCH_W = 2
+H3_PIXEL_ALIGNMENT = H3_VAE_SPATIAL_DOWNSAMPLE * H3_PATCH_H
+
+
+@dataclass(frozen=True, slots=True)
+class H3Geometry:
+    batch: int
+    latent_t: int
+    latent_h: int
+    latent_w: int
+    pixel_h: int
+    pixel_w: int
+    padded_h: int
+    padded_w: int
+
+    @property
+    def patch_safe(self) -> bool:
+        return self.latent_h % H3_PATCH_H == 0 and self.latent_w % H3_PATCH_W == 0
+
+    @property
+    def video_rows(self) -> int:
+        return self.latent_t * (self.padded_h // H3_PATCH_H) * (self.padded_w // H3_PATCH_W)
+
+
+def geometry_from_video(video: torch.Tensor) -> H3Geometry:
+    validate_video(video)
+    batch, _, latent_t, latent_h, latent_w = map(int, video.shape)
+    padded_h = latent_h + (-latent_h) % H3_PATCH_H
+    padded_w = latent_w + (-latent_w) % H3_PATCH_W
+    return H3Geometry(
+        batch=batch,
+        latent_t=latent_t,
+        latent_h=latent_h,
+        latent_w=latent_w,
+        pixel_h=latent_h * H3_VAE_SPATIAL_DOWNSAMPLE,
+        pixel_w=latent_w * H3_VAE_SPATIAL_DOWNSAMPLE,
+        padded_h=padded_h,
+        padded_w=padded_w,
+    )
+
+
+def normalize_target_geometry(
+    *,
+    source_h: int,
+    source_w: int,
+    scale: float | None = None,
+    target_h: int | None = None,
+    target_w: int | None = None,
+    policy: str = "ceil",
+) -> tuple[int, int]:
+    """Resolve an even latent H/W without allowing native circular padding.
+
+    Dimensions are latent-space dimensions. ``ceil`` never undershoots the requested
+    size; ``nearest`` may move by one latent cell. Explicit odd targets are normalized
+    deterministically and are always reported by the caller.
+    """
+    if source_h < 2 or source_w < 2:
+        raise ValueError("source latent H/W must both be at least 2")
+    if scale is not None:
+        if target_h is not None or target_w is not None:
+            raise ValueError("provide scale or explicit target H/W, not both")
+        if not isinstance(scale, (float, int)) or isinstance(scale, bool) or float(scale) <= 0:
+            raise ValueError("scale must be a positive finite number")
+        raw_h, raw_w = source_h * float(scale), source_w * float(scale)
+    else:
+        if target_h is None or target_w is None:
+            raise ValueError("explicit target_h and target_w are both required")
+        raw_h, raw_w = float(target_h), float(target_w)
+    if not torch.isfinite(torch.tensor([raw_h, raw_w])).all().item():
+        raise ValueError("target geometry must be finite")
+    if policy == "ceil":
+        h = int(torch.ceil(torch.tensor(raw_h)).item())
+        w = int(torch.ceil(torch.tensor(raw_w)).item())
+        h += (-h) % H3_PATCH_H
+        w += (-w) % H3_PATCH_W
+    elif policy == "nearest":
+        h = round(raw_h / H3_PATCH_H) * H3_PATCH_H
+        w = round(raw_w / H3_PATCH_W) * H3_PATCH_W
+    else:
+        raise ValueError(f"unsupported geometry policy {policy!r}")
+    if h < 2 or w < 2:
+        raise ValueError("normalized target latent H/W must both be at least 2")
+    return h, w
+
+
+def pixel_to_safe_latent(height: int, width: int, *, policy: str = "ceil") -> tuple[int, int]:
+    if height < H3_PIXEL_ALIGNMENT or width < H3_PIXEL_ALIGNMENT:
+        raise ValueError(f"target pixels must be at least {H3_PIXEL_ALIGNMENT}x{H3_PIXEL_ALIGNMENT}")
+    if policy == "ceil":
+        h = (height + H3_PIXEL_ALIGNMENT - 1) // H3_PIXEL_ALIGNMENT
+        w = (width + H3_PIXEL_ALIGNMENT - 1) // H3_PIXEL_ALIGNMENT
+    elif policy == "nearest":
+        h = round(height / H3_PIXEL_ALIGNMENT)
+        w = round(width / H3_PIXEL_ALIGNMENT)
+    else:
+        raise ValueError(f"unsupported geometry policy {policy!r}")
+    return int(h * H3_PATCH_H), int(w * H3_PATCH_W)
+
+
+def validate_video(video: Any) -> torch.Tensor:
+    if not isinstance(video, torch.Tensor):
+        raise TypeError("H3 video state must be a torch.Tensor")
+    if video.ndim != 5 or video.shape[1] != H3_VIDEO_CHANNELS:
+        raise ValueError(f"H3 video state must be Bx24xTxHxW, got {tuple(video.shape)}")
+    if video.shape[0] != 1:
+        raise ValueError("native MiniMax H3 currently requires batch size 1")
+    if min(video.shape[2:]) < 1:
+        raise ValueError("H3 video axes must be non-empty")
+    if not video.is_floating_point():
+        raise TypeError("H3 video state must use floating point")
+    return video
+
+
+def validate_audio(audio: Any) -> torch.Tensor:
+    if not isinstance(audio, torch.Tensor):
+        raise TypeError("H3 audio state must be a torch.Tensor")
+    if audio.ndim != 4 or audio.shape[1] != H3_AUDIO_CHANNELS or audio.shape[2] != H3_AUDIO_TRACKS:
+        raise ValueError(f"H3 audio state must be Bx32x2xT, got {tuple(audio.shape)}")
+    if audio.shape[0] != 1 or audio.shape[-1] < 1:
+        raise ValueError("H3 audio requires batch size 1 and a non-empty time axis")
+    if not audio.is_floating_point():
+        raise TypeError("H3 audio state must use floating point")
+    return audio
+
+
+def validate_av(video: Any, audio: Any, *, require_patch_safe: bool = True) -> tuple[torch.Tensor, torch.Tensor]:
+    video = validate_video(video)
+    audio = validate_audio(audio)
+    if require_patch_safe and (video.shape[-2] % 2 or video.shape[-1] % 2):
+        raise ValueError("H3 video latent H/W must be even; odd geometry would invoke native circular padding")
+    return video, audio
+
+
+def resize_spatial_5d(tensor: torch.Tensor, target_h: int, target_w: int, *, mode: str = "bicubic") -> torch.Tensor:
+    if not isinstance(tensor, torch.Tensor) or tensor.ndim != 5 or not tensor.is_floating_point():
+        raise TypeError("spatial resize input must be a floating-point BxCxTxHxW tensor")
+    if target_h % 2 or target_w % 2:
+        raise ValueError("target latent H/W must be even")
+    if mode not in {"nearest", "bilinear", "bicubic", "area"}:
+        raise ValueError(f"unsupported spatial transfer mode {mode!r}")
+    b, c, t, h, w = tensor.shape
+    work = tensor.permute(0, 2, 1, 3, 4).reshape(b * t, c, h, w).float()
+    kwargs: dict[str, Any] = {"size": (target_h, target_w), "mode": mode}
+    if mode in {"bilinear", "bicubic"}:
+        kwargs["align_corners"] = False
+        kwargs["antialias"] = target_h < h or target_w < w
+    out = F.interpolate(work, **kwargs)
+    return out.reshape(b, t, c, target_h, target_w).permute(0, 2, 1, 3, 4).to(tensor)
+
+
+def resize_video(video: torch.Tensor, target_h: int, target_w: int, *, mode: str = "bicubic") -> torch.Tensor:
+    validate_video(video)
+    return resize_spatial_5d(video, target_h, target_w, mode=mode)
+
+
+def pack_streams(streams: Iterable[torch.Tensor]) -> tuple[torch.Tensor, list[tuple[int, ...]]]:
+    shapes: list[tuple[int, ...]] = []
+    flattened: list[torch.Tensor] = []
+    for tensor in streams:
+        shapes.append(tuple(int(v) for v in tensor.shape))
+        flattened.append(tensor.reshape(tensor.shape[0], 1, -1))
+    if not flattened:
+        raise ValueError("at least one stream is required")
+    return torch.cat(flattened, dim=-1), shapes
+
+
+def unpack_streams(packed: torch.Tensor, shapes: Iterable[tuple[int, ...]]) -> list[torch.Tensor]:
+    result: list[torch.Tensor] = []
+    offset = 0
+    for shape in shapes:
+        count = 1
+        for size in shape[1:]:
+            count *= int(size)
+        result.append(packed[..., offset : offset + count].reshape((packed.shape[0], *shape[1:])))
+        offset += count
+    if offset != packed.shape[-1]:
+        raise ValueError(f"packed state has {packed.shape[-1] - offset} unmatched values")
+    return result

--- a/h3_flow_regenerate/guidance.py
+++ b/h3_flow_regenerate/guidance.py
@@ -1,0 +1,238 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from itertools import pairwise
+
+import torch
+import torch.nn.functional as F
+
+from .contracts import TrajectoryRun, TrajectorySample
+from .geometry import resize_video
+from .sigma import interpolate_coordinate
+
+
+@dataclass(frozen=True, slots=True)
+class GuidanceConfig:
+    mode: str = "direction"
+    direction_weight: float = 0.35
+    acceleration_weight: float = 0.0
+    consistency_weight: float = 0.0
+    cutoff: float = 0.25
+    schedule_power: float = 1.0
+    transfer_mode: str = "bicubic"
+    max_correction_rms_ratio: float = 0.5
+
+    def __post_init__(self) -> None:
+        modes = {"off", "direction", "direction+acceleration", "downsample_consistency"}
+        if self.mode not in modes:
+            raise ValueError(f"unsupported guidance mode {self.mode!r}")
+        for name in ("direction_weight", "acceleration_weight", "consistency_weight"):
+            value = float(getattr(self, name))
+            if not math.isfinite(value) or value < 0:
+                raise ValueError(f"{name} must be finite and non-negative")
+        if not 0 < self.cutoff <= 1:
+            raise ValueError("cutoff must be in (0, 1]")
+        if self.schedule_power < 0 or not math.isfinite(self.schedule_power):
+            raise ValueError("schedule_power must be finite and non-negative")
+        if not math.isfinite(float(self.max_correction_rms_ratio)) or self.max_correction_rms_ratio <= 0:
+            raise ValueError("max_correction_rms_ratio must be finite and positive")
+
+
+@dataclass(slots=True)
+class GuidanceState:
+    start_coordinate: float | None = None
+    previous_coordinate: float | None = None
+    previous_high_x0: torch.Tensor | None = None
+    previous_reference: torch.Tensor | None = None
+    last_schedule: float | None = None
+    last_correction_rms: float | None = None
+    last_baseline_rms: float | None = None
+    last_correction_rms_ratio: float | None = None
+    last_clamp_scale: float | None = None
+
+    def reset(self) -> None:
+        self.start_coordinate = None
+        self.previous_coordinate = None
+        self.previous_high_x0 = None
+        self.previous_reference = None
+        self.last_schedule = None
+        self.last_correction_rms = None
+        self.last_baseline_rms = None
+        self.last_correction_rms_ratio = None
+        self.last_clamp_scale = None
+
+
+_PHASE_PRIORITY = {
+    "handoff_probe": 4,
+    "corrected": 3,
+    "single": 2,
+    "predicted": 1,
+}
+
+
+def trustworthy_samples(run: TrajectoryRun) -> tuple[TrajectorySample, ...]:
+    if not run.complete:
+        raise RuntimeError("incomplete trajectory runs cannot guide regeneration")
+    exact = [sample for sample in run.samples if sample.provenance == "actual"]
+    if not exact:
+        raise RuntimeError("trajectory has no exact anchors")
+    if any(not math.isfinite(float(sample.coordinate)) for sample in exact):
+        raise RuntimeError("trajectory contains a non-finite exact coordinate")
+    exact.sort(key=lambda sample: sample.coordinate, reverse=True)
+
+    # PECE evaluates predicted and corrected states at the same sigma. Keep one
+    # exact anchor per coordinate, preferring the corrected endpoint; a dedicated
+    # handoff probe is the strongest anchor because it evaluates the actual
+    # stopped low-stage state at the split coordinate.
+    deduplicated: list[TrajectorySample] = []
+    for sample in exact:
+        if deduplicated and math.isclose(
+            float(sample.coordinate),
+            float(deduplicated[-1].coordinate),
+            rel_tol=0.0,
+            abs_tol=1e-12,
+        ):
+            current = deduplicated[-1]
+            if _PHASE_PRIORITY.get(sample.phase, 0) > _PHASE_PRIORITY.get(current.phase, 0):
+                deduplicated[-1] = sample
+            continue
+        deduplicated.append(sample)
+    return tuple(deduplicated)
+
+
+def time_matched_reference(run: TrajectoryRun, coordinate: float) -> torch.Tensor:
+    samples = trustworthy_samples(run)
+    if coordinate >= samples[0].coordinate:
+        return samples[0].video_x0
+    if coordinate <= samples[-1].coordinate:
+        return samples[-1].video_x0
+    for left, right in pairwise(samples):
+        if left.coordinate >= coordinate >= right.coordinate:
+            weight = interpolate_coordinate(left.coordinate, right.coordinate, coordinate)
+            return torch.lerp(left.video_x0, right.video_x0, weight)
+    raise RuntimeError("trajectory interpolation support is inconsistent")
+
+
+def low_frequency_projection(video: torch.Tensor, cutoff: float) -> torch.Tensor:
+    if video.ndim != 5:
+        raise ValueError("low-frequency projection expects BxCxTxHxW")
+    if cutoff >= 1.0:
+        return video
+    h, w = video.shape[-2:]
+    radius = max(1, round(0.5 / cutoff))
+    kernel = 2 * radius + 1
+    work = video.permute(0, 2, 1, 3, 4).reshape(-1, video.shape[1], h, w).float()
+    padded = F.pad(work, (radius, radius, radius, radius), mode="replicate")
+    filtered = F.avg_pool2d(padded, kernel_size=kernel, stride=1)
+    return filtered.reshape(video.shape[0], video.shape[2], video.shape[1], h, w).permute(0, 2, 1, 3, 4).to(video)
+
+
+def _bounded(
+    correction: torch.Tensor,
+    reference: torch.Tensor,
+    ratio: float,
+) -> tuple[torch.Tensor, dict[str, float]]:
+    dims = tuple(range(1, correction.ndim))
+    corr_rms = correction.float().square().mean(dim=dims, keepdim=True).sqrt()
+    ref_rms = reference.float().square().mean(dim=dims, keepdim=True).sqrt().clamp_min(1e-8)
+    scale = torch.clamp(ref_rms * ratio / corr_rms.clamp_min(1e-8), max=1.0)
+    bounded_rms = corr_rms * scale
+    summary = (
+        torch.stack(
+            (
+                bounded_rms.mean(),
+                ref_rms.mean(),
+                (bounded_rms / ref_rms).mean(),
+                scale.mean(),
+            )
+        )
+        .detach()
+        .to(device="cpu", dtype=torch.float64)
+    )
+    correction_rms, baseline_rms, correction_rms_ratio, clamp_scale = map(float, summary.tolist())
+    stats = {
+        "correction_rms": correction_rms,
+        "baseline_rms": baseline_rms,
+        "correction_rms_ratio": correction_rms_ratio,
+        "clamp_scale": clamp_scale,
+    }
+    return correction * scale.to(correction), stats
+
+
+def apply_guidance(
+    high_x0: torch.Tensor,
+    *,
+    run: TrajectoryRun,
+    coordinate: float,
+    config: GuidanceConfig,
+    state: GuidanceState,
+) -> torch.Tensor:
+    if config.mode == "off":
+        return high_x0
+    if config.mode == "direction+acceleration" and config.acceleration_weight > 0 and len(trustworthy_samples(run)) < 3:
+        raise RuntimeError("acceleration guidance requires at least three exact trajectory anchors")
+    coordinate = float(coordinate)
+    if not math.isfinite(coordinate) or not 0.0 <= coordinate <= 1.0:
+        raise ValueError("guidance coordinate must be finite and inside [0, 1]")
+    source_ref = time_matched_reference(run, coordinate).to(device=high_x0.device, dtype=high_x0.dtype)
+    ref = resize_video(source_ref, high_x0.shape[-2], high_x0.shape[-1], mode=config.transfer_mode)
+    if state.start_coordinate is None:
+        state.start_coordinate = coordinate
+    start = max(float(state.start_coordinate), 1e-8)
+    schedule = min(1.0, max(0.0, coordinate / start)) ** config.schedule_power
+    correction = torch.zeros_like(high_x0)
+    if config.mode in {"direction", "direction+acceleration"}:
+        residual = low_frequency_projection(ref - high_x0, config.cutoff)
+        correction = correction + schedule * config.direction_weight * residual
+    if config.mode == "downsample_consistency":
+        source_size = (run.geometry.latent_h, run.geometry.latent_w)
+        work = high_x0.permute(0, 2, 1, 3, 4).reshape(-1, high_x0.shape[1], *high_x0.shape[-2:]).float()
+        down = F.interpolate(work, size=source_size, mode="area")
+        down = down.reshape(high_x0.shape[0], high_x0.shape[2], high_x0.shape[1], *source_size).permute(0, 2, 1, 3, 4)
+        source_error = source_ref - down.to(source_ref)
+        error = resize_video(source_error, *high_x0.shape[-2:], mode=config.transfer_mode)
+        correction = correction + schedule * config.consistency_weight * error
+    if (
+        config.mode == "direction+acceleration"
+        and config.acceleration_weight > 0
+        and state.previous_coordinate is not None
+        and state.previous_high_x0 is not None
+        and state.previous_reference is not None
+        and abs(coordinate - state.previous_coordinate) > 1e-8
+    ):
+        ref_delta = low_frequency_projection(ref - state.previous_reference, config.cutoff)
+        high_delta = low_frequency_projection(high_x0 - state.previous_high_x0, config.cutoff)
+        correction = correction + schedule * config.acceleration_weight * (ref_delta - high_delta)
+    correction, correction_stats = _bounded(correction, high_x0, config.max_correction_rms_ratio)
+    state.last_schedule = float(schedule)
+    state.last_correction_rms = correction_stats["correction_rms"]
+    state.last_baseline_rms = correction_stats["baseline_rms"]
+    state.last_correction_rms_ratio = correction_stats["correction_rms_ratio"]
+    state.last_clamp_scale = correction_stats["clamp_scale"]
+    if config.mode == "direction+acceleration" and config.acceleration_weight > 0:
+        state.previous_coordinate = float(coordinate)
+        state.previous_high_x0 = high_x0.detach()
+        state.previous_reference = ref.detach()
+    else:
+        state.previous_coordinate = None
+        state.previous_high_x0 = None
+        state.previous_reference = None
+    return high_x0 + correction
+
+
+def conditional_renoise_alignment(
+    reference_x0: torch.Tensor,
+    *,
+    target_h: int,
+    target_w: int,
+    sigma: float,
+    noise: torch.Tensor,
+    transfer_mode: str = "bicubic",
+) -> torch.Tensor:
+    if not 0 <= sigma <= 1:
+        raise ValueError("sigma must be in [0, 1]")
+    ref = resize_video(reference_x0, target_h, target_w, mode=transfer_mode).to(noise)
+    if ref.shape != noise.shape:
+        raise ValueError("initialization reference and noise shapes differ")
+    return (1.0 - sigma) * ref + sigma * noise

--- a/h3_flow_regenerate/handoff.py
+++ b/h3_flow_regenerate/handoff.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+import torch
+
+from .geometry import normalize_target_geometry, pack_streams, unpack_streams, validate_av
+from .guidance import conditional_renoise_alignment
+from .sigma import H3_VIDEO_SHIFT, normalized_coordinate
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressiveHandoffConfig:
+    target_latent_h: int | None = None
+    target_latent_w: int | None = None
+    target_scale: float | None = None
+    handoff_coordinate: float = 0.35
+    handoff_selection: str = "fixed"
+    auto_min_coordinate: float = 0.2
+    auto_max_coordinate: float = 0.55
+    transfer_mode: str = "bicubic"
+    matching_mode: str = "conditional_renoise"
+    seed_offset: int = 0x4833464C4F57
+    min_high_steps: int = 2
+
+    def __post_init__(self) -> None:
+        explicit = self.target_latent_h is not None or self.target_latent_w is not None
+        if explicit == (self.target_scale is not None):
+            raise ValueError("provide either target latent H/W or target scale")
+        if explicit:
+            if self.target_latent_h is None or self.target_latent_h < 2 or self.target_latent_h % 2:
+                raise ValueError("target latent H must be positive and even")
+            if self.target_latent_w is None or self.target_latent_w < 2 or self.target_latent_w % 2:
+                raise ValueError("target latent W must be positive and even")
+        elif not math.isfinite(float(self.target_scale)) or float(self.target_scale) <= 1.0:
+            raise ValueError("target scale must be finite and greater than 1")
+        if not 0 < self.handoff_coordinate < 1 or not math.isfinite(self.handoff_coordinate):
+            raise ValueError("handoff coordinate must be finite and inside (0, 1)")
+        if self.handoff_selection not in {"fixed", "auto_compute"}:
+            raise ValueError("handoff selection must be fixed or auto_compute")
+        if not 0 < self.auto_min_coordinate <= self.auto_max_coordinate < 1:
+            raise ValueError("automatic handoff bounds must lie inside (0, 1)")
+        if self.matching_mode != "conditional_renoise":
+            raise ValueError("only the derived conditional_renoise handoff is currently supported")
+        if self.min_high_steps < 1:
+            raise ValueError("min_high_steps must be positive")
+
+    def resolve_target(self, source_h: int, source_w: int) -> tuple[int, int]:
+        if self.target_scale is not None:
+            target_h, target_w = normalize_target_geometry(
+                source_h=source_h,
+                source_w=source_w,
+                scale=self.target_scale,
+                policy="nearest",
+            )
+        else:
+            target_h, target_w = int(self.target_latent_h), int(self.target_latent_w)
+        if target_h < int(source_h) or target_w < int(source_w):
+            raise ValueError("progressive handoff target must not shrink either video axis")
+        if target_h == int(source_h) and target_w == int(source_w):
+            raise ValueError("progressive handoff target must increase at least one video axis")
+        return target_h, target_w
+
+    def resolve_coordinate(self, source_h: int, source_w: int, target_h: int, target_w: int) -> float:
+        if self.handoff_selection == "fixed":
+            return self.handoff_coordinate
+        area_ratio = (target_h * target_w) / (source_h * source_w)
+        estimate = self.handoff_coordinate / math.sqrt(area_ratio)
+        return min(self.auto_max_coordinate, max(self.auto_min_coordinate, estimate))
+
+
+@dataclass(frozen=True, slots=True)
+class ProgressiveTargetInputConfig:
+    """Run early denoising on a smaller grid while the workflow stays target-sized.
+
+    This mode is designed for Continuum and other pipelines whose latent/session
+    contract must remain on the final output grid. The wrapper derives a low-grid
+    sampler invocation internally and returns to the original target grid at the
+    handoff, so downstream spatial contracts never observe a geometry change.
+    """
+
+    source_latent_h: int | None = None
+    source_latent_w: int | None = None
+    source_scale: float | None = None
+    handoff_coordinate: float = 0.35
+    handoff_selection: str = "fixed"
+    auto_min_coordinate: float = 0.2
+    auto_max_coordinate: float = 0.55
+    transfer_mode: str = "bicubic"
+    matching_mode: str = "conditional_renoise"
+    seed_offset: int = 0x4833464C4F57
+    source_noise_offset: int = 0x48334C4F574C52
+    min_high_steps: int = 2
+
+    def __post_init__(self) -> None:
+        explicit = self.source_latent_h is not None or self.source_latent_w is not None
+        if explicit == (self.source_scale is not None):
+            raise ValueError("provide either source latent H/W or source scale")
+        if explicit:
+            if self.source_latent_h is None or self.source_latent_h < 2 or self.source_latent_h % 2:
+                raise ValueError("source latent H must be positive and even")
+            if self.source_latent_w is None or self.source_latent_w < 2 or self.source_latent_w % 2:
+                raise ValueError("source latent W must be positive and even")
+        elif not math.isfinite(float(self.source_scale)) or not 0.0 < float(self.source_scale) < 1.0:
+            raise ValueError("source scale must be finite and inside (0, 1)")
+        if not 0 < self.handoff_coordinate < 1 or not math.isfinite(self.handoff_coordinate):
+            raise ValueError("handoff coordinate must be finite and inside (0, 1)")
+        if self.handoff_selection not in {"fixed", "auto_compute"}:
+            raise ValueError("handoff selection must be fixed or auto_compute")
+        if not 0 < self.auto_min_coordinate <= self.auto_max_coordinate < 1:
+            raise ValueError("automatic handoff bounds must lie inside (0, 1)")
+        if self.matching_mode != "conditional_renoise":
+            raise ValueError("only the derived conditional_renoise handoff is currently supported")
+        if self.min_high_steps < 1:
+            raise ValueError("min_high_steps must be positive")
+
+    def resolve_source(self, target_h: int, target_w: int) -> tuple[int, int]:
+        if self.source_scale is not None:
+            source_h, source_w = normalize_target_geometry(
+                source_h=target_h,
+                source_w=target_w,
+                scale=self.source_scale,
+                policy="nearest",
+            )
+        else:
+            source_h, source_w = int(self.source_latent_h), int(self.source_latent_w)
+        if source_h > int(target_h) or source_w > int(target_w):
+            raise ValueError("target-input progressive source must not exceed either target video axis")
+        if source_h == int(target_h) and source_w == int(target_w):
+            raise ValueError("target-input progressive source must reduce at least one video axis")
+        return source_h, source_w
+
+    def resolve_coordinate(self, source_h: int, source_w: int, target_h: int, target_w: int) -> float:
+        if self.handoff_selection == "fixed":
+            return self.handoff_coordinate
+        area_ratio = (target_h * target_w) / (source_h * source_w)
+        estimate = self.handoff_coordinate / math.sqrt(area_ratio)
+        return min(self.auto_max_coordinate, max(self.auto_min_coordinate, estimate))
+
+
+def select_handoff_index(
+    sigmas: torch.Tensor,
+    coordinate: float,
+    *,
+    min_high_steps: int = 2,
+    video_shift: float = H3_VIDEO_SHIFT,
+) -> int:
+    if sigmas.ndim != 1 or sigmas.numel() < 4:
+        raise ValueError("progressive handoff requires at least three sampling intervals")
+    if not bool(torch.isfinite(sigmas).all().item()):
+        raise ValueError("progressive handoff requires finite sigma values")
+    if not math.isfinite(float(coordinate)) or not 0.0 < float(coordinate) < 1.0:
+        raise ValueError("progressive handoff coordinate must be finite and inside (0, 1)")
+    if not math.isfinite(float(video_shift)) or float(video_shift) <= 0.0:
+        raise ValueError("progressive handoff video shift must be finite and positive")
+    if bool((sigmas[1:] >= sigmas[:-1]).any()):
+        raise ValueError("progressive handoff requires a strictly descending sigma schedule")
+    candidates = torch.arange(1, sigmas.numel() - min_high_steps, device=sigmas.device)
+    if candidates.numel() == 0:
+        raise ValueError("sigma schedule leaves no valid handoff interval")
+    base_coordinates = normalized_coordinate(sigmas[candidates], video_shift=video_shift)
+    distances = (base_coordinates - float(coordinate)).abs()
+    return int(candidates[int(distances.argmin())].item())
+
+
+def deterministic_video_noise(
+    shape: tuple[int, ...],
+    *,
+    seed: int,
+    device: torch.device,
+    dtype: torch.dtype,
+) -> torch.Tensor:
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(int(seed) & ((1 << 63) - 1))
+    return torch.randn(shape, generator=generator, dtype=torch.float32, device="cpu").to(device=device, dtype=dtype)
+
+
+def build_handoff_state(
+    *,
+    source_packed_state: torch.Tensor,
+    source_x0_packed: torch.Tensor,
+    source_shapes: list[tuple[int, ...]],
+    sigma: float,
+    target_h: int,
+    target_w: int,
+    seed: int,
+    transfer_mode: str = "bicubic",
+) -> tuple[torch.Tensor, list[tuple[int, ...]]]:
+    if len(source_shapes) != 2:
+        raise ValueError("progressive H3 handoff requires exactly video and audio streams")
+    if not 0 < sigma < 1:
+        raise ValueError("handoff sigma must be strictly inside (0, 1)")
+    source_video, source_audio = unpack_streams(source_packed_state, source_shapes)
+    x0_video, _x0_audio = unpack_streams(source_x0_packed, source_shapes)
+    validate_av(source_video, source_audio)
+    if x0_video.shape != source_video.shape:
+        raise ValueError("source x0 video geometry does not match the handoff state")
+    if (target_h, target_w) == tuple(source_video.shape[-2:]):
+        return source_packed_state.clone(), list(source_shapes)
+    noise = deterministic_video_noise(
+        (source_video.shape[0], source_video.shape[1], source_video.shape[2], target_h, target_w),
+        seed=seed,
+        device=source_video.device,
+        dtype=source_video.dtype,
+    )
+    target_video = conditional_renoise_alignment(
+        x0_video,
+        target_h=target_h,
+        target_w=target_w,
+        sigma=float(sigma),
+        noise=noise,
+        transfer_mode=transfer_mode,
+    )
+    # The packed sampler carries audio on the video sigma schedule. Its state is
+    # preserved byte-for-byte across a purely spatial video transition.
+    target_packed, target_shapes = pack_streams((target_video, source_audio.clone()))
+    return target_packed, target_shapes

--- a/h3_flow_regenerate/metrics.py
+++ b/h3_flow_regenerate/metrics.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import threading
+import time
+from collections import Counter
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+@dataclass(frozen=True, slots=True)
+class MetricEvent:
+    kind: str
+    timestamp_ns: int = field(default_factory=time.time_ns)
+    fields: dict[str, Any] = field(default_factory=dict)
+
+
+class H3FlowMetrics:
+    api_version = 1
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._events: list[MetricEvent] = []
+        self._counters: Counter[str] = Counter()
+
+    def event(self, kind: str, **fields: Any) -> None:
+        with self._lock:
+            self._events.append(MetricEvent(kind=str(kind), fields=dict(fields)))
+
+    def increment(self, name: str, amount: int = 1) -> None:
+        with self._lock:
+            self._counters[str(name)] += int(amount)
+
+    @property
+    def events(self) -> tuple[MetricEvent, ...]:
+        with self._lock:
+            return tuple(self._events)
+
+    @property
+    def counters(self) -> dict[str, int]:
+        with self._lock:
+            return dict(self._counters)
+
+    def snapshot(self) -> dict[str, Any]:
+        return {
+            "schema_version": 1,
+            "counters": self.counters,
+            "events": [asdict(event) for event in self.events],
+        }
+
+    def to_json(self, *, indent: int = 2) -> str:
+        return json.dumps(self.snapshot(), indent=indent, sort_keys=True, default=str)
+
+    def write_json(self, path: str | Path) -> Path:
+        target = Path(path)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        temporary: Path | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=target.parent,
+                prefix=f".{target.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as handle:
+                handle.write(self.to_json() + "\n")
+                temporary = Path(handle.name)
+            temporary.replace(target)
+            return target
+        finally:
+            if temporary is not None:
+                temporary.unlink(missing_ok=True)

--- a/h3_flow_regenerate/metrics.py
+++ b/h3_flow_regenerate/metrics.py
@@ -24,10 +24,15 @@ class H3FlowMetrics:
         self._lock = threading.RLock()
         self._events: list[MetricEvent] = []
         self._counters: Counter[str] = Counter()
+        self._autosave_path: Path | None = None
 
     def event(self, kind: str, **fields: Any) -> None:
+        kind = str(kind)
         with self._lock:
-            self._events.append(MetricEvent(kind=str(kind), fields=dict(fields)))
+            self._events.append(MetricEvent(kind=kind, fields=dict(fields)))
+            autosave_path = self._autosave_path if kind == "sampler_wall" else None
+        if autosave_path is not None:
+            self.write_json(autosave_path)
 
     def increment(self, name: str, amount: int = 1) -> None:
         with self._lock:
@@ -52,6 +57,12 @@ class H3FlowMetrics:
 
     def to_json(self, *, indent: int = 2) -> str:
         return json.dumps(self.snapshot(), indent=indent, sort_keys=True, default=str)
+
+    def enable_autosave(self, path: str | Path) -> Path:
+        target = Path(path)
+        with self._lock:
+            self._autosave_path = target
+        return self.write_json(target)
 
     def write_json(self, path: str | Path) -> Path:
         target = Path(path)

--- a/h3_flow_regenerate/nodes.py
+++ b/h3_flow_regenerate/nodes.py
@@ -518,17 +518,17 @@ class H3MetricsJSON:
     def render(self, metrics, filename_prefix="h3_flow_regenerate/metrics"):
         import folder_paths
 
-        payload = metrics.to_json()
         output_dir = folder_paths.get_output_directory()
         full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
             filename_prefix,
             output_dir,
         )
         file_name = f"{filename}_{counter:05}_.json"
-        metrics.write_json(Path(full_output_folder) / file_name)
+        metrics.enable_autosave(Path(full_output_folder) / file_name)
+        payload = metrics.to_json()
         relative_path = f"{subfolder}/{file_name}" if subfolder else file_name
         return {
-            "ui": {"text": [f"Saved metrics JSON: {relative_path}"]},
+            "ui": {"text": [f"Saving metrics JSON: {relative_path}"]},
             "result": (payload,),
         }
 

--- a/h3_flow_regenerate/nodes.py
+++ b/h3_flow_regenerate/nodes.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+from dataclasses import asdict
+from pathlib import Path
+
+from .attention import AttentionConfig
+from .comfy_compat import patch_flow_model
+from .contracts import H3FlowTrajectory
+from .geometry import pixel_to_safe_latent
+from .guidance import GuidanceConfig
+from .handoff import ProgressiveHandoffConfig, ProgressiveTargetInputConfig
+from .metrics import H3FlowMetrics
+from .reference import apply_reference_budget
+from .runtime import FLOW_BINDING_KEY, FlowBinding, conditioning_signature_from_conditioning
+from .sigma import resolution_aware_sigmas, resolution_shift_factor
+
+
+class H3FlowTrajectoryNode:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "storage": (["system_ram", "vram"], {"default": "system_ram"}),
+                "max_runs": ("INT", {"default": 16, "min": 1, "max": 128}),
+            }
+        }
+
+    RETURN_TYPES = ("H3_FLOW_TRAJECTORY",)
+    FUNCTION = "create"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    @classmethod
+    def IS_CHANGED(cls, storage, max_runs):
+        # The trajectory is mutable execution state, not a reusable cached value.
+        # Returning NaN makes Comfy create one fresh handle for each prompt while
+        # still sharing that single handle across all downstream nodes in it.
+        return float("nan")
+
+    def create(self, storage, max_runs):
+        return (H3FlowTrajectory(storage=storage, max_runs=max_runs),)
+
+
+class H3TrajectoryCapture:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "trajectory": ("H3_FLOW_TRAJECTORY",),
+                "capture_forecasts": ("BOOLEAN", {"default": False}),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("model", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def patch(self, model, trajectory, capture_forecasts=False):
+        metrics = H3FlowMetrics()
+        patched, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=GuidanceConfig(mode="off"),
+            clear_progressive=True,
+            capture_enabled=True,
+            capture_forecasts=capture_forecasts,
+            clear_guidance_conditioning_signature=True,
+            clear_guidance_run_id=True,
+            metrics=metrics,
+        )
+        return patched, metrics
+
+
+class H3FlowAlignedRegenerate:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "trajectory": ("H3_FLOW_TRAJECTORY",),
+                "guidance_mode": (
+                    ["off", "direction", "direction+acceleration", "downsample_consistency"],
+                    {"default": "direction"},
+                ),
+                "direction_weight": ("FLOAT", {"default": 0.35, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "acceleration_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "consistency_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
+            },
+            "optional": {
+                "source_conditioning": ("CONDITIONING",),
+                "source_negative": ("CONDITIONING",),
+                "metrics": ("H3_FLOW_METRICS",),
+            },
+        }
+
+    RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("model", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def patch(
+        self,
+        model,
+        trajectory,
+        guidance_mode,
+        direction_weight,
+        acceleration_weight,
+        consistency_weight,
+        low_frequency_cutoff,
+        source_conditioning=None,
+        source_negative=None,
+        metrics=None,
+    ):
+        metrics = metrics or H3FlowMetrics()
+        if source_negative is not None and source_conditioning is None:
+            raise ValueError("source_negative requires source_conditioning")
+        source_signature = (
+            conditioning_signature_from_conditioning(source_conditioning, source_negative)
+            if source_conditioning is not None
+            else None
+        )
+        guidance = GuidanceConfig(
+            mode=guidance_mode,
+            direction_weight=direction_weight,
+            acceleration_weight=acceleration_weight,
+            consistency_weight=consistency_weight,
+            cutoff=low_frequency_cutoff,
+        )
+        patched, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=guidance,
+            clear_progressive=True,
+            capture_enabled=False,
+            capture_forecasts=False,
+            guidance_conditioning_signature=source_signature,
+            clear_guidance_conditioning_signature=source_signature is None,
+            clear_guidance_run_id=True,
+            metrics=metrics,
+        )
+        return patched, metrics
+
+
+class H3FlowAlignedRefineState:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "refine_state": ("H3_CONTINUUM_REFINE_STATE",),
+                "trajectory": ("H3_FLOW_TRAJECTORY",),
+                "guidance_mode": (
+                    ["off", "direction", "direction+acceleration", "downsample_consistency"],
+                    {"default": "direction"},
+                ),
+                "direction_weight": ("FLOAT", {"default": 0.35, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "acceleration_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "consistency_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
+            },
+            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+        }
+
+    RETURN_TYPES = ("H3_CONTINUUM_REFINE_STATE", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("refine_state", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def patch(
+        self,
+        refine_state,
+        trajectory,
+        guidance_mode,
+        direction_weight,
+        acceleration_weight,
+        consistency_weight,
+        low_frequency_cutoff,
+        metrics=None,
+    ):
+        if not isinstance(refine_state, dict):
+            raise TypeError("H3 Continuum refine_state must be a dictionary")
+        if type(refine_state.get("api")) is not int or int(refine_state["api"]) != 1:
+            raise ValueError("H3 Flow-Aligned Refine State requires H3 Continuum refine_state API 1")
+        model = refine_state.get("model")
+        positive = refine_state.get("positive")
+        if model is None or positive is None:
+            raise ValueError("H3 Continuum refine_state is missing model or positive conditioning")
+        guidance = GuidanceConfig(
+            mode=guidance_mode,
+            direction_weight=direction_weight,
+            acceleration_weight=acceleration_weight,
+            consistency_weight=consistency_weight,
+            cutoff=low_frequency_cutoff,
+        )
+        metrics = metrics or H3FlowMetrics()
+        source_signature = conditioning_signature_from_conditioning(positive)
+        source_binding = (getattr(model, "model_options", None) or {}).get(FLOW_BINDING_KEY)
+        source_run_id = source_binding.captured_run_id if isinstance(source_binding, FlowBinding) else None
+        if source_run_id is None:
+            raise RuntimeError(
+                "H3 Continuum refine_state MODEL has no captured trajectory provenance. "
+                "Ensure MiniMax H3 Trajectory Capture is the final MODEL patch before Continuum "
+                "and that Flow-Aligned Refine State uses the same H3_FLOW_TRAJECTORY."
+            )
+        patched_model, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=guidance,
+            clear_progressive=True,
+            capture_enabled=False,
+            capture_forecasts=False,
+            guidance_conditioning_signature=source_signature,
+            guidance_run_id=source_run_id,
+            metrics=metrics,
+        )
+        patched_state = dict(refine_state)
+        patched_state["model"] = patched_model
+        return patched_state, metrics
+
+
+class H3ProgressiveHandoff:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "trajectory": ("H3_FLOW_TRAJECTORY",),
+                "target_mode": (["scale", "pixels"], {"default": "scale"}),
+                "scale": ("FLOAT", {"default": 1.2, "min": 1.01, "max": 4.0, "step": 0.01}),
+                "target_width": ("INT", {"default": 1024, "min": 32, "max": 8192, "step": 32}),
+                "target_height": ("INT", {"default": 768, "min": 32, "max": 8192, "step": 32}),
+                "handoff_coordinate": ("FLOAT", {"default": 0.35, "min": 0.01, "max": 0.99, "step": 0.01}),
+                "handoff_selection": (["fixed", "auto_compute"], {"default": "fixed"}),
+                "guidance_mode": (
+                    ["off", "direction", "direction+acceleration", "downsample_consistency"],
+                    {"default": "direction"},
+                ),
+                "direction_weight": ("FLOAT", {"default": 0.25, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "acceleration_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "consistency_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
+            },
+            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+        }
+
+    RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("model", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def patch(
+        self,
+        model,
+        trajectory,
+        target_mode,
+        scale,
+        target_width,
+        target_height,
+        handoff_coordinate,
+        handoff_selection,
+        guidance_mode,
+        direction_weight,
+        acceleration_weight,
+        consistency_weight,
+        low_frequency_cutoff,
+        metrics=None,
+    ):
+        if target_mode == "scale":
+            progressive = ProgressiveHandoffConfig(
+                target_scale=scale,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+            )
+        else:
+            target_h, target_w = pixel_to_safe_latent(target_height, target_width)
+            progressive = ProgressiveHandoffConfig(
+                target_latent_h=target_h,
+                target_latent_w=target_w,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+            )
+        guidance = GuidanceConfig(
+            mode=guidance_mode,
+            direction_weight=direction_weight,
+            acceleration_weight=acceleration_weight,
+            consistency_weight=consistency_weight,
+            cutoff=low_frequency_cutoff,
+        )
+        metrics = metrics or H3FlowMetrics()
+        patched, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=guidance,
+            progressive=progressive,
+            capture_enabled=True,
+            capture_forecasts=False,
+            clear_guidance_conditioning_signature=True,
+            clear_guidance_run_id=True,
+            metrics=metrics,
+        )
+        return patched, metrics
+
+
+class H3ProgressiveTargetInputHandoff:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "trajectory": ("H3_FLOW_TRAJECTORY",),
+                "source_mode": (["pixels", "scale"], {"default": "pixels"}),
+                "source_scale": ("FLOAT", {"default": 0.84, "min": 0.1, "max": 0.99, "step": 0.01}),
+                "source_width": ("INT", {"default": 864, "min": 32, "max": 8192, "step": 32}),
+                "source_height": ("INT", {"default": 640, "min": 32, "max": 8192, "step": 32}),
+                "handoff_coordinate": ("FLOAT", {"default": 0.35, "min": 0.01, "max": 0.99, "step": 0.01}),
+                "handoff_selection": (["fixed", "auto_compute"], {"default": "fixed"}),
+                "guidance_mode": (
+                    ["off", "direction", "direction+acceleration", "downsample_consistency"],
+                    {"default": "direction"},
+                ),
+                "direction_weight": ("FLOAT", {"default": 0.25, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "acceleration_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "consistency_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
+            },
+            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+        }
+
+    RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("model", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def patch(
+        self,
+        model,
+        trajectory,
+        source_mode,
+        source_scale,
+        source_width,
+        source_height,
+        handoff_coordinate,
+        handoff_selection,
+        guidance_mode,
+        direction_weight,
+        acceleration_weight,
+        consistency_weight,
+        low_frequency_cutoff,
+        metrics=None,
+    ):
+        if source_mode == "scale":
+            progressive = ProgressiveTargetInputConfig(
+                source_scale=source_scale,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+            )
+        else:
+            source_h, source_w = pixel_to_safe_latent(source_height, source_width)
+            progressive = ProgressiveTargetInputConfig(
+                source_latent_h=source_h,
+                source_latent_w=source_w,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+            )
+        guidance = GuidanceConfig(
+            mode=guidance_mode,
+            direction_weight=direction_weight,
+            acceleration_weight=acceleration_weight,
+            consistency_weight=consistency_weight,
+            cutoff=low_frequency_cutoff,
+        )
+        metrics = metrics or H3FlowMetrics()
+        patched, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=guidance,
+            progressive=progressive,
+            capture_enabled=True,
+            capture_forecasts=False,
+            clear_guidance_conditioning_signature=True,
+            clear_guidance_run_id=True,
+            metrics=metrics,
+        )
+        return patched, metrics
+
+
+class H3ResolutionAwareSigmas:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "sigmas": ("SIGMAS",),
+                "mode": (["off", "resolution_aware", "calibrated"], {"default": "off"}),
+                "source_width": ("INT", {"default": 864, "min": 32, "max": 8192}),
+                "source_height": ("INT", {"default": 640, "min": 32, "max": 8192}),
+                "target_width": ("INT", {"default": 1024, "min": 32, "max": 8192}),
+                "target_height": ("INT", {"default": 768, "min": 32, "max": 8192}),
+                "strength": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.01}),
+                "calibrated_factor": ("FLOAT", {"default": 1.0, "min": 0.01, "max": 8.0, "step": 0.01}),
+            }
+        }
+
+    RETURN_TYPES = ("SIGMAS", "H3_FLOW_DIAGNOSTICS")
+    RETURN_NAMES = ("sigmas", "diagnostics")
+    FUNCTION = "map"
+    CATEGORY = "MiniMax H3/flow regenerate/experimental"
+
+    def map(self, sigmas, mode, source_width, source_height, target_width, target_height, strength, calibrated_factor):
+        source_area = source_width * source_height
+        target_area = target_width * target_height
+        mapped = resolution_aware_sigmas(
+            sigmas,
+            source_area=source_area,
+            target_area=target_area,
+            mode=mode,
+            strength=strength,
+            calibrated_factor=calibrated_factor,
+        )
+        if mode == "off":
+            effective_factor = 1.0
+        elif mode == "calibrated":
+            effective_factor = float(calibrated_factor)
+        else:
+            effective_factor = resolution_shift_factor(source_area, target_area, strength)
+        return mapped, {
+            "mode": mode,
+            "source_area": source_area,
+            "target_area": target_area,
+            "extra_shift_factor": effective_factor,
+        }
+
+
+class H3ReferenceBudget:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "conditioning": ("CONDITIONING",),
+                "mode": (["native", "diagnostic", "decoupled_direct_experimental"], {"default": "native"}),
+                "max_direct_video_rows": ("INT", {"default": 2048, "min": 64, "max": 65536, "step": 64}),
+            }
+        }
+
+    RETURN_TYPES = ("CONDITIONING", "H3_REFERENCE_REPORT")
+    RETURN_NAMES = ("conditioning", "report")
+    FUNCTION = "apply"
+    CATEGORY = "MiniMax H3/flow regenerate/experimental"
+
+    def apply(self, conditioning, mode, max_direct_video_rows):
+        result, report = apply_reference_budget(
+            conditioning,
+            mode=mode,
+            max_direct_video_rows=max_direct_video_rows,
+        )
+        return result, asdict(report)
+
+
+class H3AttentionExperiment:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "mode": (["native", "diagnostic", "experimental_sparse"], {"default": "native"}),
+                "layers": ("STRING", {"default": "8,16,24,32,40"}),
+                "sparse_window": ("INT", {"default": 4, "min": 1, "max": 32}),
+                "global_heads": ("INT", {"default": 8, "min": 0, "max": 56}),
+                "max_sequence": ("INT", {"default": 8192, "min": 256, "max": 65536}),
+            },
+            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+        }
+
+    RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
+    RETURN_NAMES = ("model", "metrics")
+    FUNCTION = "patch"
+    CATEGORY = "MiniMax H3/flow regenerate/experimental"
+
+    def patch(self, model, mode, layers, sparse_window, global_heads, max_sequence, metrics=None):
+        try:
+            selected = tuple(sorted({int(value.strip()) for value in layers.split(",") if value.strip()}))
+        except ValueError as exc:
+            raise ValueError("layers must be a comma-separated list of non-negative integers") from exc
+        if not selected:
+            raise ValueError("layers must select at least one H3 transformer block")
+        config = AttentionConfig(
+            mode=mode,
+            layers=selected,
+            sparse_window=sparse_window,
+            global_heads=global_heads,
+            max_sequence=max_sequence,
+        )
+        metrics = metrics or H3FlowMetrics()
+        if mode == "native":
+            return model, metrics
+        patched, _ = patch_flow_model(model, attention=config, metrics=metrics)
+        return patched, metrics
+
+
+class H3MetricsJSON:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {"metrics": ("H3_FLOW_METRICS",)},
+            "optional": {
+                "filename_prefix": (
+                    "STRING",
+                    {"default": "h3_flow_regenerate/metrics"},
+                )
+            },
+        }
+
+    RETURN_TYPES = ("STRING",)
+    FUNCTION = "render"
+    OUTPUT_NODE = True
+    CATEGORY = "MiniMax H3/flow regenerate"
+
+    def render(self, metrics, filename_prefix="h3_flow_regenerate/metrics"):
+        import folder_paths
+
+        payload = metrics.to_json()
+        output_dir = folder_paths.get_output_directory()
+        full_output_folder, filename, counter, subfolder, _ = folder_paths.get_save_image_path(
+            filename_prefix,
+            output_dir,
+        )
+        file_name = f"{filename}_{counter:05}_.json"
+        metrics.write_json(Path(full_output_folder) / file_name)
+        relative_path = f"{subfolder}/{file_name}" if subfolder else file_name
+        return {
+            "ui": {"text": [f"Saved metrics JSON: {relative_path}"]},
+            "result": (payload,),
+        }
+
+
+NODE_CLASS_MAPPINGS = {
+    "H3FlowTrajectory": H3FlowTrajectoryNode,
+    "H3TrajectoryCapture": H3TrajectoryCapture,
+    "H3FlowAlignedRegenerate": H3FlowAlignedRegenerate,
+    "H3FlowAlignedRefineState": H3FlowAlignedRefineState,
+    "H3ProgressiveHandoff": H3ProgressiveHandoff,
+    "H3ProgressiveTargetInputHandoff": H3ProgressiveTargetInputHandoff,
+    "H3ResolutionAwareSigmas": H3ResolutionAwareSigmas,
+    "H3ReferenceBudget": H3ReferenceBudget,
+    "H3AttentionExperiment": H3AttentionExperiment,
+    "H3MetricsJSON": H3MetricsJSON,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "H3FlowTrajectory": "MiniMax H3 Flow Trajectory",
+    "H3TrajectoryCapture": "MiniMax H3 Trajectory Capture",
+    "H3FlowAlignedRegenerate": "MiniMax H3 Flow-Aligned Regenerate",
+    "H3FlowAlignedRefineState": "MiniMax H3 Flow-Aligned Refine State",
+    "H3ProgressiveHandoff": "MiniMax H3 Progressive Handoff",
+    "H3ProgressiveTargetInputHandoff": "MiniMax H3 Progressive Handoff (Target Input)",
+    "H3ResolutionAwareSigmas": "MiniMax H3 Resolution-Aware Sigmas [Experimental]",
+    "H3ReferenceBudget": "MiniMax H3 Reference Budget [Experimental]",
+    "H3AttentionExperiment": "MiniMax H3 Attention Lab [Experimental]",
+    "H3MetricsJSON": "MiniMax H3 Metrics JSON",
+}

--- a/h3_flow_regenerate/reference.py
+++ b/h3_flow_regenerate/reference.py
@@ -1,0 +1,104 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+
+from .geometry import resize_video, validate_video
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceBudgetReport:
+    qwen_rows: int
+    direct_video_rows_before: int
+    direct_video_rows_after: int
+    direct_audio_rows: int
+    changed_direct_refs: int
+    mode: str
+
+
+def _conditioning_rows(conditioning: list[Any]) -> int:
+    rows = 0
+    for entry in conditioning:
+        if isinstance(entry, (list, tuple)) and entry and torch.is_tensor(entry[0]):
+            rows += int(entry[0].shape[-2])
+    return rows
+
+
+def _fit_reference(video: torch.Tensor, max_rows: int, mode: str) -> torch.Tensor:
+    validate_video(video)
+    temporal = int(video.shape[2])
+    current_rows = temporal * (int(video.shape[-2]) // 2) * (int(video.shape[-1]) // 2)
+    if current_rows <= max_rows:
+        return video
+    if max_rows < temporal:
+        raise ValueError("direct-reference row budget is smaller than one spatial patch per frame")
+    scale = math.sqrt(max_rows / current_rows)
+    source_h, source_w = map(int, video.shape[-2:])
+    target_h = max(2, round(source_h * scale / 2) * 2)
+    target_w = max(2, round(source_w * scale / 2) * 2)
+    while temporal * (target_h // 2) * (target_w // 2) > max_rows and max(target_h, target_w) > 2:
+        if target_h >= target_w and target_h > 2:
+            target_h -= 2
+        elif target_w > 2:
+            target_w -= 2
+        else:
+            break
+    return resize_video(video, target_h, target_w, mode=mode)
+
+
+def apply_reference_budget(
+    conditioning: list[Any],
+    *,
+    mode: str = "native",
+    max_direct_video_rows: int = 2048,
+    resize_mode: str = "area",
+) -> tuple[list[Any], ReferenceBudgetReport]:
+    if mode not in {"native", "diagnostic", "decoupled_direct_experimental"}:
+        raise ValueError(f"unsupported reference budget mode {mode!r}")
+    if max_direct_video_rows < 1:
+        raise ValueError("max_direct_video_rows must be positive")
+    if mode == "decoupled_direct_experimental":
+        result = []
+        for entry in conditioning:
+            if not isinstance(entry, (list, tuple)) or len(entry) < 2 or not isinstance(entry[1], dict):
+                result.append(entry)
+                continue
+            metadata = dict(entry[1])
+            metadata["minimax_refs"] = [dict(ref) for ref in metadata.get("minimax_refs") or []]
+            result.append([entry[0], metadata, *entry[2:]])
+    else:
+        result = conditioning
+    before = after = audio = changed = 0
+    for entry in result:
+        if not isinstance(entry, (list, tuple)) or len(entry) < 2 or not isinstance(entry[1], dict):
+            continue
+        refs = entry[1].get("minimax_refs") or []
+        for ref in refs:
+            latent = ref.get("latent") if isinstance(ref, dict) else None
+            if torch.is_tensor(latent):
+                rows_before = int(latent.shape[2]) * (int(latent.shape[-2]) // 2) * (int(latent.shape[-1]) // 2)
+                before += rows_before
+                if mode == "decoupled_direct_experimental":
+                    fitted = _fit_reference(latent, max_direct_video_rows, resize_mode)
+                    ref["latent"] = fitted
+                    ref["latent_h"] = int(fitted.shape[-2])
+                    ref["latent_w"] = int(fitted.shape[-1])
+                    if "latent_t" in ref:
+                        ref["latent_t"] = int(fitted.shape[2])
+                    changed += int(fitted.shape != latent.shape)
+                    latent = fitted
+                after += int(latent.shape[2]) * (int(latent.shape[-2]) // 2) * (int(latent.shape[-1]) // 2)
+            audio_latent = ref.get("audio_latent") if isinstance(ref, dict) else None
+            if torch.is_tensor(audio_latent):
+                audio += int(audio_latent.shape[-1]) * 2
+    return result, ReferenceBudgetReport(
+        qwen_rows=_conditioning_rows(conditioning),
+        direct_video_rows_before=before,
+        direct_video_rows_after=after,
+        direct_audio_rows=audio,
+        changed_direct_refs=changed,
+        mode=mode,
+    )

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -1,0 +1,1058 @@
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import logging
+import math
+import struct
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+import torch
+
+from .contracts import H3FlowTrajectory, TrajectorySample
+from .geometry import geometry_from_video, pack_streams, resize_spatial_5d, unpack_streams
+from .guidance import GuidanceConfig, GuidanceState, apply_guidance
+from .handoff import (
+    ProgressiveHandoffConfig,
+    ProgressiveTargetInputConfig,
+    build_handoff_state,
+    deterministic_video_noise,
+    select_handoff_index,
+)
+from .metrics import H3FlowMetrics
+from .sigma import H3_AUDIO_SHIFT, H3_VIDEO_SHIFT, audio_sigma, normalized_coordinate
+
+LOG = logging.getLogger(__name__)
+
+FLOW_BINDING_KEY = "h3_flow_regenerate_binding"
+PROGRESSIVE_KEY = "h3_flow_progressive_v1"
+OUTER_WRAPPER_KEY = "h3_flow_regenerate.outer.v1"
+PREDICT_WRAPPER_KEY = "h3_flow_regenerate.predict.v1"
+CLONE_CALLBACK_KEY = "h3_flow_regenerate.clone.v1"
+PROBE_MARKER = "_h3_flow_exact_probe"
+PROBE_CONTEXT_KEY = "h3_flow_exact_probe_context"
+FLOW_STAGE_KEY = "h3_flow_stage"
+SPECTRUM_ACTUAL_KEY = "spectrum_h3_actual"
+SPECTRUM_PHASE_KEY = "spectrum_h3_solver_phase"
+SPECTRUM_OUTER_STEP_KEY = "spectrum_h3_outer_step_id"
+
+
+@dataclass(slots=True)
+class _ActiveCapture:
+    run_id: str
+    shapes: list[tuple[int, ...]]
+    phases: tuple[tuple[int, str], ...]
+    call_index: int = 0
+
+
+@dataclass(slots=True)
+class FlowBinding:
+    trajectory: H3FlowTrajectory | None = None
+    guidance: GuidanceConfig | None = None
+    metrics: H3FlowMetrics = field(default_factory=H3FlowMetrics)
+    capture_enabled: bool = False
+    capture_forecasts: bool = False
+    guidance_conditioning_signature: str | None = None
+    captured_run_id: str | None = None
+    guidance_run_id: str | None = None
+    guidance_state: GuidanceState = field(default_factory=GuidanceState)
+    active_capture: _ActiveCapture | None = None
+    active_guidance_run: Any = None
+
+
+def sampler_name(sampler: Any) -> str:
+    function = getattr(sampler, "sampler_function", None)
+    return str(getattr(function, "__name__", type(sampler).__name__))
+
+
+def _validate_progressive_sampler_state(sampler: Any) -> None:
+    options = getattr(sampler, "extra_options", {}) or {}
+    if not isinstance(options, dict):
+        raise TypeError("progressive handoff requires sampler extra_options to be a dictionary")
+    if options.get("noise_sampler") is not None:
+        raise ValueError(
+            "progressive handoff does not support an explicit sampler noise_sampler; "
+            "its mutable RNG/history cannot be proven reset across low/probe/high lifetimes"
+        )
+
+
+def _sampler_phases(sampler: Any, sigmas: torch.Tensor) -> tuple[tuple[int, str], ...]:
+    name = sampler_name(sampler)
+    outer_steps = max(0, int(sigmas.numel()) - 1)
+    sa_solvers = {
+        "sample_sa_solver",
+        "sample_sa_solver_pece",
+        "sample_refdelta_sa_solver",
+        "sample_refdelta_sa_solver_pece",
+    }
+    if name in sa_solvers:
+        options = getattr(sampler, "extra_options", {}) or {}
+        pece = name.endswith("_pece") or options.get("use_pece") is True
+        corrector_order = int(options.get("corrector_order", 4))
+        phases: list[tuple[int, str]] = []
+        for outer in range(outer_steps):
+            phases.append((outer, "predicted"))
+            if pece and corrector_order > 0 and outer > 0:
+                phases.append((outer, "corrected"))
+        return tuple(phases)
+    stages = {
+        "sample_seeds_2": 2,
+        "sample_refdelta_seeds_2": 2,
+        "sample_seeds_3": 3,
+        "sample_refdelta_seeds_3": 3,
+    }.get(name)
+    if stages:
+        phases = []
+        for outer in range(outer_steps):
+            count = 1 if float(sigmas[outer + 1]) == 0.0 else stages
+            phases.extend((outer, f"stage_{stage + 1}") for stage in range(count))
+        return tuple(phases)
+    return tuple((outer, "single") for outer in range(outer_steps))
+
+
+def _schedule_signature(sigmas: torch.Tensor) -> str:
+    values = b"".join(
+        struct.pack("!d", float(value)) for value in sigmas.detach().to(device="cpu", dtype=torch.float64)
+    )
+    return hashlib.sha256(values).hexdigest()[:16]
+
+
+def _interop_identity(model_options: dict[str, Any] | None) -> tuple[str, str]:
+    transformer = (model_options or {}).get("transformer_options") or {}
+    continuum = transformer.get("h3_continuum")
+    if isinstance(continuum, dict) and continuum.get("active") is True:
+        chunk = str(continuum.get("chunk_index", "unknown"))
+        session = str(continuum.get("session_id", "continuum"))
+        return session, chunk
+    return "standalone", "standalone"
+
+
+def _tensor_signature(tensor: torch.Tensor, *, max_values: int = 128) -> bytes:
+    """Return a bounded, device-independent content fingerprint.
+
+    Conditioning can contain multi-megabyte Qwen embeddings and reference
+    latents. Hashing every byte would introduce a full GPU readback. Sampling
+    deterministic positions catches ordinary prompt/reference changes while
+    keeping the identity check bounded; shape/dtype/layout are always included.
+    """
+    digest = hashlib.sha256()
+    digest.update(f"{tuple(tensor.shape)}|{tensor.dtype}|{tensor.layout}".encode())
+    if tensor.numel() == 0 or tensor.device.type == "meta" or tensor.layout != torch.strided:
+        return digest.digest()
+
+    count = min(int(max_values), int(tensor.numel()))
+    if count == 1:
+        linear = torch.zeros(1, dtype=torch.long, device=tensor.device)
+    else:
+        ordinal = torch.arange(count, dtype=torch.long, device=tensor.device)
+        linear = torch.div(
+            ordinal * (int(tensor.numel()) - 1),
+            count - 1,
+            rounding_mode="floor",
+        )
+    if tensor.ndim == 0:
+        sampled = tensor.detach().reshape(1)
+    else:
+        remainder = linear
+        reversed_coords: list[torch.Tensor] = []
+        for size in reversed(tensor.shape):
+            reversed_coords.append(remainder.remainder(int(size)))
+            remainder = torch.div(remainder, int(size), rounding_mode="floor")
+        sampled = tensor.detach()[tuple(reversed(reversed_coords))]
+    raw = sampled.contiguous().view(torch.uint8).to(device="cpu")
+    digest.update(bytes(raw.tolist()))
+    return digest.digest()
+
+
+def _update_conditioning_digest(digest, value: Any, *, depth: int = 0) -> None:
+    if depth > 8:
+        digest.update(f"<depth:{type(value).__module__}.{type(value).__qualname__}>".encode())
+        return
+    if torch.is_tensor(value):
+        digest.update(b"tensor:")
+        digest.update(_tensor_signature(value))
+        return
+    if isinstance(value, dict):
+        # ComfyUI's convert_cond creates a fresh UUID on each conversion. It is
+        # execution identity, not conditioning identity, so it must be excluded
+        # from both the keyed payload *and the structural field count*.
+        keys = [key for key in value if str(key) != "uuid"]
+        digest.update(f"dict:{len(keys)}:".encode())
+        for key in sorted(keys, key=lambda item: str(item)):
+            digest.update(f"key:{key!s}:".encode())
+            _update_conditioning_digest(digest, value[key], depth=depth + 1)
+        return
+    if isinstance(value, (list, tuple)):
+        digest.update(f"{type(value).__name__}:{len(value)}:".encode())
+        for item in value:
+            _update_conditioning_digest(digest, item, depth=depth + 1)
+        return
+    if value is None or isinstance(value, (bool, int, float, str, bytes)):
+        digest.update(f"{type(value).__name__}:{value!r}:".encode())
+        return
+    digest.update(f"type:{type(value).__module__}.{type(value).__qualname__}:".encode())
+
+
+def _conditioning_signature_from_original(original: dict[str, Any]) -> str:
+    digest = hashlib.sha256()
+    _update_conditioning_digest(digest, original)
+    return digest.hexdigest()[:32]
+
+
+def _convert_conditioning_for_signature(conditioning: list[Any]) -> list[dict[str, Any]]:
+    converted = []
+    for entry in conditioning:
+        if not isinstance(entry, (list, tuple)) or len(entry) < 2 or not isinstance(entry[1], dict):
+            raise TypeError("conditioning entries must contain tensor/context plus metadata dictionary")
+        metadata = entry[1].copy()
+        model_conds = metadata.get("model_conds", {})
+        if entry[0] is not None:
+            metadata["cross_attn"] = entry[0]
+        metadata["model_conds"] = model_conds
+        converted.append(metadata)
+    return converted
+
+
+def conditioning_signature_from_conditioning(
+    positive: list[Any],
+    negative: list[Any] | None = None,
+) -> str:
+    """Match CFGGuider.convert_cond without its execution-only UUID."""
+    original = {"positive": _convert_conditioning_for_signature(positive)}
+    if negative is not None:
+        original["negative"] = _convert_conditioning_for_signature(negative)
+    return _conditioning_signature_from_original(original)
+
+
+def _conditioning_signature(guider: Any) -> str:
+    original = getattr(guider, "original_conds", {}) or {}
+    if not isinstance(original, dict):
+        raise TypeError("guider original_conds must be a dictionary")
+    return _conditioning_signature_from_original(original)
+
+
+def _resolve_binding(guider: Any) -> FlowBinding | None:
+    value = (getattr(guider, "model_options", None) or {}).get(FLOW_BINDING_KEY)
+    return value if isinstance(value, FlowBinding) else None
+
+
+def flow_model_clone_callback(source_model: Any, cloned_model: Any) -> None:
+    source_options = getattr(source_model, "model_options", None) or {}
+    binding = source_options.get(FLOW_BINDING_KEY)
+    if not isinstance(binding, FlowBinding):
+        return
+    cloned_options = getattr(cloned_model, "model_options", None)
+    if not isinstance(cloned_options, dict):
+        cloned_model.model_options = {}
+        cloned_options = cloned_model.model_options
+    cloned_options[FLOW_BINDING_KEY] = FlowBinding(
+        trajectory=binding.trajectory,
+        guidance=binding.guidance,
+        metrics=binding.metrics,
+        capture_enabled=binding.capture_enabled,
+        capture_forecasts=binding.capture_forecasts,
+        guidance_conditioning_signature=binding.guidance_conditioning_signature,
+        captured_run_id=binding.captured_run_id,
+        guidance_run_id=binding.guidance_run_id,
+    )
+
+
+def _begin_capture(
+    binding: FlowBinding,
+    guider: Any,
+    sampler: Any,
+    sigmas: torch.Tensor,
+    latent_shapes: list[tuple[int, ...]],
+) -> None:
+    trajectory = binding.trajectory
+    if not binding.capture_enabled or trajectory is None or sampler_name(sampler) == PROBE_MARKER:
+        return
+    if len(latent_shapes) != 2:
+        raise ValueError("H3 trajectory capture requires exactly video and audio latent shapes")
+    video = torch.empty(latent_shapes[0], device="meta")
+    geometry = geometry_from_video(video)
+    session_id, chunk_id = _interop_identity(getattr(guider, "model_options", None))
+    binding.captured_run_id = None
+    run_id = trajectory.begin(
+        session_id=session_id,
+        chunk_id=chunk_id,
+        sampler=sampler_name(sampler),
+        scheduler=_schedule_signature(sigmas),
+        geometry=geometry,
+        audio_shape=tuple(latent_shapes[1]),
+        layout_signature=f"{latent_shapes[0]}|{latent_shapes[1]}",
+        conditioning_signature=_conditioning_signature(guider),
+    )
+    binding.active_capture = _ActiveCapture(
+        run_id=run_id,
+        shapes=list(latent_shapes),
+        phases=_sampler_phases(sampler, sigmas),
+    )
+    binding.metrics.event(
+        "trajectory_begin",
+        run_id=run_id,
+        sampler=sampler_name(sampler),
+        chunk_id=chunk_id,
+        geometry=tuple(latent_shapes[0]),
+        pixels=(geometry.pixel_h, geometry.pixel_w),
+        padded=(geometry.padded_h, geometry.padded_w),
+        spatial_padding=not geometry.patch_safe,
+        trajectory_bytes=binding.trajectory.bytes,
+    )
+
+
+def _finish_capture(binding: FlowBinding, *, error: BaseException | None = None):
+    active = binding.active_capture
+    if active is None or binding.trajectory is None:
+        return None
+    binding.active_capture = None
+    if error is None:
+        run = binding.trajectory.commit(active.run_id)
+        binding.captured_run_id = run.run_id
+        binding.metrics.event(
+            "trajectory_commit",
+            run_id=run.run_id,
+            samples=len(run.samples),
+            trajectory_bytes=binding.trajectory.bytes,
+        )
+        return run
+    run = binding.trajectory.abort(active.run_id, f"{type(error).__name__}: {error}")
+    binding.captured_run_id = None
+    binding.metrics.event("trajectory_abort", run_id=active.run_id, error=type(error).__name__)
+    return run
+
+
+def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
+    guider = executor.class_obj
+    binding = _resolve_binding(guider)
+    progressive = (getattr(guider, "model_options", None) or {}).get(PROGRESSIVE_KEY)
+    progressive_active = isinstance(progressive, (ProgressiveHandoffConfig, ProgressiveTargetInputConfig))
+    if (
+        binding is not None
+        and "multigpu_clones" in (model_options or {})
+        and (binding.active_capture is not None or binding.active_guidance_run is not None or progressive_active)
+    ):
+        raise RuntimeError(
+            "H3 flow trajectory capture/guidance/progressive handoff does not support parallel multi-GPU model calls"
+        )
+    started = time.perf_counter()
+    result = executor(x, timestep, model_options, seed)
+    if binding is None:
+        return result
+    transformer = (model_options or {}).get("transformer_options") or {}
+    probe_context = transformer.get(PROBE_CONTEXT_KEY)
+    stage = str(transformer.get(FLOW_STAGE_KEY, "single"))
+    actual_value = transformer.get(SPECTRUM_ACTUAL_KEY)
+    actual = True if actual_value is None else bool(actual_value)
+    if isinstance(probe_context, dict) and not actual:
+        raise RuntimeError("progressive handoff exact probe was forecast instead of evaluated")
+    binding.metrics.increment("transformer_actual_nfe" if actual else "spectrum_forecast_calls")
+    binding.metrics.increment(f"transformer_actual_nfe_{stage}" if actual else f"spectrum_forecast_calls_{stage}")
+    binding.metrics.increment("sampler_logical_calls")
+    binding.metrics.increment(f"sampler_logical_calls_{stage}")
+    sigma = float(timestep.detach().reshape(-1)[0].item())
+    video_shift = float(transformer.get("minimax_h3_sigma_shift_video", H3_VIDEO_SHIFT))
+    audio_shift = float(transformer.get("minimax_h3_sigma_shift_audio", H3_AUDIO_SHIFT))
+    coordinate = float(normalized_coordinate(sigma, video_shift=video_shift))
+    binding.metrics.event(
+        "model_call",
+        stage=stage,
+        sigma=sigma,
+        coordinate=coordinate,
+        actual=actual,
+        video_shift=video_shift,
+        audio_shift=audio_shift,
+        audio_sigma=float(audio_sigma(sigma, video_shift=video_shift, audio_shift=audio_shift)),
+        elapsed_ms=(time.perf_counter() - started) * 1000.0,
+    )
+
+    active = binding.active_capture
+    if active is not None:
+        if active.call_index < len(active.phases):
+            fallback_outer, fallback_phase = active.phases[active.call_index]
+        else:
+            fallback_outer, fallback_phase = active.call_index, "unclassified"
+        phase = str(transformer.get(SPECTRUM_PHASE_KEY, fallback_phase))
+        outer = int(transformer.get(SPECTRUM_OUTER_STEP_KEY, fallback_outer))
+        if isinstance(probe_context, dict):
+            phase = "handoff_probe"
+            outer = int(probe_context["outer_step"])
+        if actual or binding.capture_forecasts:
+            video_x0 = unpack_streams(result, active.shapes)[0]
+            binding.trajectory.append(
+                active.run_id,
+                TrajectorySample(
+                    coordinate=coordinate,
+                    video_sigma=sigma,
+                    audio_sigma=float(audio_sigma(sigma, video_shift=video_shift, audio_shift=audio_shift)),
+                    outer_step=outer,
+                    call_index=active.call_index,
+                    phase=phase,
+                    provenance="actual" if actual else "forecast",
+                    video_x0=video_x0,
+                ),
+            )
+        active.call_index += 1
+
+    if binding.guidance is not None and binding.guidance.mode != "off":
+        run = binding.active_guidance_run
+        if run is None:
+            return result
+        base_model = getattr(guider, "inner_model", None)
+        shapes = getattr(base_model, "latent_shapes", None)
+        if not isinstance(shapes, list) or len(shapes) != 2:
+            raise RuntimeError("flow guidance could not resolve H3 AV latent shapes")
+        video_x0, audio_x0 = unpack_streams(result, shapes)
+        guidance_started = time.perf_counter()
+        guided_video = apply_guidance(
+            video_x0,
+            run=run,
+            coordinate=coordinate,
+            config=binding.guidance,
+            state=binding.guidance_state,
+        )
+        guidance_elapsed_ms = (time.perf_counter() - guidance_started) * 1000.0
+        result, _ = pack_streams((guided_video, audio_x0))
+        binding.metrics.event(
+            "guidance",
+            coordinate=coordinate,
+            elapsed_ms=guidance_elapsed_ms,
+            mode=binding.guidance.mode,
+            schedule=binding.guidance_state.last_schedule,
+            correction_rms=binding.guidance_state.last_correction_rms,
+            baseline_rms=binding.guidance_state.last_baseline_rms,
+            correction_rms_ratio=binding.guidance_state.last_correction_rms_ratio,
+            clamp_scale=binding.guidance_state.last_clamp_scale,
+        )
+    return result
+
+
+def flow_outer_wrapper(
+    executor,
+    noise,
+    latent_image,
+    sampler,
+    sigmas,
+    denoise_mask=None,
+    callback=None,
+    disable_pbar=False,
+    seed=None,
+    latent_shapes=None,
+):
+    outer_started = time.perf_counter()
+    guider = executor.class_obj
+    binding = _resolve_binding(guider)
+    if binding is None:
+        return executor(
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+    if not isinstance(latent_shapes, list):
+        raise RuntimeError("H3 flow wrapper requires mutable packed latent shape metadata")
+    binding.guidance_state.reset()
+    binding.active_guidance_run = None
+    progressive = (getattr(guider, "model_options", None) or {}).get(PROGRESSIVE_KEY)
+    is_progressive = isinstance(progressive, (ProgressiveHandoffConfig, ProgressiveTargetInputConfig))
+    if not is_progressive and binding.guidance is not None and binding.guidance.mode != "off":
+        if binding.trajectory is None:
+            raise RuntimeError("flow guidance requires an H3_FLOW_TRAJECTORY")
+        if binding.guidance_run_id is not None:
+            run = binding.trajectory.select(run_id=binding.guidance_run_id)
+        else:
+            session_id, chunk_id = _interop_identity(getattr(guider, "model_options", None))
+            expected_signature = binding.guidance_conditioning_signature or _conditioning_signature(guider)
+            run = binding.trajectory.select(
+                chunk_id=chunk_id,
+                session_id=session_id,
+                conditioning_signature=expected_signature,
+            )
+        if run.geometry.latent_t != int(latent_shapes[0][2]):
+            raise ValueError("trajectory and target video temporal geometry differ")
+        binding.active_guidance_run = run
+    if not is_progressive:
+        _begin_capture(binding, guider, sampler, sigmas, latent_shapes)
+    error: BaseException | None = None
+    try:
+        if is_progressive:
+            return _run_progressive(
+                executor,
+                guider,
+                binding,
+                progressive,
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes,
+            )
+        return executor(
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+    except BaseException as exc:
+        error = exc
+        raise
+    finally:
+        if not is_progressive:
+            _finish_capture(binding, error=error)
+        binding.guidance_state.reset()
+        binding.active_guidance_run = None
+        binding.metrics.event(
+            "sampler_wall",
+            elapsed_ms=(time.perf_counter() - outer_started) * 1000.0,
+            progressive=is_progressive,
+            failed=error is not None,
+        )
+
+
+def _exact_probe_function(model, x, sigmas, extra_args=None, callback=None, disable=False, **_options):
+    if sigmas.numel() != 1 or not 0 < float(sigmas[0]) < 1:
+        raise ValueError("H3 exact handoff probe requires exactly one non-terminal sigma")
+    extra_args = {} if extra_args is None else extra_args
+    s_in = x.new_ones([x.shape[0]])
+    denoised = model(x, sigmas[0] * s_in, **extra_args)
+    if callback is not None:
+        callback({"x": x, "i": 0, "sigma": sigmas[0], "sigma_hat": sigmas[0], "denoised": denoised})
+    # Comfy's flow KSAMPLER applies inverse_noise_scaling at the terminal sigma.
+    return denoised * (1.0 - sigmas[0])
+
+
+_exact_probe_function.__name__ = PROBE_MARKER
+
+
+def _make_probe_sampler(source_sampler: Any):
+    import comfy.samplers
+
+    inpaint_options = dict(getattr(source_sampler, "inpaint_options", {}) or {})
+    return comfy.samplers.KSAMPLER(_exact_probe_function, inpaint_options=inpaint_options)
+
+
+def _raw_sampler_state(
+    base_model: Any,
+    returned: torch.Tensor,
+    shapes: list[tuple[int, ...]],
+    sigma: float,
+) -> torch.Tensor:
+    previous = getattr(base_model, "latent_shapes", None)
+    try:
+        base_model.latent_shapes = shapes
+        carried = base_model.process_latent_in(returned)
+    finally:
+        base_model.latent_shapes = previous
+    return carried * (1.0 - sigma)
+
+
+def _process_latent_in(base_model: Any, value: torch.Tensor, shapes: list[tuple[int, ...]]) -> torch.Tensor:
+    previous = getattr(base_model, "latent_shapes", None)
+    try:
+        base_model.latent_shapes = shapes
+        return base_model.process_latent_in(value)
+    finally:
+        base_model.latent_shapes = previous
+
+
+def _noise_argument(
+    base_model: Any,
+    state: torch.Tensor,
+    sigma: float,
+    latent_image: torch.Tensor | None = None,
+) -> torch.Tensor:
+    model_sampling = getattr(base_model, "model_sampling", None)
+    noise_scale = float(getattr(model_sampling, "noise_scale", 1.0))
+    if not math.isfinite(noise_scale) or noise_scale <= 0:
+        raise ValueError("H3 model noise_scale must be finite and positive")
+    if not math.isfinite(float(sigma)) or float(sigma) <= 0.0:
+        raise ValueError("H3 noise reconstruction requires a finite positive sigma")
+    numerator = state
+    if latent_image is not None:
+        if latent_image.shape != state.shape:
+            raise ValueError("H3 latent_image and sampler state shapes differ")
+        numerator = state - (1.0 - float(sigma)) * latent_image
+    return numerator / (float(sigma) * noise_scale)
+
+
+def _resize_packed_latent_image(
+    latent_image: torch.Tensor,
+    source_shapes: list[tuple[int, ...]],
+    target_shapes: list[tuple[int, ...]],
+) -> torch.Tensor:
+    video, audio = unpack_streams(latent_image, source_shapes)
+    target_h, target_w = target_shapes[0][-2:]
+    video = resize_spatial_5d(video, target_h, target_w, mode="bicubic")
+    return pack_streams((video, audio))[0]
+
+
+def _resize_packed_mask(
+    mask: torch.Tensor | None,
+    source_shapes: list[tuple[int, ...]],
+    target_shapes: list[tuple[int, ...]],
+) -> torch.Tensor | None:
+    """Resize ComfyUI's already-prepared packed AV denoise mask.
+
+    CFGGuider expands each user mask to the corresponding latent channel count
+    before OUTER_SAMPLE wrappers run, so this boundary sees the same packed shape
+    as the AV sampler state rather than the original single-channel mask.
+    """
+    if mask is None:
+        return None
+    if tuple(mask.shape) != (source_shapes[0][0], 1, sum(math.prod(shape[1:]) for shape in source_shapes)):
+        raise ValueError("prepared H3 denoise mask does not match source packed AV geometry")
+    video_mask, audio_mask = unpack_streams(mask, source_shapes)
+    target_h, target_w = target_shapes[0][-2:]
+    video_mask = resize_spatial_5d(video_mask, target_h, target_w, mode="nearest")
+    packed, packed_shapes = pack_streams((video_mask, audio_mask))
+    if packed_shapes != target_shapes:
+        raise RuntimeError("resized H3 denoise mask does not match target packed AV geometry")
+    return packed
+
+
+def _merge_preserved_noise(
+    generated_noise: torch.Tensor,
+    preserved_noise: torch.Tensor,
+    denoise_mask: torch.Tensor | None,
+) -> torch.Tensor:
+    """Keep native inpaint noise in protected regions.
+
+    MiniMax H3's scale_latent_inpaint uses the sampler's original noise for its
+    0.999 visual-conditioning injection. Replacing that noise in mask==0 regions
+    changes the protected context seen by the transformer even though ComfyUI
+    restores the clean latent after every denoised prediction.
+    """
+    if denoise_mask is None:
+        return generated_noise
+    if generated_noise.shape != preserved_noise.shape or generated_noise.shape != denoise_mask.shape:
+        raise ValueError("H3 handoff noise/mask shapes differ")
+    mask = denoise_mask.to(device=generated_noise.device, dtype=generated_noise.dtype)
+    return generated_noise * mask + preserved_noise.to(generated_noise) * (1.0 - mask)
+
+
+def _resize_target_keyframes(entry: dict[str, Any], target_h: int, target_w: int) -> dict[str, Any]:
+    out = entry.copy()
+    keyframes = entry.get("minimax_keyframes")
+    if keyframes is None:
+        return out
+    if not isinstance(keyframes, (list, tuple)):
+        raise TypeError("minimax_keyframes must be a list or tuple")
+    resized_keyframes = []
+    for block in keyframes:
+        if not isinstance(block, dict):
+            raise TypeError("MiniMax H3 keyframe entries must be dictionaries")
+        resized = block.copy()
+        latent = block.get("latent")
+        if latent is not None:
+            if not torch.is_tensor(latent) or latent.ndim not in (4, 5) or latent.shape[1] != 24:
+                raise ValueError("MiniMax H3 keyframe latent must be Bx24xHxW or Bx24xTxHxW")
+            if latent.ndim == 4:
+                latent = resize_spatial_5d(latent.unsqueeze(2), target_h, target_w, mode="bicubic").squeeze(2)
+            else:
+                latent = resize_spatial_5d(latent, target_h, target_w, mode="bicubic")
+            resized["latent"] = latent
+            if "latent_h" in resized:
+                resized["latent_h"] = int(target_h)
+            if "latent_w" in resized:
+                resized["latent_w"] = int(target_w)
+        resized_keyframes.append(resized)
+    out["minimax_keyframes"] = tuple(resized_keyframes) if isinstance(keyframes, tuple) else resized_keyframes
+    return out
+
+
+def _reset_guider_conds(
+    guider: Any,
+    *,
+    template: dict[str, list[Any]] | None = None,
+    target_video_hw: tuple[int, int] | None = None,
+) -> None:
+    """Recreate conditioning before each independent geometry/sampler lifetime.
+
+    ComfyUI resolves percentage areas, masks, and model conditions in-place on
+    guider.conds. Reusing the processed low-resolution structure for the
+    probe/high stage can therefore leak low-grid shape metadata across a
+    progressive handoff. The progressive caller supplies a pristine snapshot of
+    guider.conds taken *after* ComfyUI's hook preprocessing/filtering so those
+    call-boundary hook semantics are not lost when geometry is rebuilt.
+    """
+    source = template if template is not None else getattr(guider, "original_conds", None)
+    if not isinstance(source, dict):
+        return
+    target_h, target_w = target_video_hw if target_video_hw is not None else (None, None)
+    rebuilt = {}
+    for key, entries in source.items():
+        copied_entries = []
+        for entry in entries:
+            copied = entry.copy() if isinstance(entry, dict) else copy.copy(entry)
+            if target_video_hw is not None and isinstance(copied, dict):
+                copied = _resize_target_keyframes(copied, int(target_h), int(target_w))
+            copied_entries.append(copied)
+        rebuilt[key] = copied_entries
+    guider.conds = rebuilt
+
+
+@contextlib.contextmanager
+def _flow_stage_contract(guider: Any, stage: str):
+    options = getattr(guider, "model_options", None)
+    if not isinstance(options, dict):
+        raise RuntimeError("H3 flow stage tracking requires mutable model options")
+    transformer = options.setdefault("transformer_options", {})
+    if not isinstance(transformer, dict):
+        raise RuntimeError("H3 flow stage tracking requires mutable transformer options")
+    previous = transformer.get(FLOW_STAGE_KEY)
+    transformer[FLOW_STAGE_KEY] = str(stage)
+    try:
+        yield
+    finally:
+        if previous is None:
+            transformer.pop(FLOW_STAGE_KEY, None)
+        else:
+            transformer[FLOW_STAGE_KEY] = previous
+
+
+@contextlib.contextmanager
+def _high_stage_contract(guider: Any):
+    options = getattr(guider, "model_options", None)
+    if not isinstance(options, dict):
+        raise RuntimeError("progressive handoff requires mutable model options")
+    transformer = options.setdefault("transformer_options", {})
+    previous = transformer.get("h3_refinement")
+    request = {
+        "api": 1,
+        "active": True,
+        "min_actual_prefix_steps": 1,
+        "sigma_reference": 1.0,
+        "source": "h3_flow_progressive_handoff",
+    }
+    if previous is not None:
+        if not isinstance(previous, dict):
+            raise RuntimeError("existing h3_refinement contract is not a dictionary")
+        conflicts = {
+            key: (previous[key], value) for key, value in request.items() if key in previous and previous[key] != value
+        }
+        if conflicts:
+            raise RuntimeError(f"existing h3_refinement contract conflicts with progressive handoff: {conflicts}")
+        request = {**previous, **request}
+    transformer["h3_refinement"] = request
+    try:
+        yield
+    finally:
+        if previous is None:
+            transformer.pop("h3_refinement", None)
+        else:
+            transformer["h3_refinement"] = previous
+
+
+def _run_progressive(
+    executor,
+    guider,
+    binding: FlowBinding,
+    config: ProgressiveHandoffConfig | ProgressiveTargetInputConfig,
+    noise,
+    latent_image,
+    sampler,
+    sigmas,
+    denoise_mask,
+    callback,
+    disable_pbar,
+    seed,
+    latent_shapes,
+):
+    if len(latent_shapes) != 2:
+        raise ValueError("progressive handoff supports native packed H3 AV latents only")
+    _validate_progressive_sampler_state(sampler)
+    if sigmas.ndim != 1 or sigmas.numel() < 4:
+        raise ValueError("progressive handoff requires a full H3 sigma schedule")
+    if not math.isclose(float(sigmas[0]), 1.0, rel_tol=0.0, abs_tol=1e-6) or not math.isclose(
+        float(sigmas[-1]), 0.0, rel_tol=0.0, abs_tol=1e-8
+    ):
+        raise ValueError("progressive handoff requires a full 1-to-0 H3 sigma schedule")
+    input_shapes = list(latent_shapes)
+    if input_shapes[0][-2] % 2 or input_shapes[0][-1] % 2:
+        raise ValueError("input H3 geometry is not patch-safe")
+    model_options = getattr(guider, "model_options", None)
+    if not isinstance(model_options, dict):
+        raise RuntimeError("progressive handoff requires mutable model options")
+    transformer = model_options.setdefault("transformer_options", {})
+    if not isinstance(transformer, dict):
+        raise RuntimeError("progressive handoff requires mutable transformer options")
+    current_conds = getattr(guider, "conds", None)
+    if not isinstance(current_conds, dict):
+        raise RuntimeError("progressive handoff requires ComfyUI guider conditioning state")
+    conditioning_template = {
+        key: [entry.copy() if isinstance(entry, dict) else copy.copy(entry) for entry in entries]
+        for key, entries in current_conds.items()
+    }
+    video_shift = float(transformer.get("minimax_h3_sigma_shift_video", H3_VIDEO_SHIFT))
+
+    target_input = isinstance(config, ProgressiveTargetInputConfig)
+    if target_input:
+        target_shapes = input_shapes
+        target_h, target_w = target_shapes[0][-2:]
+        source_h, source_w = config.resolve_source(target_h, target_w)
+        source_shapes = list(target_shapes)
+        source_shapes[0] = (*source_shapes[0][:-2], source_h, source_w)
+        target_video_noise, target_audio_noise = unpack_streams(noise, target_shapes)
+        source_video_noise = deterministic_video_noise(
+            (*target_video_noise.shape[:-2], source_h, source_w),
+            seed=int(seed or 0) + config.source_noise_offset,
+            device=target_video_noise.device,
+            dtype=target_video_noise.dtype,
+        )
+        low_noise = pack_streams((source_video_noise, target_audio_noise))[0]
+        low_latent_image = _resize_packed_latent_image(latent_image, target_shapes, source_shapes)
+        low_mask = _resize_packed_mask(denoise_mask, target_shapes, source_shapes)
+    else:
+        source_shapes = input_shapes
+        source_h, source_w = source_shapes[0][-2:]
+        target_h, target_w = config.resolve_target(source_h, source_w)
+        if target_h * target_w <= source_h * source_w:
+            raise ValueError("progressive handoff target must increase the video latent area")
+        target_shapes = None
+        low_noise = noise
+        low_latent_image = latent_image
+        low_mask = denoise_mask
+    selected_coordinate = config.resolve_coordinate(
+        source_shapes[0][-2],
+        source_shapes[0][-1],
+        target_h,
+        target_w,
+    )
+    index = select_handoff_index(
+        sigmas,
+        selected_coordinate,
+        min_high_steps=config.min_high_steps,
+        video_shift=video_shift,
+    )
+    sigma = float(sigmas[index].item())
+    low_sigmas = sigmas[: index + 1]
+    high_sigmas = sigmas[index:]
+    binding.metrics.event(
+        "handoff_plan",
+        index=index,
+        sigma=sigma,
+        coordinate=float(normalized_coordinate(sigma, video_shift=video_shift)),
+        requested_coordinate=config.handoff_coordinate,
+        selected_coordinate=selected_coordinate,
+        selection=config.handoff_selection,
+        input_mode="target_grid" if target_input else "source_grid",
+        source_shape=source_shapes[0],
+        target_hw=(target_h, target_w),
+    )
+
+    sampler_invocation_count = 0
+    history_boundary_count = 0
+
+    def low_callback(step, x0, x, _total):
+        if callback is None:
+            return None
+        if target_input:
+            # CFGGuider's packed callback closure was created against the caller's
+            # target latent_shapes. Feed it target-shaped preview/state tensors even
+            # though this private sampler lifetime runs on source_shapes.
+            x0 = _resize_packed_latent_image(x0, source_shapes, target_shapes)
+            x = _resize_packed_latent_image(x, source_shapes, target_shapes)
+        return callback(step, x0, x, len(sigmas) - 1)
+
+    _begin_capture(binding, guider, sampler, low_sigmas, source_shapes)
+    try:
+        _reset_guider_conds(
+            guider,
+            template=conditioning_template,
+            target_video_hw=(source_h, source_w) if target_input else None,
+        )
+        low_started = time.perf_counter()
+        try:
+            sampler_invocation_count += 1
+            binding.metrics.increment("progressive_sampler_invocations")
+            with _flow_stage_contract(guider, "low"):
+                low_result = executor(
+                    low_noise,
+                    low_latent_image,
+                    sampler,
+                    low_sigmas,
+                    low_mask,
+                    low_callback,
+                    disable_pbar,
+                    seed,
+                    latent_shapes=source_shapes,
+                )
+        finally:
+            binding.metrics.event("low_stage_wall", elapsed_ms=(time.perf_counter() - low_started) * 1000.0)
+        base_model = guider.model_patcher.model
+        source_raw = _raw_sampler_state(base_model, low_result, source_shapes, sigma)
+        source_latent_internal = _process_latent_in(base_model, low_latent_image, source_shapes)
+        active = binding.active_capture
+        if active is not None:
+            active.phases = (*active.phases, (index, "handoff_probe"))
+        probe_started = time.perf_counter()
+        probe_noise = _noise_argument(base_model, source_raw, sigma, source_latent_internal)
+        previous_probe = transformer.get(PROBE_CONTEXT_KEY)
+        transformer[PROBE_CONTEXT_KEY] = {"outer_step": index}
+        try:
+            _reset_guider_conds(
+                guider,
+                template=conditioning_template,
+                target_video_hw=(source_h, source_w) if target_input else None,
+            )
+            # The probe is a one-call sampler lifetime, but model-level patches such
+            # as DiffAid must still see the full H3 sigma reference. The explicit
+            # refinement contract provides that reference without carrying solver or
+            # Spectrum history across the split.
+            sampler_invocation_count += 1
+            history_boundary_count += 1
+            binding.metrics.increment("progressive_sampler_invocations")
+            binding.metrics.increment("progressive_history_boundaries")
+            with _flow_stage_contract(guider, "probe"), _high_stage_contract(guider):
+                source_x0 = executor(
+                    probe_noise,
+                    low_latent_image,
+                    _make_probe_sampler(sampler),
+                    sigmas[index : index + 1],
+                    low_mask,
+                    None,
+                    disable_pbar,
+                    seed,
+                    latent_shapes=source_shapes,
+                )
+        finally:
+            if previous_probe is None:
+                transformer.pop(PROBE_CONTEXT_KEY, None)
+            else:
+                transformer[PROBE_CONTEXT_KEY] = previous_probe
+            binding.metrics.event("handoff_probe_wall", elapsed_ms=(time.perf_counter() - probe_started) * 1000.0)
+    except BaseException as exc:
+        _finish_capture(binding, error=exc)
+        raise
+    committed_low_run = _finish_capture(binding)
+    binding.metrics.increment("handoff_exact_probe_nfe")
+    try:
+        source_x0 = _process_latent_in(base_model, source_x0, source_shapes)
+        transfer_started = time.perf_counter()
+        target_raw, target_shapes = build_handoff_state(
+            source_packed_state=source_raw,
+            source_x0_packed=source_x0,
+            source_shapes=source_shapes,
+            sigma=sigma,
+            target_h=target_h,
+            target_w=target_w,
+            seed=int(seed or 0) + config.seed_offset,
+            transfer_mode=config.transfer_mode,
+        )
+        if target_input and target_shapes != input_shapes:
+            raise RuntimeError("target-input progressive handoff changed the caller-visible AV geometry")
+        if target_input:
+            target_latent_image = latent_image
+            target_mask = denoise_mask
+        else:
+            target_latent_image = _resize_packed_latent_image(latent_image, source_shapes, target_shapes)
+            target_mask = _resize_packed_mask(denoise_mask, source_shapes, target_shapes)
+            latent_shapes[:] = target_shapes
+        target_latent_internal = _process_latent_in(base_model, target_latent_image, target_shapes)
+        target_noise = _noise_argument(base_model, target_raw, sigma, target_latent_internal)
+        if target_input:
+            target_noise = _merge_preserved_noise(target_noise, noise, target_mask)
+        binding.metrics.event("handoff_transfer_wall", elapsed_ms=(time.perf_counter() - transfer_started) * 1000.0)
+
+        if binding.guidance is not None and binding.guidance.mode != "off":
+            if binding.trajectory is None:
+                raise RuntimeError("flow guidance requires an H3_FLOW_TRAJECTORY")
+            session_id, chunk_id = _interop_identity(getattr(guider, "model_options", None))
+            expected_signature = binding.guidance_conditioning_signature or _conditioning_signature(guider)
+            run = binding.trajectory.select(
+                chunk_id=chunk_id,
+                session_id=session_id,
+                conditioning_signature=expected_signature,
+            )
+            if run.geometry.latent_t != int(target_shapes[0][2]):
+                raise ValueError("trajectory and target video temporal geometry differ")
+            binding.active_guidance_run = run
+
+        def high_callback(step, x0, x, _total):
+            if callback is not None:
+                return callback(index + step, x0, x, len(sigmas) - 1)
+            return None
+
+        high_started = time.perf_counter()
+        high_event_start = len(binding.metrics.events)
+        _reset_guider_conds(
+            guider,
+            template=conditioning_template,
+            target_video_hw=None if target_input else (target_h, target_w),
+        )
+        sampler_invocation_count += 1
+        history_boundary_count += 1
+        binding.metrics.increment("progressive_sampler_invocations")
+        binding.metrics.increment("progressive_history_boundaries")
+        with _flow_stage_contract(guider, "high"), _high_stage_contract(guider):
+            result = executor(
+                target_noise,
+                target_latent_image,
+                sampler,
+                high_sigmas,
+                target_mask,
+                high_callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        binding.metrics.event("high_stage_wall", elapsed_ms=(time.perf_counter() - high_started) * 1000.0)
+        high_model_calls = [event for event in binding.metrics.events[high_event_start:] if event.kind == "model_call"]
+        if not high_model_calls:
+            raise RuntimeError("progressive high stage produced no H3 model evaluations")
+        first_high_actual = bool(high_model_calls[0].fields.get("actual"))
+        if not first_high_actual:
+            raise RuntimeError("progressive high stage did not begin with the required exact H3 model evaluation")
+        binding.metrics.event(
+            "handoff_complete",
+            sigma=sigma,
+            target_shape=target_shapes[0],
+            audio_state_copied=True,
+            separate_sampler_invocations=True,
+            sampler_invocation_count=sampler_invocation_count,
+            history_boundary_count=history_boundary_count,
+            exact_probe_performed=True,
+            high_stage_exact_prefix_requested=1,
+            high_stage_first_call_actual=first_high_actual,
+            high_stage_model_calls=len(high_model_calls),
+            conditioning_rebuilt_for_high_grid=True,
+            input_mode="target_grid" if target_input else "source_grid",
+        )
+        return result
+
+    except BaseException as exc:
+        if committed_low_run is not None and binding.trajectory is not None:
+            invalid = binding.trajectory.invalidate(
+                committed_low_run.run_id,
+                f"progressive continuation failed: {type(exc).__name__}: {exc}",
+            )
+            binding.metrics.event(
+                "trajectory_invalidate",
+                run_id=invalid.run_id,
+                error=type(exc).__name__,
+            )
+        raise
+
+
+def clone_sampler(sampler: Any) -> Any:
+    cloned = copy.copy(sampler)
+    if hasattr(sampler, "extra_options"):
+        cloned.extra_options = dict(getattr(sampler, "extra_options", {}) or {})
+    return cloned

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -35,6 +35,7 @@ CLONE_CALLBACK_KEY = "h3_flow_regenerate.clone.v1"
 PROBE_MARKER = "_h3_flow_exact_probe"
 PROBE_CONTEXT_KEY = "h3_flow_exact_probe_context"
 FLOW_STAGE_KEY = "h3_flow_stage"
+SPECTRUM_BINDING_KEY = "spectrum_h3_binding"
 SPECTRUM_ACTUAL_KEY = "spectrum_h3_actual"
 SPECTRUM_PHASE_KEY = "spectrum_h3_solver_phase"
 SPECTRUM_OUTER_STEP_KEY = "spectrum_h3_outer_step_id"
@@ -325,6 +326,14 @@ def _finish_capture(binding: FlowBinding, *, error: BaseException | None = None)
     return run
 
 
+def _active_spectrum_runtime(guider: Any) -> Any | None:
+    spectrum_binding = (getattr(guider, "model_options", None) or {}).get(SPECTRUM_BINDING_KEY)
+    runtime = getattr(spectrum_binding, "runtime", None)
+    if runtime is None or getattr(runtime, "active_run_id", None) is None:
+        return None
+    return runtime
+
+
 def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
     guider = executor.class_obj
     binding = _resolve_binding(guider)
@@ -338,6 +347,12 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
         raise RuntimeError(
             "H3 flow trajectory capture/guidance/progressive handoff does not support parallel multi-GPU model calls"
         )
+    spectrum_runtime = _active_spectrum_runtime(guider) if binding is not None else None
+    spectrum_completed_before = (
+        getattr(spectrum_runtime, "last_completed_step_id", None)
+        if spectrum_runtime is not None
+        else None
+    )
     started = time.perf_counter()
     result = executor(x, timestep, model_options, seed)
     if binding is None:
@@ -347,6 +362,24 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
     stage = str(transformer.get(FLOW_STAGE_KEY, "single"))
     actual_value = transformer.get(SPECTRUM_ACTUAL_KEY)
     actual = True if actual_value is None else bool(actual_value)
+    spectrum_completed_after = (
+        getattr(spectrum_runtime, "last_completed_step_id", None)
+        if spectrum_runtime is not None
+        else None
+    )
+    spectrum_completed_here = (
+        spectrum_runtime is not None
+        and spectrum_completed_after is not None
+        and spectrum_completed_after != spectrum_completed_before
+    )
+    if spectrum_completed_here:
+        completed_mode = getattr(spectrum_runtime, "last_completed_mode", None)
+        if completed_mode == "actual":
+            actual = True
+        elif completed_mode == "forecast":
+            actual = False
+        else:
+            raise RuntimeError(f"unreviewed completed Spectrum H3 mode {completed_mode!r}")
     if isinstance(probe_context, dict) and not actual:
         raise RuntimeError("progressive handoff exact probe was forecast instead of evaluated")
     binding.metrics.increment("transformer_actual_nfe" if actual else "spectrum_forecast_calls")
@@ -375,8 +408,12 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
             fallback_outer, fallback_phase = active.phases[active.call_index]
         else:
             fallback_outer, fallback_phase = active.call_index, "unclassified"
-        phase = str(transformer.get(SPECTRUM_PHASE_KEY, fallback_phase))
-        outer = int(transformer.get(SPECTRUM_OUTER_STEP_KEY, fallback_outer))
+        if spectrum_completed_here:
+            phase = fallback_phase
+            outer = fallback_outer
+        else:
+            phase = str(transformer.get(SPECTRUM_PHASE_KEY, fallback_phase))
+            outer = int(transformer.get(SPECTRUM_OUTER_STEP_KEY, fallback_outer))
         if isinstance(probe_context, dict):
             phase = "handoff_probe"
             outer = int(probe_context["outer_step"])

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -327,7 +327,9 @@ def _finish_capture(binding: FlowBinding, *, error: BaseException | None = None)
 
 
 def _active_spectrum_runtime(guider: Any) -> Any | None:
-    spectrum_binding = (getattr(guider, "model_options", None) or {}).get(SPECTRUM_BINDING_KEY)
+    spectrum_binding = (getattr(guider, "model_options", None) or {}).get(
+        SPECTRUM_BINDING_KEY
+    )
     runtime = getattr(spectrum_binding, "runtime", None)
     if runtime is None or getattr(runtime, "active_run_id", None) is None:
         return None

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -327,9 +327,7 @@ def _finish_capture(binding: FlowBinding, *, error: BaseException | None = None)
 
 
 def _active_spectrum_runtime(guider: Any) -> Any | None:
-    spectrum_binding = (getattr(guider, "model_options", None) or {}).get(
-        SPECTRUM_BINDING_KEY
-    )
+    spectrum_binding = (getattr(guider, "model_options", None) or {}).get(SPECTRUM_BINDING_KEY)
     runtime = getattr(spectrum_binding, "runtime", None)
     if runtime is None or getattr(runtime, "active_run_id", None) is None:
         return None
@@ -351,9 +349,7 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
         )
     spectrum_runtime = _active_spectrum_runtime(guider) if binding is not None else None
     spectrum_completed_before = (
-        getattr(spectrum_runtime, "last_completed_step_id", None)
-        if spectrum_runtime is not None
-        else None
+        getattr(spectrum_runtime, "last_completed_step_id", None) if spectrum_runtime is not None else None
     )
     started = time.perf_counter()
     result = executor(x, timestep, model_options, seed)
@@ -365,9 +361,7 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
     actual_value = transformer.get(SPECTRUM_ACTUAL_KEY)
     actual = True if actual_value is None else bool(actual_value)
     spectrum_completed_after = (
-        getattr(spectrum_runtime, "last_completed_step_id", None)
-        if spectrum_runtime is not None
-        else None
+        getattr(spectrum_runtime, "last_completed_step_id", None) if spectrum_runtime is not None else None
     )
     spectrum_completed_here = (
         spectrum_runtime is not None

--- a/h3_flow_regenerate/sigma.py
+++ b/h3_flow_regenerate/sigma.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import math
+
+import torch
+
+H3_VIDEO_SHIFT = 12.0
+H3_AUDIO_SHIFT = 3.0
+
+
+def _positive_shift(shift: float) -> float:
+    value = float(shift)
+    if not math.isfinite(value) or value <= 0:
+        raise ValueError("flow shift must be finite and positive")
+    return value
+
+
+def flow_shift(t: torch.Tensor | float, shift: float) -> torch.Tensor | float:
+    shift = _positive_shift(shift)
+    return shift * t / (1.0 + (shift - 1.0) * t)
+
+
+def inverse_flow_shift(sigma: torch.Tensor | float, shift: float) -> torch.Tensor | float:
+    shift = _positive_shift(shift)
+    return sigma / (shift + (1.0 - shift) * sigma)
+
+
+def remap_shift(sigma: torch.Tensor | float, from_shift: float, to_shift: float) -> torch.Tensor | float:
+    return flow_shift(inverse_flow_shift(sigma, from_shift), to_shift)
+
+
+def audio_sigma(
+    video_sigma: torch.Tensor | float,
+    *,
+    video_shift: float = H3_VIDEO_SHIFT,
+    audio_shift: float = H3_AUDIO_SHIFT,
+) -> torch.Tensor | float:
+    return remap_shift(video_sigma, video_shift, audio_shift)
+
+
+def normalized_coordinate(video_sigma: torch.Tensor | float, *, video_shift: float = H3_VIDEO_SHIFT):
+    """Return H3's unshifted full-trajectory coordinate in [0, 1]."""
+    return inverse_flow_shift(video_sigma, video_shift)
+
+
+def resolution_shift_factor(source_area: int, target_area: int, strength: float = 1.0) -> float:
+    if source_area <= 0 or target_area <= 0:
+        raise ValueError("source and target areas must be positive")
+    if not math.isfinite(float(strength)):
+        raise ValueError("resolution shift strength must be finite")
+    # SD3 Eq. 23 uses alpha=sqrt(m/n). Strength interpolates in log-space,
+    # preserving alpha=1 at strength=0 and composition at strength=1.
+    return math.exp(0.5 * float(strength) * math.log(target_area / source_area))
+
+
+def resolution_aware_sigmas(
+    sigmas: torch.Tensor,
+    *,
+    source_area: int,
+    target_area: int,
+    mode: str = "resolution_aware",
+    strength: float = 1.0,
+    calibrated_factor: float = 1.0,
+    video_shift: float = H3_VIDEO_SHIFT,
+) -> torch.Tensor:
+    if not isinstance(sigmas, torch.Tensor) or sigmas.ndim != 1 or sigmas.numel() < 2:
+        raise ValueError("sigmas must be a one-dimensional tensor with at least two entries")
+    if not bool(torch.isfinite(sigmas).all()) or bool((sigmas < 0).any()):
+        raise ValueError("sigmas must be finite and non-negative")
+    if bool((sigmas[1:] > sigmas[:-1]).any()):
+        raise ValueError("sigmas must be monotonically non-increasing")
+    if mode == "off":
+        return sigmas.clone()
+    if mode == "resolution_aware":
+        factor = resolution_shift_factor(source_area, target_area, strength)
+    elif mode == "calibrated":
+        factor = _positive_shift(calibrated_factor)
+    else:
+        raise ValueError(f"unsupported resolution shift mode {mode!r}")
+    base = inverse_flow_shift(sigmas, video_shift)
+    mapped = flow_shift(flow_shift(base, factor), video_shift).to(sigmas)
+    mapped[0] = sigmas.new_tensor(1.0) if float(sigmas[0]) == 1.0 else mapped[0]
+    mapped[-1] = sigmas.new_tensor(0.0) if float(sigmas[-1]) == 0.0 else mapped[-1]
+    if not bool(torch.isfinite(mapped).all()) or bool((mapped[1:] > mapped[:-1]).any()):
+        raise RuntimeError("resolution-aware mapping broke the sigma schedule invariant")
+    return mapped
+
+
+def interpolate_coordinate(a: float, b: float, target: float) -> float:
+    if not all(math.isfinite(v) for v in (a, b, target)):
+        raise ValueError("interpolation coordinates must be finite")
+    if a == b:
+        raise ValueError("cannot interpolate across a zero-width coordinate interval")
+    weight = (target - a) / (b - a)
+    return min(1.0, max(0.0, weight))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,39 @@
+[build-system]
+requires = ["hatchling>=1.27"]
+build-backend = "hatchling.build"
+
+[project]
+name = "comfyui-minimax-h3-flow-aligned-regenerate"
+version = "0.1.0.dev0"
+description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
+readme = "README.md"
+requires-python = ">=3.10"
+authors = [{ name = "xmarre" }]
+keywords = ["comfyui", "minimax-h3", "rectified-flow", "video", "audio"]
+dependencies = []
+
+[project.urls]
+Repository = "https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate"
+
+[tool.comfy]
+PublisherId = "xmarre"
+DisplayName = "MiniMax H3 Flow-Aligned Regenerate"
+Icon = ""
+includes = []
+
+[project.optional-dependencies]
+test = ["numpy>=1.25", "pytest>=8.3", "ruff>=0.11", "torch>=2.5"]
+
+[tool.hatch.build.targets.wheel]
+packages = ["h3_flow_regenerate"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+addopts = "-ra"
+
+[tool.ruff]
+target-version = "py310"
+line-length = 120
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B", "SIM", "RUF"]

--- a/tests/test_attention_reference_runtime.py
+++ b/tests/test_attention_reference_runtime.py
@@ -1,0 +1,1391 @@
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.attention import AttentionConfig, layout_summary, make_attention_override, video_local_mask
+from h3_flow_regenerate.comfy_compat import patch_flow_model, reconfigure_binding
+from h3_flow_regenerate.contracts import H3FlowTrajectory
+from h3_flow_regenerate.geometry import pack_streams, unpack_streams
+from h3_flow_regenerate.guidance import GuidanceConfig
+from h3_flow_regenerate.handoff import ProgressiveHandoffConfig, ProgressiveTargetInputConfig
+from h3_flow_regenerate.metrics import H3FlowMetrics
+from h3_flow_regenerate.nodes import H3FlowAlignedRefineState, H3FlowAlignedRegenerate
+from h3_flow_regenerate.reference import apply_reference_budget
+from h3_flow_regenerate.runtime import (
+    FLOW_BINDING_KEY,
+    FLOW_STAGE_KEY,
+    PROBE_CONTEXT_KEY,
+    PROGRESSIVE_KEY,
+    SPECTRUM_ACTUAL_KEY,
+    SPECTRUM_OUTER_STEP_KEY,
+    SPECTRUM_PHASE_KEY,
+    FlowBinding,
+    _begin_capture,
+    _conditioning_signature,
+    _finish_capture,
+    _high_stage_contract,
+    _make_probe_sampler,
+    _merge_preserved_noise,
+    _noise_argument,
+    _resize_packed_mask,
+    _run_progressive,
+    _sampler_phases,
+    _validate_progressive_sampler_state,
+    conditioning_signature_from_conditioning,
+    flow_model_clone_callback,
+    flow_predict_wrapper,
+)
+
+
+def layout():
+    # text=2, ref=2, audio=4, video=2*2*3=12
+    return SimpleNamespace(
+        segments=[(0, 2, "text"), (2, 4, "ref_img"), (4, 8, "audio"), (8, 20, "video")],
+        signature=(2, 2, 4, 6, 2),
+        seq_len=20,
+    )
+
+
+def test_sparse_mask_keeps_nonvideo_global_and_video_spatiotemporal_local():
+    mask = video_local_mask(layout(), torch.tensor([0, 8]), radius=1, device=torch.device("cpu"))
+    assert mask[0].all()
+    assert mask[1, :8].all()
+    # Same spatial location in both frames remains visible.
+    assert mask[1, 8]
+    assert mask[1, 14]
+    # Far spatial corner is hidden.
+    assert not mask[1, 13]
+
+
+def test_layout_summary_counts_packed_modalities():
+    summary = layout_summary(layout())
+    assert summary["text_rows"] == 2
+    assert summary["reference_rows"] == 2
+    assert summary["audio_rows"] == 4
+    assert summary["video_rows"] == 12
+    assert summary["sequence_rows"] == 20
+
+
+def test_layout_summary_accumulates_repeated_reference_segments():
+    repeated = SimpleNamespace(
+        segments=[
+            (0, 2, "text"),
+            (2, 5, "cond"),
+            (5, 7, "cond"),
+            (7, 11, "ref_img"),
+            (11, 14, "ref_img"),
+            (14, 16, "ref_audio"),
+            (16, 20, "audio"),
+            (20, 32, "video"),
+        ],
+        signature=(2, 1, 4, 6, 2),
+        seq_len=32,
+    )
+    summary = layout_summary(repeated)
+    assert summary["text_rows"] == 2
+    assert summary["reference_rows"] == 14
+    assert summary["audio_rows"] == 4
+    assert summary["video_rows"] == 12
+
+
+def test_sparse_attention_uses_query_key_additive_mask():
+    test_layout = layout()
+    q = torch.randn(1, 2, 20, 4)
+    k = torch.randn_like(q)
+    v = torch.randn_like(q)
+    observed = []
+
+    def backend(q, _k, _v, heads, mask=None, skip_reshape=False, **_kwargs):
+        assert skip_reshape
+        b, h, q_len, d = q.shape
+        if mask is not None:
+            assert mask.dtype == q.dtype
+            assert mask.ndim == 2
+            assert mask.shape == (q_len, 20)
+            assert bool((mask <= 0).all())
+            observed.append(mask.detach().clone())
+        return torch.zeros(b, q_len, h * d, dtype=q.dtype)
+
+    config = AttentionConfig(
+        mode="experimental_sparse",
+        layers=(0,),
+        global_heads=1,
+        sparse_window=1,
+        query_chunk=7,
+        max_sequence=64,
+    )
+    metrics = H3FlowMetrics()
+    override = make_attention_override(config, metrics)
+    result = override(
+        backend,
+        q,
+        k,
+        v,
+        2,
+        mask=None,
+        skip_reshape=True,
+        transformer_options={"h3_flow_attention_context": {"layout": test_layout, "layer": 0}},
+    )
+    assert result.shape == (1, 20, 8)
+    assert [mask.shape[0] for mask in observed] == [7, 7, 6]
+    first_video = observed[1][1]
+    assert first_video[:8].eq(0).all()
+    assert first_video[8].item() == 0
+    assert first_video[13].item() < 0
+
+
+def test_attention_config_is_guarded():
+    with pytest.raises(ValueError):
+        AttentionConfig(mode="experimental_sparse", layers=(-1,))
+
+
+def test_attention_diagnostic_preserves_existing_override():
+    metrics = H3FlowMetrics()
+    calls = []
+
+    def previous(backend, q, k, v, heads, mask=None, skip_reshape=False, **kwargs):
+        calls.append((mask, skip_reshape))
+        return backend(q, k, v, heads, mask=mask, skip_reshape=skip_reshape, **kwargs)
+
+    config = AttentionConfig(mode="diagnostic", layers=(0,))
+    override = make_attention_override(config, metrics, previous_override=previous)
+    q = torch.randn(1, 2, 20, 4)
+
+    def backend(q, _k, _v, heads, mask=None, skip_reshape=False, **_kwargs):
+        assert mask is None
+        assert skip_reshape
+        return q.transpose(1, 2).reshape(1, q.shape[2], heads * q.shape[-1])
+
+    result = override(
+        backend,
+        q,
+        q,
+        q,
+        2,
+        skip_reshape=True,
+        transformer_options={"h3_flow_attention_context": {"layout": layout(), "layer": 0}},
+    )
+    assert result.shape == (1, 20, 8)
+    assert calls == [(None, True)]
+    assert metrics.events[-1].kind == "attention_diagnostic"
+
+
+def test_sparse_backend_error_falls_back_to_full_attention():
+    metrics = H3FlowMetrics()
+    config = AttentionConfig(
+        mode="experimental_sparse",
+        layers=(0,),
+        global_heads=0,
+        query_chunk=4,
+    )
+    override = make_attention_override(config, metrics)
+    q = torch.randn(1, 2, 20, 4)
+    calls = []
+
+    def backend(q, _k, _v, heads, mask=None, **_kwargs):
+        calls.append(mask)
+        if mask is not None:
+            raise RuntimeError("mask unavailable")
+        return q.transpose(1, 2).reshape(1, q.shape[2], heads * q.shape[-1])
+
+    result = override(
+        backend,
+        q,
+        q,
+        q,
+        2,
+        skip_reshape=True,
+        transformer_options={"h3_flow_attention_context": {"layout": layout(), "layer": 0}},
+    )
+    assert result.shape == (1, 20, 8)
+    assert calls[-1] is None
+    assert metrics.events[-1].fields["reason"] == "backend_rejected_sparse_mask"
+
+
+def test_binding_reconfiguration_preserves_shared_metrics():
+    original = FlowBinding(trajectory=H3FlowTrajectory())
+    updated = reconfigure_binding(original, capture_forecasts=True)
+    assert updated.trajectory is original.trajectory
+    assert updated.metrics is original.metrics
+    assert updated.capture_forecasts
+
+
+class FakeH3Base:
+    def __init__(self):
+        self.diffusion_model = SimpleNamespace(
+            patch_size=(1, 2, 2),
+            latents_dim=24,
+            audio_latents_dim=32,
+            sigma_shift_video=12.0,
+            sigma_shift_audio=3.0,
+            blocks=[object() for _ in range(50)],
+        )
+        self.latent_shapes = None
+
+    def process_latent_in(self, value):
+        return value
+
+
+class MiniMaxH3:
+    def __init__(self):
+        self.diffusion_model = FakeH3Base().diffusion_model
+
+    def process_latent_in(self, value):
+        return value
+
+
+class FakePatcher:
+    def __init__(self):
+        self.model = MiniMaxH3()
+        self.model_options = {
+            "transformer_options": {
+                "wrappers": {
+                    "outer_sample": {"spectrum": [object()]},
+                    "predict_noise": {"spectrum": [object()]},
+                }
+            }
+        }
+        self.wrappers = self.model_options["transformer_options"]["wrappers"]
+        self.callbacks = {}
+
+    def clone(self):
+        cloned = FakePatcher()
+        cloned.model = self.model
+        cloned.model_options = {
+            **self.model_options,
+            "transformer_options": dict(self.model_options["transformer_options"]),
+        }
+        cloned.wrappers = {key: dict(value) for key, value in self.wrappers.items()}
+        cloned.model_options["transformer_options"]["wrappers"] = cloned.wrappers
+        cloned.callbacks = {
+            callback_type: {key: list(values) for key, values in keyed.items()}
+            for callback_type, keyed in self.callbacks.items()
+        }
+        for keyed in self.callbacks.values():
+            for callbacks in keyed.values():
+                for callback in callbacks:
+                    callback(self, cloned)
+        return cloned
+
+    def remove_wrappers_with_key(self, wrapper_type, key):
+        self.wrappers.get(wrapper_type, {}).pop(key, None)
+
+    def set_model_patch_replace(self, patch, name, block_name, number):
+        patches = self.model_options["transformer_options"].setdefault("patches_replace", {})
+        patches.setdefault(name, {})[(block_name, number)] = patch
+
+    def remove_callbacks_with_key(self, callback_type, key):
+        self.callbacks.get(callback_type, {}).pop(key, None)
+
+    def add_callback_with_key(self, callback_type, key, callback):
+        self.callbacks.setdefault(callback_type, {}).setdefault(key, []).append(callback)
+
+
+def test_model_patch_preserves_existing_wrapper_order_and_binding(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+    trajectory = H3FlowTrajectory()
+    patched, binding = patch_flow_model(FakePatcher(), trajectory=trajectory)
+    assert binding.trajectory is trajectory
+    assert next(iter(patched.wrappers["outer_sample"])) == "h3_flow_regenerate.outer.v1"
+    assert "spectrum" in patched.wrappers["outer_sample"]
+    assert next(iter(patched.wrappers["predict_noise"])) == "spectrum"
+    assert list(patched.wrappers["predict_noise"])[-1] == "h3_flow_regenerate.predict.v1"
+    assert ("double_block", 0) in patched.model_options["transformer_options"]["patches_replace"]["dit"]
+
+
+def test_repatch_replaces_prior_flow_attention_override_without_nesting(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    first, _ = patch_flow_model(
+        FakePatcher(),
+        attention=AttentionConfig(mode="diagnostic", layers=(0,)),
+    )
+    first_override = first.model_options["transformer_options"]["optimized_attention_override"]
+    assert first_override._h3_flow_attention_override
+
+    second, _ = patch_flow_model(
+        first,
+        attention=AttentionConfig(mode="diagnostic", layers=(0,)),
+    )
+    second_override = second.model_options["transformer_options"]["optimized_attention_override"]
+    assert second_override is not first_override
+    assert second_override._h3_flow_previous_override is None
+
+
+def test_repatch_preserves_existing_flow_attention_context_wrapper(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    attention_metrics = H3FlowMetrics()
+    attention_model, _ = patch_flow_model(
+        FakePatcher(),
+        attention=AttentionConfig(mode="diagnostic", layers=(0,)),
+        metrics=attention_metrics,
+    )
+    attention_wrapper = attention_model.model_options["transformer_options"]["patches_replace"]["dit"][
+        ("double_block", 0)
+    ]
+    assert attention_wrapper._h3_flow_layout_scope == "attention"
+
+    flow_metrics = H3FlowMetrics()
+    repatched, _ = patch_flow_model(attention_model, metrics=flow_metrics)
+    outer = repatched.model_options["transformer_options"]["patches_replace"]["dit"][("double_block", 0)]
+    assert outer._h3_flow_layout_scope == "layout"
+    assert outer._h3_flow_metrics is flow_metrics
+    assert outer._h3_flow_previous is attention_wrapper
+
+    replacement_metrics = H3FlowMetrics()
+    replaced, _ = patch_flow_model(
+        repatched,
+        attention=AttentionConfig(mode="diagnostic", layers=(0,)),
+        metrics=replacement_metrics,
+    )
+    replacement = replaced.model_options["transformer_options"]["patches_replace"]["dit"][("double_block", 0)]
+    assert replacement._h3_flow_layout_scope == "attention"
+    assert replacement._h3_flow_metrics is replacement_metrics
+    assert not getattr(replacement._h3_flow_previous, "_h3_flow_layout_wrapper", False)
+
+
+def test_repatch_keeps_single_flow_clone_callback(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    first, _ = patch_flow_model(FakePatcher())
+    second, _ = patch_flow_model(first)
+    callbacks = second.callbacks["on_clone"]["h3_flow_regenerate.clone.v1"]
+    assert callbacks == [flow_model_clone_callback]
+
+
+def test_model_clone_gets_fresh_flow_execution_state(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    trajectory = H3FlowTrajectory()
+    patched, binding = patch_flow_model(
+        FakePatcher(),
+        trajectory=trajectory,
+        guidance=GuidanceConfig(mode="direction"),
+        capture_enabled=True,
+        capture_forecasts=True,
+    )
+    binding.captured_run_id = "captured-run"
+    binding.guidance_run_id = "guidance-run"
+    binding.active_capture = object()
+    binding.active_guidance_run = object()
+    binding.guidance_state.start_coordinate = 0.5
+
+    cloned = patched.clone()
+    cloned_binding = cloned.model_options[FLOW_BINDING_KEY]
+    assert cloned_binding is not binding
+    assert cloned_binding.trajectory is trajectory
+    assert cloned_binding.guidance is binding.guidance
+    assert cloned_binding.metrics is binding.metrics
+    assert cloned_binding.capture_enabled
+    assert cloned_binding.capture_forecasts
+    assert cloned_binding.captured_run_id == "captured-run"
+    assert cloned_binding.guidance_run_id == "guidance-run"
+    assert cloned_binding.active_capture is None
+    assert cloned_binding.active_guidance_run is None
+    assert cloned_binding.guidance_state.start_coordinate is None
+
+
+def test_patch_can_explicitly_disable_inherited_capture(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    first, first_binding = patch_flow_model(FakePatcher(), capture_enabled=True)
+    assert first_binding.capture_enabled
+    _, second_binding = patch_flow_model(first, capture_enabled=False)
+    assert not second_binding.capture_enabled
+
+
+def test_patch_can_explicitly_clear_inherited_progressive_handoff(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    progressive = ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4)
+    first, _ = patch_flow_model(FakePatcher(), progressive=progressive)
+    assert first.model_options[PROGRESSIVE_KEY] is progressive
+
+    inherited, _ = patch_flow_model(first)
+    assert inherited.model_options[PROGRESSIVE_KEY] is progressive
+
+    cleared, _ = patch_flow_model(inherited, clear_progressive=True)
+    assert PROGRESSIVE_KEY not in cleared.model_options
+
+    with pytest.raises(ValueError, match="cannot set and clear"):
+        patch_flow_model(first, progressive=progressive, clear_progressive=True)
+
+
+def test_patch_can_explicitly_clear_inherited_guidance_signature(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    first, first_binding = patch_flow_model(FakePatcher(), guidance_conditioning_signature="source")
+    assert first_binding.guidance_conditioning_signature == "source"
+
+    inherited, inherited_binding = patch_flow_model(first)
+    assert inherited_binding.guidance_conditioning_signature == "source"
+
+    _, cleared = patch_flow_model(inherited, clear_guidance_conditioning_signature=True)
+    assert cleared.guidance_conditioning_signature is None
+
+    with pytest.raises(ValueError, match="cannot set and clear guidance conditioning signature"):
+        patch_flow_model(
+            first,
+            guidance_conditioning_signature="other",
+            clear_guidance_conditioning_signature=True,
+        )
+
+
+def test_patch_can_explicitly_disable_inherited_forecast_capture(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    first, first_binding = patch_flow_model(FakePatcher(), capture_forecasts=True)
+    assert first_binding.capture_forecasts
+    second, second_binding = patch_flow_model(first, capture_forecasts=False)
+    assert not second_binding.capture_forecasts
+    _, inherited = patch_flow_model(second)
+    assert not inherited.capture_forecasts
+
+
+def test_attention_layers_are_validated_against_loaded_block_count(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    model = FakePatcher()
+    model.model.diffusion_model.blocks.append(object())
+    patched, _ = patch_flow_model(
+        model,
+        attention=AttentionConfig(mode="diagnostic", layers=(50,)),
+    )
+    assert ("double_block", 50) in patched.model_options["transformer_options"]["patches_replace"]["dit"]
+
+
+def test_conditioning_signature_tracks_content_across_tensor_clones():
+    cross = torch.arange(24, dtype=torch.float32).reshape(1, 3, 8)
+    ref = torch.arange(1 * 24 * 1 * 4 * 4, dtype=torch.float32).reshape(1, 24, 1, 4, 4)
+
+    def guider(cross_tensor, ref_tensor):
+        return SimpleNamespace(
+            original_conds={
+                "positive": [
+                    {
+                        "cross_attn": cross_tensor,
+                        "minimax_refs": [{"kind": "video", "latent": ref_tensor}],
+                    }
+                ]
+            }
+        )
+
+    signature = _conditioning_signature(guider(cross, ref))
+    assert signature == _conditioning_signature(guider(cross.clone(), ref.clone()))
+    assert signature != _conditioning_signature(guider(cross + 1, ref))
+    assert signature != _conditioning_signature(guider(cross, ref + 1))
+
+
+def test_conditioning_signature_is_strict_for_keyframe_content_and_geometry():
+    cross = torch.arange(24, dtype=torch.float32).reshape(1, 3, 8)
+    low = torch.arange(1 * 24 * 1 * 4 * 4, dtype=torch.float32).reshape(1, 24, 1, 4, 4)
+    high = torch.nn.functional.interpolate(
+        low.reshape(24, 1, 4, 4),
+        size=(8, 8),
+        mode="bilinear",
+        align_corners=False,
+    ).reshape(1, 24, 1, 8, 8)
+
+    def guider(keyframe):
+        return SimpleNamespace(
+            original_conds={
+                "positive": [
+                    {
+                        "cross_attn": cross,
+                        "model_conds": {},
+                        "minimax_keyframes": [{"latent": keyframe}],
+                    }
+                ]
+            }
+        )
+
+    signature = _conditioning_signature(guider(low))
+    assert signature != _conditioning_signature(guider(high))
+    assert signature != _conditioning_signature(guider(low + 1))
+
+
+def test_raw_conditioning_signature_matches_cfg_guider_conversion():
+    cross = torch.arange(24, dtype=torch.float32).reshape(1, 3, 8)
+    keyframe = torch.randn(1, 24, 1, 4, 4)
+    raw = [[cross, {"minimax_keyframes": [{"latent": keyframe}], "tag": "chunk"}]]
+    converted = SimpleNamespace(
+        original_conds={
+            "positive": [
+                {
+                    "cross_attn": cross,
+                    "model_conds": {},
+                    "minimax_keyframes": [{"latent": keyframe}],
+                    "tag": "chunk",
+                    "uuid": "fresh-runtime-only-uuid",
+                }
+            ]
+        }
+    )
+    assert conditioning_signature_from_conditioning(raw) == _conditioning_signature(converted)
+
+
+def test_standalone_regenerate_can_bind_low_pass_source_conditioning(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    low_cross = torch.arange(24, dtype=torch.float32).reshape(1, 3, 8)
+    low_keyframe = torch.arange(1 * 24 * 1 * 4 * 4, dtype=torch.float32).reshape(1, 24, 1, 4, 4)
+    source_conditioning = [
+        [
+            low_cross,
+            {
+                "minimax_keyframes": [{"latent": low_keyframe}],
+            },
+        ]
+    ]
+    source_negative = [[torch.zeros_like(low_cross), {"tag": "negative"}]]
+    patched, _metrics = H3FlowAlignedRegenerate().patch(
+        FakePatcher(),
+        H3FlowTrajectory(),
+        "direction",
+        0.35,
+        0.0,
+        0.0,
+        0.25,
+        source_conditioning,
+        source_negative,
+    )
+    binding = patched.model_options[FLOW_BINDING_KEY]
+    assert binding.guidance_conditioning_signature == conditioning_signature_from_conditioning(
+        source_conditioning,
+        source_negative,
+    )
+    assert not binding.capture_enabled
+    assert not binding.capture_forecasts
+
+
+def test_standalone_source_negative_requires_source_conditioning():
+    with pytest.raises(ValueError, match="source_negative requires source_conditioning"):
+        H3FlowAlignedRegenerate().patch(
+            FakePatcher(),
+            H3FlowTrajectory(),
+            "direction",
+            0.35,
+            0.0,
+            0.0,
+            0.25,
+            None,
+            [[torch.zeros(1, 2, 4), {}]],
+        )
+
+
+def test_continuum_refine_state_patch_preserves_payload_and_disables_capture(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    trajectory = H3FlowTrajectory()
+    base_model, source_binding = patch_flow_model(FakePatcher(), trajectory=trajectory, capture_enabled=True)
+    source_binding.captured_run_id = "exact-continuum-run"
+    positive = [[torch.zeros(1, 2, 4), {"tag": "chunk"}]]
+    opaque = object()
+    state = {"api": 1, "model": base_model, "positive": positive, "opaque": opaque}
+
+    patched_state, metrics = H3FlowAlignedRefineState().patch(
+        state,
+        trajectory,
+        "direction",
+        0.35,
+        0.0,
+        0.0,
+        0.25,
+    )
+    binding = patched_state["model"].model_options[FLOW_BINDING_KEY]
+    assert patched_state is not state
+    assert patched_state["positive"] is positive
+    assert patched_state["opaque"] is opaque
+    assert binding.trajectory is trajectory
+    assert binding.guidance.mode == "direction"
+    assert not binding.capture_enabled
+    assert binding.guidance_conditioning_signature == conditioning_signature_from_conditioning(positive)
+    assert binding.guidance_run_id == "exact-continuum-run"
+    assert binding.metrics is metrics
+    layout_wrapper = patched_state["model"].model_options["transformer_options"]["patches_replace"]["dit"][
+        ("double_block", 0)
+    ]
+    assert layout_wrapper._h3_flow_metrics is metrics
+
+
+def test_continuum_refine_state_requires_exact_capture_provenance(monkeypatch):
+    fake_extension = ModuleType("comfy.patcher_extension")
+    fake_extension.WrappersMP = SimpleNamespace(OUTER_SAMPLE="outer_sample", PREDICT_NOISE="predict_noise")
+    fake_extension.CallbacksMP = SimpleNamespace(ON_CLONE="on_clone")
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.patcher_extension = fake_extension
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.patcher_extension", fake_extension)
+
+    trajectory = H3FlowTrajectory()
+    base_model, _ = patch_flow_model(FakePatcher(), trajectory=trajectory, capture_enabled=True)
+    state = {
+        "api": 1,
+        "model": base_model,
+        "positive": [[torch.zeros(1, 2, 4), {"tag": "chunk"}]],
+    }
+
+    with pytest.raises(RuntimeError, match="no captured trajectory provenance"):
+        H3FlowAlignedRefineState().patch(
+            state,
+            trajectory,
+            "direction",
+            0.35,
+            0.0,
+            0.0,
+            0.25,
+        )
+
+
+def test_active_flow_state_rejects_parallel_multigpu_model_calls():
+    video = torch.zeros(1, 24, 1, 4, 4)
+    audio = torch.zeros(1, 32, 2, 5)
+    packed, shapes = pack_streams((video, audio))
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(trajectory=trajectory, capture_enabled=True)
+    guider = SimpleNamespace(
+        model_options={FLOW_BINDING_KEY: binding, "transformer_options": {}},
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+
+    def native():
+        pass
+
+    native.__name__ = "sample_euler"
+    _begin_capture(
+        binding,
+        guider,
+        SimpleNamespace(sampler_function=native, extra_options={}),
+        torch.tensor([1.0, 0.5, 0.0]),
+        list(shapes),
+    )
+
+    executor_called = False
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            nonlocal executor_called
+            executor_called = True
+            return packed
+
+    with pytest.raises(RuntimeError, match="parallel multi-GPU"):
+        flow_predict_wrapper(
+            Executor(),
+            packed,
+            torch.tensor([0.5]),
+            {"multigpu_clones": {"cuda:1": object()}, "transformer_options": {}},
+            7,
+        )
+    assert not executor_called
+    _finish_capture(binding, error=RuntimeError("multigpu unsupported"))
+
+
+def test_progressive_flow_rejects_parallel_multigpu_even_without_active_capture():
+    video = torch.zeros(1, 24, 1, 4, 4)
+    audio = torch.zeros(1, 32, 2, 5)
+    packed, _ = pack_streams((video, audio))
+    binding = FlowBinding(trajectory=H3FlowTrajectory(), capture_enabled=True)
+    guider = SimpleNamespace(
+        model_options={
+            FLOW_BINDING_KEY: binding,
+            PROGRESSIVE_KEY: ProgressiveHandoffConfig(target_scale=1.2),
+            "transformer_options": {},
+        }
+    )
+    executor_called = False
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            nonlocal executor_called
+            executor_called = True
+            return packed
+
+    with pytest.raises(RuntimeError, match="parallel multi-GPU"):
+        flow_predict_wrapper(
+            Executor(),
+            packed,
+            torch.tensor([0.5]),
+            {"multigpu_clones": {"cuda:1": object()}, "transformer_options": {}},
+            7,
+        )
+    assert not executor_called
+
+
+def test_spectrum_forecasts_never_become_exact_trajectory_anchors():
+    video = torch.full((1, 24, 1, 4, 4), 2.0)
+    audio = torch.full((1, 32, 2, 5), 3.0)
+    packed, shapes = pack_streams((video, audio))
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(trajectory=trajectory, capture_enabled=True, capture_forecasts=False)
+    guider = SimpleNamespace(
+        model_options={FLOW_BINDING_KEY: binding, "transformer_options": {}},
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+
+    def native():
+        pass
+
+    native.__name__ = "sample_sa_solver_pece"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    _begin_capture(binding, guider, sampler, torch.tensor([1.0, 0.5, 0.0]), list(shapes))
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            return packed
+
+    forecast_options = {
+        "transformer_options": {
+            SPECTRUM_ACTUAL_KEY: False,
+            SPECTRUM_PHASE_KEY: "predicted",
+            SPECTRUM_OUTER_STEP_KEY: 0,
+        }
+    }
+    actual_options = {
+        "transformer_options": {
+            SPECTRUM_ACTUAL_KEY: True,
+            SPECTRUM_PHASE_KEY: "corrected",
+            SPECTRUM_OUTER_STEP_KEY: 1,
+        }
+    }
+    flow_predict_wrapper(Executor(), packed, torch.tensor([0.5]), forecast_options, 7)
+    flow_predict_wrapper(Executor(), packed, torch.tensor([0.4]), actual_options, 7)
+    _finish_capture(binding)
+
+    run = trajectory.latest
+    assert len(run.samples) == 1
+    assert run.samples[0].provenance == "actual"
+    assert run.samples[0].phase == "corrected"
+    assert run.samples[0].call_index == 1
+    assert binding.metrics.counters["spectrum_forecast_calls"] == 1
+    assert binding.metrics.counters["transformer_actual_nfe"] == 1
+
+
+def test_model_call_metrics_are_stage_scoped():
+    video = torch.full((1, 24, 1, 4, 4), 2.0)
+    audio = torch.full((1, 32, 2, 5), 3.0)
+    packed, _ = pack_streams((video, audio))
+    binding = FlowBinding()
+    guider = SimpleNamespace(model_options={FLOW_BINDING_KEY: binding})
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            return packed
+
+    options = {
+        "transformer_options": {
+            FLOW_STAGE_KEY: "high",
+            SPECTRUM_ACTUAL_KEY: True,
+        }
+    }
+    flow_predict_wrapper(Executor(), packed, torch.tensor([0.5]), options, 7)
+    assert binding.metrics.counters["transformer_actual_nfe"] == 1
+    assert binding.metrics.counters["transformer_actual_nfe_high"] == 1
+    assert binding.metrics.counters["sampler_logical_calls_high"] == 1
+    assert binding.metrics.events[-1].fields["stage"] == "high"
+
+
+def test_progressive_probe_rejects_explicit_spectrum_forecast():
+    video = torch.full((1, 24, 1, 4, 4), 2.0)
+    audio = torch.full((1, 32, 2, 5), 3.0)
+    packed, shapes = pack_streams((video, audio))
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(trajectory=trajectory, capture_enabled=True)
+    guider = SimpleNamespace(
+        model_options={FLOW_BINDING_KEY: binding, "transformer_options": {}},
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+
+    def native():
+        pass
+
+    native.__name__ = "sample_euler"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    _begin_capture(binding, guider, sampler, torch.tensor([1.0, 0.5, 0.0]), list(shapes))
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            return packed
+
+    options = {
+        "transformer_options": {
+            PROBE_CONTEXT_KEY: {"outer_step": 1},
+            SPECTRUM_ACTUAL_KEY: False,
+            SPECTRUM_PHASE_KEY: "predicted",
+            SPECTRUM_OUTER_STEP_KEY: 1,
+        }
+    }
+    with pytest.raises(RuntimeError, match="exact probe was forecast"):
+        flow_predict_wrapper(Executor(), packed, torch.tensor([0.5]), options, 7)
+    _finish_capture(binding, error=RuntimeError("probe forecast"))
+    assert not trajectory.runs[-1].complete
+    assert trajectory.runs[-1].samples == ()
+
+
+def test_noise_reconstruction_includes_preserved_latent_image():
+    base_model = SimpleNamespace(model_sampling=SimpleNamespace(noise_scale=2.0))
+    state = torch.randn(1, 1, 32)
+    latent = torch.randn_like(state)
+    sigma = 0.4
+    noise = _noise_argument(base_model, state, sigma, latent)
+    reconstructed = sigma * 2.0 * noise + (1.0 - sigma) * latent
+    assert torch.allclose(reconstructed, state, atol=1e-6, rtol=1e-6)
+
+
+def test_progressive_mask_resize_uses_prepared_full_channel_av_geometry():
+    source_shapes = [(1, 24, 1, 4, 4), (1, 32, 2, 5)]
+    target_shapes = [(1, 24, 1, 8, 6), (1, 32, 2, 5)]
+    video_mask = torch.arange(16, dtype=torch.float32).reshape(1, 1, 1, 4, 4).repeat(1, 24, 1, 1, 1)
+    audio_mask = torch.arange(10, dtype=torch.float32).reshape(1, 1, 2, 5).repeat(1, 32, 1, 1)
+    packed_mask, _ = pack_streams((video_mask, audio_mask))
+
+    resized = _resize_packed_mask(packed_mask, source_shapes, target_shapes)
+    out_video, out_audio = unpack_streams(resized, target_shapes)
+    assert out_video.shape == (1, 24, 1, 8, 6)
+    assert torch.equal(out_audio, audio_mask)
+
+
+def test_preserved_noise_merge_keeps_native_noise_only_under_mask():
+    generated = torch.full((1, 1, 8), 7.0)
+    native = torch.arange(8, dtype=torch.float32).reshape(1, 1, 8)
+    mask = torch.tensor([0.0, 0.0, 0.5, 1.0, 1.0, 0.25, 0.75, 0.0]).reshape(1, 1, 8)
+    merged = _merge_preserved_noise(generated, native, mask)
+    expected = generated * mask + native * (1.0 - mask)
+    assert torch.equal(merged, expected)
+    assert torch.equal(merged[..., :2], native[..., :2])
+    assert torch.equal(merged[..., 3:5], generated[..., 3:5])
+
+
+def test_exact_probe_preserves_sampler_inpaint_options(monkeypatch):
+    class KSampler:
+        def __init__(self, function, inpaint_options=None):
+            self.sampler_function = function
+            self.inpaint_options = dict(inpaint_options or {})
+
+    fake_samplers = ModuleType("comfy.samplers")
+    fake_samplers.KSAMPLER = KSampler
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.samplers = fake_samplers
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake_samplers)
+
+    source = SimpleNamespace(inpaint_options={"random": True, "custom": "keep"})
+    probe = _make_probe_sampler(source)
+    assert probe.inpaint_options == source.inpaint_options
+    assert probe.inpaint_options is not source.inpaint_options
+
+
+def test_progressive_runtime_uses_three_fresh_downstream_calls_and_preserves_audio(monkeypatch):
+    class KSampler:
+        def __init__(self, function, inpaint_options=None):
+            self.sampler_function = function
+            self.extra_options = {}
+            self.inpaint_options = dict(inpaint_options or {})
+
+    fake_samplers = ModuleType("comfy.samplers")
+    fake_samplers.KSAMPLER = KSampler
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.samplers = fake_samplers
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake_samplers)
+
+    source_video = torch.randn(1, 24, 1, 4, 4)
+    source_audio = torch.randn(1, 32, 2, 5)
+    source_raw, source_shapes = __import__("h3_flow_regenerate.geometry", fromlist=["pack_streams"]).pack_streams(
+        (source_video, source_audio)
+    )
+    source_x0 = source_raw.clone()
+    sigmas = torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_sa_solver_pece"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    original_cond = {
+        "cross_attn": torch.zeros(1, 2, 4),
+        "minimax_keyframes": [{"latent": source_video.clone(), "latent_h": 4, "latent_w": 4}],
+    }
+    runtime_cond = original_cond.copy()
+    runtime_cond["hooks"] = "filtered-runtime-hooks"
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=MiniMaxH3()),
+        original_conds={"positive": [original_cond]},
+        conds={"positive": [runtime_cond]},
+    )
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, call_sampler, call_sigmas, *args, latent_shapes):
+            calls.append(
+                (
+                    call_sampler.sampler_function.__name__,
+                    list(latent_shapes),
+                    dict(guider.model_options["transformer_options"]),
+                    call_sigmas.clone(),
+                    "stage_mutated" in guider.conds["positive"][0],
+                    tuple(guider.conds["positive"][0]["minimax_keyframes"][0]["latent"].shape[-2:]),
+                )
+            )
+            guider.conds["positive"][0]["stage_mutated"] = True
+            if call_sampler.sampler_function.__name__ == "_h3_flow_exact_probe":
+                return source_x0
+            if len(calls) == 1:
+                return source_raw / (1.0 - call_sigmas[-1])
+            if len(calls) == 3:
+                binding.metrics.event("model_call", actual=True)
+            return noise
+
+    binding = FlowBinding(trajectory=H3FlowTrajectory(), guidance=GuidanceConfig(mode="off"))
+    mutable_shapes = list(source_shapes)
+    result = _run_progressive(
+        Executor(),
+        guider,
+        binding,
+        ProgressiveHandoffConfig(8, 6, handoff_coordinate=0.3),
+        source_raw,
+        torch.zeros_like(source_raw),
+        sampler,
+        sigmas,
+        None,
+        None,
+        True,
+        7,
+        mutable_shapes,
+    )
+    assert [call[0] for call in calls] == ["sample_sa_solver_pece", "_h3_flow_exact_probe", "sample_sa_solver_pece"]
+    assert calls[1][2]["h3_refinement"]["sigma_reference"] == 1.0
+    assert calls[-1][2]["h3_refinement"]["min_actual_prefix_steps"] == 1
+    assert [call[4] for call in calls] == [False, False, False]
+    assert [call[5] for call in calls] == [(4, 4), (4, 4), (8, 6)]
+    assert mutable_shapes[0] == (1, 24, 1, 8, 6)
+    _, result_audio = __import__("h3_flow_regenerate.geometry", fromlist=["unpack_streams"]).unpack_streams(
+        result * float(calls[-1][3][0]), mutable_shapes
+    )
+    assert torch.allclose(result_audio, source_audio)
+
+
+def test_reference_native_parity_and_direct_only_decoupling():
+    cross = torch.randn(1, 9, 12)
+    ref = torch.randn(1, 24, 2, 16, 16)
+    conditioning = [
+        [
+            cross,
+            {
+                "minimax_refs": [
+                    {
+                        "kind": "video",
+                        "latent_t": 2,
+                        "latent_h": 16,
+                        "latent_w": 16,
+                        "latent": ref,
+                    }
+                ]
+            },
+        ]
+    ]
+    native, native_report = apply_reference_budget(conditioning, mode="native", max_direct_video_rows=16)
+    assert native is conditioning
+    assert native_report.qwen_rows == 9
+    changed, report = apply_reference_budget(
+        conditioning,
+        mode="decoupled_direct_experimental",
+        max_direct_video_rows=16,
+    )
+    assert changed is not conditioning
+    assert changed[0][0] is cross
+    changed_ref = changed[0][1]["minimax_refs"][0]
+    changed_shape = changed_ref["latent"].shape[-2:]
+    assert changed_shape[0] % 2 == changed_shape[1] % 2 == 0
+    assert changed_ref["latent_t"] == changed_ref["latent"].shape[2]
+    assert changed_ref["latent_h"] == changed_shape[0]
+    assert changed_ref["latent_w"] == changed_shape[1]
+    assert conditioning[0][1]["minimax_refs"][0]["latent"] is ref
+    assert conditioning[0][1]["minimax_refs"][0]["latent_h"] == 16
+    assert report.direct_video_rows_after <= 16
+
+
+def test_reference_budget_handles_thin_aspect_ratios():
+    thin = torch.randn(1, 24, 1, 2, 40)
+    conditioning = [[torch.randn(1, 3, 4), {"minimax_refs": [{"kind": "video", "latent": thin}]}]]
+    changed, report = apply_reference_budget(
+        conditioning,
+        mode="decoupled_direct_experimental",
+        max_direct_video_rows=5,
+    )
+    fitted = changed[0][1]["minimax_refs"][0]["latent"]
+    assert fitted.shape[-2] == 2
+    assert report.direct_video_rows_after <= 5
+
+
+def test_high_stage_contract_preserves_compatible_provider_metadata():
+    previous = {
+        "api": 1,
+        "active": True,
+        "min_actual_prefix_steps": 1,
+        "sigma_reference": 1.0,
+        "source": "h3_flow_progressive_handoff",
+        "provider_note": "keep-me",
+    }
+    guider = SimpleNamespace(model_options={"transformer_options": {"h3_refinement": previous}})
+    with _high_stage_contract(guider):
+        active = guider.model_options["transformer_options"]["h3_refinement"]
+        assert active["provider_note"] == "keep-me"
+        assert active is not previous
+    assert guider.model_options["transformer_options"]["h3_refinement"] is previous
+
+
+def test_high_stage_contract_rejects_conflicting_provider_contract():
+    previous = {
+        "api": 1,
+        "active": True,
+        "min_actual_prefix_steps": 2,
+        "sigma_reference": 1.0,
+    }
+    guider = SimpleNamespace(model_options={"transformer_options": {"h3_refinement": previous}})
+    with pytest.raises(RuntimeError, match="conflicts with progressive handoff"), _high_stage_contract(guider):
+        pass
+    assert guider.model_options["transformer_options"]["h3_refinement"] is previous
+
+
+def test_progressive_rejects_explicit_stateful_noise_sampler():
+    sampler = SimpleNamespace(
+        sampler_function=SimpleNamespace(__name__="sample_sa_solver"),
+        extra_options={"noise_sampler": object()},
+    )
+    with pytest.raises(ValueError, match="explicit sampler noise_sampler"):
+        _validate_progressive_sampler_state(sampler)
+
+
+def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
+    class KSampler:
+        def __init__(self, function, inpaint_options=None):
+            self.sampler_function = function
+            self.extra_options = {}
+            self.inpaint_options = dict(inpaint_options or {})
+
+    fake_samplers = ModuleType("comfy.samplers")
+    fake_samplers.KSAMPLER = KSampler
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.samplers = fake_samplers
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake_samplers)
+
+    target_video = torch.randn(1, 24, 1, 8, 6)
+    target_audio = torch.randn(1, 32, 2, 5)
+    target_latent, target_shapes = pack_streams((target_video, target_audio))
+    target_noise = torch.randn_like(target_latent)
+    video_mask = torch.ones(1, 24, 1, 8, 6)
+    video_mask[:, :, :, :2] = 0
+    audio_mask = torch.ones(1, 32, 2, 5)
+    packed_mask, _ = pack_streams((video_mask, audio_mask))
+    source_video = torch.randn(1, 24, 1, 4, 4)
+    source_audio = target_audio.clone()
+    source_raw, _source_shapes = pack_streams((source_video, source_audio))
+    source_x0 = source_raw.clone()
+    sigmas = torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_sa_solver_pece"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    original_cond = {
+        "cross_attn": torch.zeros(1, 2, 4),
+        "minimax_keyframes": [{"latent": target_video.clone(), "latent_h": 8, "latent_w": 6}],
+    }
+    runtime_cond = original_cond.copy()
+    runtime_cond["hooks"] = "filtered-runtime-hooks"
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=MiniMaxH3()),
+        original_conds={"positive": [original_cond]},
+        conds={"positive": [runtime_cond]},
+    )
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, call_sampler, call_sigmas, mask, *args, latent_shapes):
+            callback_arg = args[0] if args else None
+            mask_shapes = None
+            if mask is not None:
+                mask_shapes = tuple(
+                    tensor.shape
+                    for tensor in unpack_streams(
+                        mask,
+                        latent_shapes,
+                    )
+                )
+            calls.append(
+                {
+                    "name": call_sampler.sampler_function.__name__,
+                    "stage": guider.model_options["transformer_options"].get(FLOW_STAGE_KEY),
+                    "shapes": list(latent_shapes),
+                    "keyframe_hw": tuple(guider.conds["positive"][0]["minimax_keyframes"][0]["latent"].shape[-2:]),
+                    "hooks": guider.conds["positive"][0].get("hooks"),
+                    "mask_shapes": mask_shapes,
+                }
+            )
+            if callback_arg is not None:
+                callback_arg(0, noise, noise, len(call_sigmas) - 1)
+            if call_sampler.sampler_function.__name__ == "_h3_flow_exact_probe":
+                return source_x0
+            if len(calls) == 1:
+                return source_raw / (1.0 - call_sigmas[-1])
+            if len(calls) == 3:
+                binding.metrics.event("model_call", actual=True)
+            return noise
+
+    callback_shapes = []
+
+    def target_callback(_step, x0, x, _total):
+        callback_shapes.append(
+            (
+                tuple(unpack_streams(x0, target_shapes)[0].shape[-2:]),
+                tuple(unpack_streams(x, target_shapes)[0].shape[-2:]),
+            )
+        )
+
+    mutable_shapes = list(target_shapes)
+    binding = FlowBinding(trajectory=H3FlowTrajectory(), guidance=GuidanceConfig(mode="off"), capture_enabled=True)
+    result = _run_progressive(
+        Executor(),
+        guider,
+        binding,
+        ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4, handoff_coordinate=0.3),
+        target_noise,
+        target_latent,
+        sampler,
+        sigmas,
+        packed_mask,
+        target_callback,
+        True,
+        7,
+        mutable_shapes,
+    )
+
+    assert [call["name"] for call in calls] == [
+        "sample_sa_solver_pece",
+        "_h3_flow_exact_probe",
+        "sample_sa_solver_pece",
+    ]
+    assert [call["stage"] for call in calls] == ["low", "probe", "high"]
+    assert [call["shapes"][0][-2:] for call in calls] == [(4, 4), (4, 4), (8, 6)]
+    assert callback_shapes == [((8, 6), (8, 6)), ((8, 6), (8, 6))]
+    assert [call["keyframe_hw"] for call in calls] == [(4, 4), (4, 4), (8, 6)]
+    assert [call["hooks"] for call in calls] == ["filtered-runtime-hooks"] * 3
+    assert calls[0]["mask_shapes"] == (torch.Size([1, 24, 1, 4, 4]), torch.Size([1, 32, 2, 5]))
+    assert calls[2]["mask_shapes"] == (torch.Size([1, 24, 1, 8, 6]), torch.Size([1, 32, 2, 5]))
+    assert mutable_shapes == target_shapes
+    assert result.shape == target_latent.shape
+    assert binding.trajectory.latest.geometry.latent_h == 4
+    assert binding.trajectory.latest.geometry.latent_w == 4
+    handoff = [event for event in binding.metrics.events if event.kind == "handoff_complete"][-1]
+    assert handoff.fields["high_stage_first_call_actual"] is True
+    assert handoff.fields["high_stage_model_calls"] == 1
+    assert handoff.fields["sampler_invocation_count"] == 3
+    assert handoff.fields["history_boundary_count"] == 2
+
+    calls.clear()
+    callback_shapes.clear()
+    _run_progressive(
+        Executor(),
+        guider,
+        binding,
+        ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4, handoff_coordinate=0.3),
+        target_noise,
+        target_latent,
+        sampler,
+        sigmas,
+        packed_mask,
+        target_callback,
+        True,
+        7,
+        mutable_shapes,
+    )
+    second_handoff = [event for event in binding.metrics.events if event.kind == "handoff_complete"][-1]
+    assert second_handoff.fields["sampler_invocation_count"] == 3
+    assert second_handoff.fields["history_boundary_count"] == 2
+    assert binding.metrics.counters["progressive_sampler_invocations"] == 6
+    assert binding.metrics.counters["progressive_history_boundaries"] == 4
+
+
+def test_progressive_high_failure_invalidates_committed_low_trajectory(monkeypatch):
+    class KSampler:
+        def __init__(self, function, inpaint_options=None):
+            self.sampler_function = function
+            self.extra_options = {}
+            self.inpaint_options = dict(inpaint_options or {})
+
+    fake_samplers = ModuleType("comfy.samplers")
+    fake_samplers.KSAMPLER = KSampler
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.samplers = fake_samplers
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake_samplers)
+
+    video = torch.randn(1, 24, 1, 4, 4)
+    audio = torch.randn(1, 32, 2, 5)
+    packed, shapes = pack_streams((video, audio))
+    sigmas = torch.tensor([1.0, 0.8, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_euler"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=MiniMaxH3()),
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+        conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+    calls = 0
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, call_sampler, call_sigmas, *args, latent_shapes):
+            nonlocal calls
+            calls += 1
+            if call_sampler.sampler_function.__name__ == "_h3_flow_exact_probe":
+                return packed
+            if calls == 1:
+                return packed / (1.0 - call_sigmas[-1])
+            raise RuntimeError("synthetic high failure")
+
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(
+        trajectory=trajectory,
+        guidance=GuidanceConfig(mode="off"),
+        capture_enabled=True,
+    )
+    with pytest.raises(RuntimeError, match="synthetic high failure"):
+        _run_progressive(
+            Executor(),
+            guider,
+            binding,
+            ProgressiveHandoffConfig(8, 6, handoff_coordinate=0.3),
+            packed,
+            torch.zeros_like(packed),
+            sampler,
+            sigmas,
+            None,
+            None,
+            True,
+            7,
+            list(shapes),
+        )
+    assert len(trajectory.runs) == 1
+    assert not trajectory.runs[0].complete
+    assert "progressive continuation failed" in trajectory.runs[0].abort_reason
+    assert any(event.kind == "trajectory_invalidate" for event in binding.metrics.events)
+
+
+@pytest.mark.parametrize(
+    ("name", "calls", "phases"),
+    [
+        ("sample_sa_solver", 3, ["predicted"] * 3),
+        ("sample_sa_solver_pece", 5, ["predicted", "predicted", "corrected", "predicted", "corrected"]),
+        ("sample_seeds_3", 7, ["stage_1", "stage_2", "stage_3", "stage_1", "stage_2", "stage_3", "stage_1"]),
+    ],
+)
+def test_sampler_topology(name, calls, phases):
+    def function():
+        pass
+
+    function.__name__ = name
+    sampler = SimpleNamespace(sampler_function=function, extra_options={})
+    schedule = torch.tensor([1.0, 0.7, 0.3, 0.0])
+    result = _sampler_phases(sampler, schedule)
+    assert len(result) == calls
+    assert [phase for _, phase in result] == phases

--- a/tests/test_attention_reference_runtime.py
+++ b/tests/test_attention_reference_runtime.py
@@ -19,6 +19,7 @@ from h3_flow_regenerate.runtime import (
     PROBE_CONTEXT_KEY,
     PROGRESSIVE_KEY,
     SPECTRUM_ACTUAL_KEY,
+    SPECTRUM_BINDING_KEY,
     SPECTRUM_OUTER_STEP_KEY,
     SPECTRUM_PHASE_KEY,
     FlowBinding,
@@ -788,6 +789,60 @@ def test_progressive_flow_rejects_parallel_multigpu_even_without_active_capture(
             7,
         )
     assert not executor_called
+
+
+def test_outer_flow_wrapper_uses_completed_spectrum_mode_for_exact_provenance():
+    video = torch.full((1, 24, 1, 4, 4), 2.0)
+    audio = torch.full((1, 32, 2, 5), 3.0)
+    packed, shapes = pack_streams((video, audio))
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(trajectory=trajectory, capture_enabled=True, capture_forecasts=False)
+    spectrum_runtime = SimpleNamespace(
+        active_run_id=1,
+        last_completed_step_id=3,
+        last_completed_mode="forecast",
+    )
+    guider = SimpleNamespace(
+        model_options={
+            FLOW_BINDING_KEY: binding,
+            SPECTRUM_BINDING_KEY: SimpleNamespace(runtime=spectrum_runtime),
+            "transformer_options": {},
+        },
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+
+    def native():
+        pass
+
+    native.__name__ = "sample_sa_solver_pece"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    _begin_capture(binding, guider, sampler, torch.tensor([1.0, 0.5, 0.0]), list(shapes))
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, x, timestep, model_options=None, seed=None):
+            spectrum_runtime.last_completed_step_id = 4
+            spectrum_runtime.last_completed_mode = "actual"
+            return packed
+
+    stale_outer_options = {
+        "transformer_options": {
+            SPECTRUM_ACTUAL_KEY: False,
+            SPECTRUM_PHASE_KEY: "corrected",
+            SPECTRUM_OUTER_STEP_KEY: 99,
+        }
+    }
+    flow_predict_wrapper(Executor(), packed, torch.tensor([0.5]), stale_outer_options, 7)
+    _finish_capture(binding)
+
+    run = trajectory.latest
+    assert len(run.samples) == 1
+    assert run.samples[0].provenance == "actual"
+    assert run.samples[0].phase == "predicted"
+    assert run.samples[0].outer_step == 0
+    assert binding.metrics.counters["transformer_actual_nfe"] == 1
+    assert binding.metrics.counters.get("spectrum_forecast_calls", 0) == 0
 
 
 def test_spectrum_forecasts_never_become_exact_trajectory_anchors():

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,59 @@
+import pytest
+import torch
+
+from h3_flow_regenerate.geometry import (
+    geometry_from_video,
+    normalize_target_geometry,
+    pack_streams,
+    pixel_to_safe_latent,
+    resize_video,
+    unpack_streams,
+    validate_av,
+)
+
+
+def video(h=40, w=54, t=3):
+    return torch.randn(1, 24, t, h, w)
+
+
+def audio(t=20):
+    return torch.randn(1, 32, 2, t)
+
+
+def test_h3_geometry_and_pixel_scale():
+    geometry = geometry_from_video(video(40, 54))
+    assert (geometry.pixel_h, geometry.pixel_w) == (640, 864)
+    assert geometry.patch_safe
+    assert geometry.video_rows == 3 * 20 * 27
+
+
+def test_known_76_by_57_regression_normalizes_even():
+    assert normalize_target_geometry(source_h=64, source_w=48, scale=1.2) == (78, 58)
+    assert normalize_target_geometry(source_h=76, source_w=57, target_h=76, target_w=57) == (76, 58)
+
+
+def test_pixel_target_maps_to_safe_latent():
+    assert pixel_to_safe_latent(768, 1024) == (48, 64)
+
+
+@pytest.mark.parametrize("shape", [(40, 54), (18, 102), (128, 26)])
+def test_arbitrary_patch_safe_aspect_ratios(shape):
+    validate_av(video(*shape), audio())
+
+
+def test_odd_geometry_is_rejected_before_h3_padding():
+    with pytest.raises(ValueError, match="circular padding"):
+        validate_av(video(57, 76), audio())
+
+
+def test_pack_unpack_preserves_av_exactly():
+    streams = (video(), audio())
+    packed, shapes = pack_streams(streams)
+    restored = unpack_streams(packed, shapes)
+    assert all(torch.equal(a, b) for a, b in zip(streams, restored, strict=True))
+
+
+def test_resize_is_spatial_only():
+    source = video(40, 54, t=5)
+    resized = resize_video(source, 48, 64)
+    assert resized.shape == (1, 24, 5, 48, 64)

--- a/tests/test_guidance.py
+++ b/tests/test_guidance.py
@@ -1,0 +1,170 @@
+import pytest
+import torch
+
+from h3_flow_regenerate.contracts import TrajectoryRun, TrajectorySample
+from h3_flow_regenerate.geometry import geometry_from_video
+from h3_flow_regenerate.guidance import (
+    GuidanceConfig,
+    GuidanceState,
+    apply_guidance,
+    conditional_renoise_alignment,
+    low_frequency_projection,
+    time_matched_reference,
+)
+
+
+def run(values=(1.0, 0.0), coords=(0.8, 0.2), provenance=("actual", "actual")):
+    samples = tuple(
+        TrajectorySample(c, c, c, i, i, "corrected", p, torch.full((1, 24, 1, 4, 4), v))
+        for i, (v, c, p) in enumerate(zip(values, coords, provenance, strict=True))
+    )
+    return TrajectoryRun(
+        1,
+        "r",
+        "s",
+        "0",
+        "sa",
+        "sched",
+        geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        (1, 32, 2, 8),
+        "layout",
+        "cond",
+        "system_ram",
+        samples,
+        0,
+        1,
+        True,
+    )
+
+
+def test_guidance_config_rejects_nonfinite_correction_bound():
+    with pytest.raises(ValueError, match="finite and positive"):
+        GuidanceConfig(max_correction_rms_ratio=float("nan"))
+    with pytest.raises(ValueError, match="finite and positive"):
+        GuidanceConfig(max_correction_rms_ratio=float("inf"))
+
+
+def test_time_matching_interpolates_coordinate_not_step():
+    ref = time_matched_reference(run(), 0.5)
+    assert torch.allclose(ref, torch.full_like(ref, 0.5))
+
+
+def test_forecast_only_trajectory_is_not_trustworthy():
+    with pytest.raises(RuntimeError, match="exact anchors"):
+        time_matched_reference(run(provenance=("forecast", "forecast")), 0.5)
+
+
+def test_duplicate_pece_coordinate_prefers_corrected_anchor():
+    values = [torch.full((1, 24, 1, 4, 4), value) for value in (1.0, 2.0, 3.0, 4.0)]
+    samples = (
+        TrajectorySample(0.8, 0.8, 0.7, 0, 0, "predicted", "actual", values[0]),
+        TrajectorySample(0.5, 0.5, 0.4, 1, 1, "predicted", "actual", values[1]),
+        TrajectorySample(0.5, 0.5, 0.4, 1, 2, "corrected", "actual", values[2]),
+        TrajectorySample(0.2, 0.2, 0.1, 2, 3, "predicted", "actual", values[3]),
+    )
+    trajectory = TrajectoryRun(
+        1,
+        "r",
+        "s",
+        "0",
+        "sa",
+        "sched",
+        geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        (1, 32, 2, 8),
+        "layout",
+        "cond",
+        "system_ram",
+        samples,
+        0,
+        1,
+        True,
+    )
+    assert torch.equal(time_matched_reference(trajectory, 0.5), values[2])
+
+
+def test_zero_weight_is_exact_baseline_parity():
+    high = torch.randn(1, 24, 1, 8, 8)
+    config = GuidanceConfig(mode="direction", direction_weight=0.0)
+    assert torch.equal(apply_guidance(high, run=run(), coordinate=0.5, config=config, state=GuidanceState()), high)
+
+
+def test_direction_schedule_is_normalized_to_refine_start_coordinate():
+    high = torch.full((1, 24, 1, 4, 4), 0.2)
+    state = GuidanceState()
+    config = GuidanceConfig(
+        mode="direction",
+        direction_weight=1.0,
+        cutoff=1.0,
+        max_correction_rms_ratio=10.0,
+    )
+    trajectory = run(values=(1.0, 0.0), coords=(0.8, 0.2))
+
+    first = apply_guidance(high, run=trajectory, coordinate=0.5, config=config, state=state)
+    assert torch.allclose(first, torch.full_like(first, 0.5))
+
+    second = apply_guidance(high, run=trajectory, coordinate=0.25, config=config, state=state)
+    reference = torch.full_like(second, (0.25 - 0.2) / (0.8 - 0.2))
+    expected = high + 0.5 * (reference - high)
+    assert torch.allclose(second, expected)
+
+
+def test_guidance_state_records_bounded_correction_telemetry():
+    high = torch.full((1, 24, 1, 4, 4), 0.2)
+    state = GuidanceState()
+    config = GuidanceConfig(
+        mode="direction",
+        direction_weight=10.0,
+        cutoff=1.0,
+        max_correction_rms_ratio=0.25,
+    )
+    apply_guidance(high, run=run(values=(1.0, 0.0), coords=(0.8, 0.2)), coordinate=0.5, config=config, state=state)
+    assert state.last_schedule == pytest.approx(1.0)
+    assert state.last_correction_rms is not None
+    assert state.last_baseline_rms is not None
+    assert state.last_correction_rms_ratio == pytest.approx(0.25, rel=1e-5)
+    assert state.last_clamp_scale is not None
+    assert 0.0 < state.last_clamp_scale < 1.0
+
+
+def test_non_acceleration_guidance_does_not_retain_full_video_state():
+    high = torch.randn(1, 24, 1, 8, 8)
+    state = GuidanceState()
+    apply_guidance(
+        high,
+        run=run(),
+        coordinate=0.5,
+        config=GuidanceConfig(mode="direction"),
+        state=state,
+    )
+    assert state.previous_coordinate is None
+    assert state.previous_high_x0 is None
+    assert state.previous_reference is None
+
+
+def test_low_frequency_projection_does_not_change_constant():
+    constant = torch.ones(1, 24, 1, 8, 8)
+    assert torch.allclose(low_frequency_projection(constant, 0.25), constant)
+
+
+def test_acceleration_requires_state_and_stays_bounded():
+    high = torch.zeros(1, 24, 1, 8, 8)
+    state = GuidanceState()
+    config = GuidanceConfig(mode="direction+acceleration", acceleration_weight=0.2)
+    trajectory = run(values=(1.0, 0.5, 0.0), coords=(0.8, 0.5, 0.2), provenance=("actual",) * 3)
+    first = apply_guidance(high, run=trajectory, coordinate=0.7, config=config, state=state)
+    second = apply_guidance(first, run=trajectory, coordinate=0.4, config=config, state=state)
+    assert torch.isfinite(second).all()
+
+
+def test_acceleration_fails_closed_without_three_exact_anchors():
+    high = torch.zeros(1, 24, 1, 8, 8)
+    config = GuidanceConfig(mode="direction+acceleration", acceleration_weight=0.2)
+    with pytest.raises(RuntimeError, match="three exact"):
+        apply_guidance(high, run=run(), coordinate=0.5, config=config, state=GuidanceState())
+
+
+def test_conditional_renoise_is_rectified_flow_law():
+    x0 = torch.ones(1, 24, 1, 4, 4)
+    noise = torch.zeros(1, 24, 1, 8, 8)
+    state = conditional_renoise_alignment(x0, target_h=8, target_w=8, sigma=0.25, noise=noise)
+    assert torch.allclose(state, torch.full_like(state, 0.75))

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -1,0 +1,104 @@
+import pytest
+import torch
+
+from h3_flow_regenerate.geometry import pack_streams, unpack_streams
+from h3_flow_regenerate.handoff import (
+    ProgressiveHandoffConfig,
+    ProgressiveTargetInputConfig,
+    build_handoff_state,
+    deterministic_video_noise,
+    select_handoff_index,
+)
+from h3_flow_regenerate.sigma import flow_shift
+
+
+def packed(h=4, w=4):
+    video = torch.randn(1, 24, 2, h, w)
+    audio = torch.randn(1, 32, 2, 7)
+    state, shapes = pack_streams((video, audio))
+    x0, _ = pack_streams((torch.randn_like(video), torch.randn_like(audio)))
+    return state, x0, shapes, video, audio
+
+
+def test_same_resolution_handoff_is_identity():
+    state, x0, shapes, _, _ = packed()
+    target, target_shapes = build_handoff_state(
+        source_packed_state=state,
+        source_x0_packed=x0,
+        source_shapes=shapes,
+        sigma=0.4,
+        target_h=4,
+        target_w=4,
+        seed=12,
+    )
+    assert torch.equal(target, state)
+    assert target_shapes == shapes
+
+
+def test_handoff_geometry_audio_and_determinism():
+    state, x0, shapes, _, audio = packed()
+    args = dict(
+        source_packed_state=state,
+        source_x0_packed=x0,
+        source_shapes=shapes,
+        sigma=0.4,
+        target_h=8,
+        target_w=6,
+        seed=123,
+    )
+    first, target_shapes = build_handoff_state(**args)
+    second, _ = build_handoff_state(**args)
+    target_video, target_audio = unpack_streams(first, target_shapes)
+    assert target_video.shape == (1, 24, 2, 8, 6)
+    assert torch.equal(target_audio, audio)
+    assert torch.equal(first, second)
+
+
+def test_cpu_rng_contract_is_retry_stable_and_seed_sensitive():
+    shape = (1, 24, 1, 4, 4)
+    a = deterministic_video_noise(shape, seed=1, device=torch.device("cpu"), dtype=torch.float32)
+    b = deterministic_video_noise(shape, seed=1, device=torch.device("cpu"), dtype=torch.float32)
+    c = deterministic_video_noise(shape, seed=2, device=torch.device("cpu"), dtype=torch.float32)
+    assert torch.equal(a, b)
+    assert not torch.equal(a, c)
+
+
+def test_handoff_selection_uses_unshifted_coordinate_and_keeps_high_steps():
+    sigmas = flow_shift(torch.linspace(1, 0, 9), 12.0)
+    index = select_handoff_index(sigmas, 0.35, min_high_steps=2)
+    assert 1 <= index < len(sigmas) - 2
+
+
+def test_invalid_schedule_fails_closed():
+    with pytest.raises(ValueError, match="descending"):
+        select_handoff_index(torch.tensor([1.0, 0.8, 0.8, 0.0]), 0.3)
+
+
+def test_nonfinite_schedule_fails_closed():
+    with pytest.raises(ValueError, match="finite"):
+        select_handoff_index(torch.tensor([1.0, float("nan"), 0.3, 0.0]), 0.3)
+
+
+def test_auto_handoff_is_deterministic_bounded_and_uses_live_area():
+    config = ProgressiveHandoffConfig(target_scale=2.0, handoff_selection="auto_compute")
+    target = config.resolve_target(40, 54)
+    first = config.resolve_coordinate(40, 54, *target)
+    second = config.resolve_coordinate(40, 54, *target)
+    assert first == second == pytest.approx(0.2)
+
+
+def test_progressive_explicit_target_rejects_mixed_shrink_expand_geometry():
+    config = ProgressiveHandoffConfig(target_latent_h=32, target_latent_w=80)
+    with pytest.raises(ValueError, match="must not shrink either"):
+        config.resolve_target(40, 54)
+
+
+def test_target_input_source_rejects_mixed_expand_shrink_geometry():
+    config = ProgressiveTargetInputConfig(source_latent_h=56, source_latent_w=20)
+    with pytest.raises(ValueError, match="must not exceed either"):
+        config.resolve_source(48, 64)
+
+
+def test_default_scale_maps_motivating_grid_without_odd_padding():
+    config = ProgressiveHandoffConfig(target_scale=1.2)
+    assert config.resolve_target(40, 54) == (48, 64)

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,68 @@
+import importlib.util
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+
+def test_package_import_without_comfyui():
+    import h3_flow_regenerate
+
+    assert h3_flow_regenerate.H3FlowTrajectory.api_version == 1
+
+
+def test_custom_node_root_registration_smoke():
+    root = Path(__file__).parents[1] / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "h3_flow_custom_node",
+        root,
+        submodule_search_locations=[str(root.parent)],
+    )
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    assert "H3ProgressiveHandoff" in module.NODE_CLASS_MAPPINGS
+
+
+def test_progressive_nodes_expose_all_selectable_guidance_controls():
+    from h3_flow_regenerate.nodes import H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff
+
+    for node in (H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff):
+        required = node.INPUT_TYPES()["required"]
+        assert {
+            "guidance_mode",
+            "direction_weight",
+            "acceleration_weight",
+            "consistency_weight",
+            "low_frequency_cutoff",
+        }.issubset(required)
+
+
+def test_metrics_json_output_node_saves_unique_json(monkeypatch, tmp_path):
+    from h3_flow_regenerate.metrics import H3FlowMetrics
+    from h3_flow_regenerate.nodes import H3MetricsJSON
+
+    def get_save_image_path(filename_prefix, output_dir, image_width=0, image_height=0):
+        del image_width, image_height
+        subfolder = "bench"
+        folder = tmp_path / subfolder
+        folder.mkdir(parents=True, exist_ok=True)
+        return str(folder), "metrics", 1, subfolder, filename_prefix
+
+    monkeypatch.setitem(
+        sys.modules,
+        "folder_paths",
+        SimpleNamespace(
+            get_output_directory=lambda: str(tmp_path),
+            get_save_image_path=get_save_image_path,
+        ),
+    )
+
+    metrics = H3FlowMetrics()
+    metrics.event("guidance", correction_rms=0.125)
+    output = H3MetricsJSON().render(metrics, "bench/metrics")
+
+    saved = tmp_path / "bench" / "metrics_00001_.json"
+    assert saved.exists()
+    assert '"correction_rms": 0.125' in saved.read_text(encoding="utf-8")
+    assert output["result"] == (metrics.to_json(),)
+    assert output["ui"]["text"] == ["Saved metrics JSON: bench/metrics_00001_.json"]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -37,7 +37,7 @@ def test_progressive_nodes_expose_all_selectable_guidance_controls():
         }.issubset(required)
 
 
-def test_metrics_json_output_node_saves_unique_json(monkeypatch, tmp_path):
+def test_metrics_json_output_node_saves_unique_json_and_refreshes_after_sampler(monkeypatch, tmp_path):
     from h3_flow_regenerate.metrics import H3FlowMetrics
     from h3_flow_regenerate.nodes import H3MetricsJSON
 
@@ -58,11 +58,24 @@ def test_metrics_json_output_node_saves_unique_json(monkeypatch, tmp_path):
     )
 
     metrics = H3FlowMetrics()
-    metrics.event("guidance", correction_rms=0.125)
+    metrics.event("trajectory_commit", samples=8)
     output = H3MetricsJSON().render(metrics, "bench/metrics")
 
     saved = tmp_path / "bench" / "metrics_00001_.json"
     assert saved.exists()
-    assert '"correction_rms": 0.125' in saved.read_text(encoding="utf-8")
-    assert output["result"] == (metrics.to_json(),)
-    assert output["ui"]["text"] == ["Saved metrics JSON: bench/metrics_00001_.json"]
+    initial = saved.read_text(encoding="utf-8")
+    assert '"trajectory_commit"' in initial
+    assert '"guidance"' not in initial
+
+    metrics.increment("transformer_actual_nfe", 7)
+    metrics.event("guidance", correction_rms=0.125)
+    assert '"guidance"' not in saved.read_text(encoding="utf-8")
+
+    metrics.event("sampler_wall", elapsed_ms=123.0, failed=False, progressive=False)
+    final = saved.read_text(encoding="utf-8")
+    assert '"guidance"' in final
+    assert '"correction_rms": 0.125' in final
+    assert '"transformer_actual_nfe": 7' in final
+    assert '"sampler_wall"' in final
+    assert output["result"] != (metrics.to_json(),)
+    assert output["ui"]["text"] == ["Saving metrics JSON: bench/metrics_00001_.json"]

--- a/tests/test_sigma.py
+++ b/tests/test_sigma.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+from h3_flow_regenerate.sigma import (
+    audio_sigma,
+    flow_shift,
+    inverse_flow_shift,
+    normalized_coordinate,
+    remap_shift,
+    resolution_aware_sigmas,
+    resolution_shift_factor,
+)
+
+
+def test_shift_inverse_and_composition():
+    base = torch.linspace(0, 1, 101)
+    shifted = flow_shift(base, 12.0)
+    assert torch.allclose(inverse_flow_shift(shifted, 12.0), base, atol=1e-6)
+    assert torch.allclose(remap_shift(shifted, 12.0, 3.0), flow_shift(base, 3.0), atol=1e-6)
+
+
+def test_joint_av_mapping_preserves_common_base_coordinate():
+    video = torch.linspace(1, 0, 101)
+    audio = audio_sigma(video)
+    assert torch.allclose(inverse_flow_shift(video, 12.0), inverse_flow_shift(audio, 3.0), atol=1e-6)
+
+
+def test_resolution_node_reports_effective_shift_factor():
+    from h3_flow_regenerate.nodes import H3ResolutionAwareSigmas
+
+    sigmas = torch.tensor([1.0, 0.7, 0.0])
+    node = H3ResolutionAwareSigmas()
+    _, off = node.map(sigmas, "off", 864, 640, 1024, 768, 1.0, 2.5)
+    _, calibrated = node.map(sigmas, "calibrated", 864, 640, 1024, 768, 1.0, 2.5)
+    _, derived = node.map(sigmas, "resolution_aware", 864, 640, 1024, 768, 1.0, 2.5)
+
+    assert off["extra_shift_factor"] == 1.0
+    assert calibrated["extra_shift_factor"] == 2.5
+    assert derived["extra_shift_factor"] == pytest.approx(resolution_shift_factor(864 * 640, 1024 * 768))
+
+
+def test_resolution_mapping_is_ordered_finite_and_exact_at_endpoints():
+    sigmas = flow_shift(torch.linspace(1, 0, 21), 12.0)
+    mapped = resolution_aware_sigmas(sigmas, source_area=864 * 640, target_area=1024 * 768)
+    assert mapped[0] == 1
+    assert mapped[-1] == 0
+    assert torch.isfinite(mapped).all()
+    assert torch.all(mapped[1:] <= mapped[:-1])
+
+
+def test_resolution_factor_matches_sd3_area_derivation():
+    assert resolution_shift_factor(100, 400) == pytest.approx(2.0)
+    assert resolution_shift_factor(100, 400, strength=0.0) == pytest.approx(1.0)
+
+
+def test_off_is_exact_parity_and_does_not_alias():
+    sigmas = torch.tensor([1.0, 0.5, 0.0])
+    mapped = resolution_aware_sigmas(sigmas, source_area=1, target_area=4, mode="off")
+    assert torch.equal(mapped, sigmas)
+    assert mapped.data_ptr() != sigmas.data_ptr()
+
+
+def test_normalized_coordinate_is_full_unshifted_trajectory():
+    assert normalized_coordinate(0.0) == pytest.approx(0.0)
+    assert normalized_coordinate(1.0) == pytest.approx(1.0)
+
+
+@pytest.mark.parametrize("bad", [torch.tensor([0.0, 1.0]), torch.tensor([1.0, float("nan")])])
+def test_bad_schedule_fails_closed(bad):
+    with pytest.raises(ValueError):
+        resolution_aware_sigmas(bad, source_area=1, target_area=2)

--- a/tests/test_trajectory.py
+++ b/tests/test_trajectory.py
@@ -1,0 +1,214 @@
+from dataclasses import replace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.contracts import H3FlowTrajectory, TrajectorySample
+from h3_flow_regenerate.geometry import geometry_from_video
+from h3_flow_regenerate.nodes import H3FlowTrajectoryNode
+
+
+def sample(value=1.0, provenance="actual", phase="corrected"):
+    return TrajectorySample(
+        coordinate=0.5,
+        video_sigma=0.9,
+        audio_sigma=0.7,
+        outer_step=1,
+        call_index=1,
+        phase=phase,
+        provenance=provenance,
+        video_x0=torch.full((1, 24, 1, 4, 4), value),
+    )
+
+
+def begin(trajectory, session="s", chunk="0"):
+    return trajectory.begin(
+        session_id=session,
+        chunk_id=chunk,
+        sampler="sa_solver_pece",
+        scheduler="abc",
+        geometry=geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        audio_shape=(1, 32, 2, 8),
+        layout_signature="layout",
+        conditioning_signature="cond",
+    )
+
+
+def test_trajectory_node_forces_fresh_prompt_local_handle():
+    changed = H3FlowTrajectoryNode.IS_CHANGED("system_ram", 16)
+    assert changed != changed  # NaN is ComfyUI's always-changed cache fingerprint.
+    first = H3FlowTrajectoryNode().create("system_ram", 16)[0]
+    second = H3FlowTrajectoryNode().create("system_ram", 16)[0]
+    assert first is not second
+
+
+def test_commit_publishes_exact_provenance_and_copies_storage():
+    trajectory = H3FlowTrajectory(storage="system_ram")
+    run_id = begin(trajectory)
+    original = sample()
+    trajectory.append(run_id, original)
+    run = trajectory.commit(run_id)
+    original.video_x0.zero_()
+    assert run.complete
+    assert run.exact_samples()[0].provenance == "actual"
+    assert torch.all(run.samples[0].video_x0 == 1)
+
+
+def test_abort_preserves_diagnostics_but_never_becomes_guidance_state():
+    trajectory = H3FlowTrajectory()
+    run_id = begin(trajectory)
+    trajectory.append(run_id, sample())
+    aborted = trajectory.abort(run_id, "cancelled")
+    assert not aborted.complete
+    assert aborted.abort_reason == "cancelled"
+    assert len(trajectory.runs) == 1
+    with pytest.raises(RuntimeError, match="latest matching trajectory is incomplete"):
+        trajectory.select()
+
+    retry = begin(trajectory)
+    trajectory.append(retry, sample(2))
+    completed = trajectory.commit(retry)
+    assert completed.samples[0].video_x0.mean() == 2
+    assert trajectory.select().run_id == completed.run_id
+    assert trajectory.latest.run_id == completed.run_id
+
+
+def test_committed_run_can_be_invalidated_after_downstream_failure():
+    trajectory = H3FlowTrajectory(max_runs=2)
+    run_id = begin(trajectory)
+    trajectory.append(run_id, sample())
+    committed = trajectory.commit(run_id)
+    assert committed.complete
+    invalid = trajectory.invalidate(run_id, "high stage failed")
+    assert not invalid.complete
+    assert invalid.abort_reason == "high stage failed"
+    with pytest.raises(RuntimeError, match="latest trajectory run is incomplete"):
+        _ = trajectory.latest
+
+
+def test_newer_incomplete_run_blocks_stale_complete_fallback():
+    trajectory = H3FlowTrajectory()
+    old = begin(trajectory, "session", "chunk")
+    trajectory.append(old, sample(1))
+    trajectory.commit(old)
+
+    failed = begin(trajectory, "session", "chunk")
+    trajectory.append(failed, sample(2))
+    trajectory.abort(failed, "new attempt failed")
+
+    with pytest.raises(RuntimeError, match="latest matching trajectory is incomplete"):
+        trajectory.select(session_id="session", chunk_id="chunk")
+    with pytest.raises(RuntimeError, match="latest trajectory run is incomplete"):
+        _ = trajectory.latest
+
+
+def test_completed_forecast_only_run_is_not_selectable_for_guidance():
+    trajectory = H3FlowTrajectory()
+    run_id = trajectory.begin(
+        session_id="s",
+        chunk_id="0",
+        sampler="euler",
+        scheduler="schedule",
+        geometry=geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        audio_shape=(1, 32, 2, 8),
+        layout_signature="layout",
+        conditioning_signature="cond",
+    )
+    forecast = sample(1)
+    trajectory.append(run_id, replace(forecast, provenance="forecast"))
+    trajectory.commit(run_id)
+    assert trajectory.runs[-1].complete
+    with pytest.raises(RuntimeError, match="no exact anchors"):
+        trajectory.select(session_id="s", chunk_id="0", conditioning_signature="cond")
+
+
+def test_conditioning_signature_isolates_interleaved_chunk_runs():
+    trajectory = H3FlowTrajectory(max_runs=8)
+
+    first = trajectory.begin(
+        session_id="continuum",
+        chunk_id="0",
+        sampler="euler",
+        scheduler="schedule",
+        geometry=geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        audio_shape=(1, 32, 2, 8),
+        layout_signature="layout",
+        conditioning_signature="cond-a",
+    )
+    trajectory.append(first, sample(1))
+    trajectory.commit(first)
+
+    second = trajectory.begin(
+        session_id="continuum",
+        chunk_id="0",
+        sampler="euler",
+        scheduler="schedule",
+        geometry=geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        audio_shape=(1, 32, 2, 8),
+        layout_signature="layout",
+        conditioning_signature="cond-b",
+    )
+    trajectory.append(second, sample(2))
+    trajectory.commit(second)
+
+    assert (
+        trajectory.select(
+            session_id="continuum",
+            chunk_id="0",
+            conditioning_signature="cond-a",
+        )
+        .samples[0]
+        .video_x0.mean()
+        == 1
+    )
+    assert (
+        trajectory.select(
+            session_id="continuum",
+            chunk_id="0",
+            conditioning_signature="cond-b",
+        )
+        .samples[0]
+        .video_x0.mean()
+        == 2
+    )
+
+
+def test_exact_run_id_selection_bypasses_recomputed_conditioning_identity():
+    trajectory = H3FlowTrajectory(max_runs=8)
+
+    first = trajectory.begin(
+        session_id="continuum",
+        chunk_id="0",
+        sampler="euler",
+        scheduler="schedule",
+        geometry=geometry_from_video(torch.zeros(1, 24, 1, 4, 4)),
+        audio_shape=(1, 32, 2, 8),
+        layout_signature="layout",
+        conditioning_signature="capture-signature",
+    )
+    trajectory.append(first, sample(1))
+    committed = trajectory.commit(first)
+
+    assert trajectory.select(run_id=committed.run_id).run_id == committed.run_id
+    with pytest.raises(RuntimeError, match="requested run_id=missing"):
+        trajectory.select(run_id="missing")
+
+
+def test_chunk_and_session_isolation():
+    trajectory = H3FlowTrajectory()
+    for session, chunk, value in [("a", "0", 1), ("a", "1", 2), ("b", "0", 3)]:
+        run_id = begin(trajectory, session, chunk)
+        trajectory.append(run_id, sample(value))
+        trajectory.commit(run_id)
+    assert trajectory.select(session_id="a", chunk_id="0").samples[0].video_x0.mean() == 1
+    assert trajectory.select(session_id="b", chunk_id="0").samples[0].video_x0.mean() == 3
+
+
+def test_stale_transaction_and_nested_begin_rejected():
+    trajectory = H3FlowTrajectory()
+    run_id = begin(trajectory)
+    with pytest.raises(RuntimeError, match="active transaction"):
+        begin(trajectory)
+    with pytest.raises(RuntimeError, match="stale"):
+        trajectory.append("wrong", sample())
+    trajectory.abort(run_id, "test")

--- a/tools/check_source_contracts.py
+++ b/tools/check_source_contracts.py
@@ -1,0 +1,192 @@
+from __future__ import annotations
+
+import argparse
+import ast
+from pathlib import Path
+
+
+def require(path: Path, *needles: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise SystemExit(f"{path}: missing required contract fragments: {missing}")
+
+
+def require_symbols(path: Path, *, functions: tuple[str, ...] = (), classes: tuple[str, ...] = ()) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    found_functions = {
+        node.name for node in ast.walk(tree) if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+    }
+    found_classes = {node.name for node in ast.walk(tree) if isinstance(node, ast.ClassDef)}
+    missing_functions = sorted(set(functions) - found_functions)
+    missing_classes = sorted(set(classes) - found_classes)
+    if missing_functions or missing_classes:
+        raise SystemExit(f"{path}: missing structural symbols functions={missing_functions} classes={missing_classes}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate pinned H3 sibling-source contracts")
+    parser.add_argument("--comfy", type=Path, required=True)
+    parser.add_argument("--spectrum", type=Path, required=True)
+    parser.add_argument("--continuum", type=Path, required=True)
+    parser.add_argument("--diffaid", type=Path, required=True)
+    parser.add_argument("--refdelta", type=Path, required=True)
+    parser.add_argument("--untwist", type=Path, required=True)
+    parser.add_argument("--upscaler", type=Path, required=True)
+    args = parser.parse_args()
+
+    require(
+        args.comfy / "comfy/ldm/minimax/model.py",
+        "latents_dim=24",
+        "audio_latents_dim=32",
+        "patch_size=(1, 2, 2)",
+        "sigma_shift_video=12.0",
+        "sigma_shift_audio=3.0",
+        'segments = [("text", text_len)]',
+        'segments.append(("audio"',
+        'segments.append(("video"',
+        "time_shift_sigma(sigma_v, shift_v, shift_a)",
+        "mask=None, skip_reshape=True",
+    )
+    require(
+        args.comfy / "comfy/model_base.py",
+        "class MiniMaxH3(BaseModel):",
+        "return self.model_sampling.audio_scale",
+        'payload["audio_scale"] = self.audio_scale()',
+    )
+    require(
+        args.comfy / "comfy/model_sampling.py",
+        "class ModelSamplingAV(ModelSamplingDiscreteFlow):",
+        "return self.shift / self.audio_shift",
+        "return sigma * (s * noise) + (1.0 - sigma) * latent_image",
+        "return latent / (1.0 - sigma)",
+    )
+    require(
+        args.comfy / "comfy/samplers.py",
+        "latent_shapes=latent_shapes",
+        "unpack_latents(output, latent_shapes)",
+        "WrappersMP.OUTER_SAMPLE",
+        "WrappersMP.PREDICT_NOISE",
+        "#Returns denoised",
+        "inverse_noise_scaling(sigmas[-1], samples)",
+        "preprocess_conds_hooks(self.conds)",
+        "filter_registered_hooks_on_conds(self.conds, self.model_options)",
+        "self.conds = process_conds(",
+    )
+    require(
+        args.comfy / "comfy/sampler_helpers.py",
+        'temp["uuid"] = uuid.uuid4()',
+    )
+    require(
+        args.comfy / "execution.py",
+        'elif hasattr(class_def, "IS_CHANGED")',
+        'node["is_changed"] = float("NaN")',
+    )
+    require(
+        args.comfy / "comfy_execution/caching.py",
+        "signature = [class_type, await self.is_changed_cache.get(node_id)]",
+    )
+    require(
+        args.comfy / "comfy/model_patcher.py",
+        "def add_callback_with_key(",
+        "def remove_callbacks_with_key(",
+        "self.get_all_callbacks(CallbacksMP.ON_CLONE)",
+        "callback(self, n)",
+    )
+    require(
+        args.comfy / "comfy/sampler_helpers.py",
+        'merge_nested_dicts(model_options["transformer_options"].setdefault("wrappers", {}), model.wrappers',
+    )
+    require(
+        args.comfy / "comfy/patcher_extension.py",
+        "for w in wrappers.get(wrapper_type, {}).values():",
+        "return self.wrappers[self.idx](self, *args, **kwargs)",
+    )
+    require(
+        args.spectrum / "comfyui_spectrum_h3/refinement_compat.py",
+        'REFINEMENT_REQUEST_KEY = "h3_refinement"',
+        'request.get("min_actual_prefix_steps")',
+        'request.get("sigma_reference")',
+    )
+    require(
+        args.spectrum / "comfyui_spectrum_h3/sampling.py",
+        'ACTUAL_KEY = "spectrum_h3_actual"',
+        'SOLVER_PHASE_KEY = "spectrum_h3_solver_phase"',
+        'OUTER_STEP_ID_KEY = "spectrum_h3_outer_step_id"',
+        "def copy_model_options_with_step(",
+        'transformer_options[ACTUAL_KEY] = bool(decision["actual"])',
+        "return executor(x, timestep, patched, seed)",
+    )
+    require(
+        args.continuum / "model_patch.py",
+        '"api": CONTINUUM_INTEROP_API',
+        '"chunk_index": int(chunk_index)',
+        '"context_frames": int(context_frames)',
+    )
+    require_symbols(
+        args.continuum / "v3/driving_nodes.py",
+        functions=("_refine_state_output", "_fresh_refine_model"),
+        classes=("H3ContinuumSamplerV34",),
+    )
+    require(
+        args.continuum / "v3/driving_nodes.py",
+        '"H3_CONTINUUM_REFINE_STATE"',
+        '"emit_refine_conditioning"',
+        '"refine_state"',
+    )
+    require(
+        args.continuum / "v2/sampling.py",
+        "def _record_chunk_refine_state(",
+        '"model": model',
+        '"positive": conditioning',
+        '"noise_mask": noise_mask',
+    )
+    require(
+        args.continuum / "v3/driving_nodes.py",
+        "def _attach_refine_masks(",
+        'record.get("noise_mask")',
+        'video_item["noise_mask"]',
+        'audio_item["noise_mask"]',
+        '"model": _fresh_refine_model',
+        '"positive": positive',
+    )
+    require(
+        args.diffaid / "spectrum_h3_compat.py",
+        '"h3_refinement"',
+        '"sigma_reference"',
+    )
+    require(
+        args.untwist / "flux_untwist/spectrum_h3.py",
+        "VISUAL_PATCH_SCHEMA_VERSION = 1",
+        'VISUAL_PATCH_ARCHITECTURE = "minimax_h3"',
+        'VISUAL_PATCH_RUNTIME_KEY = "spectrum_h3_visual_reference_patch_runtime"',
+        '"schedule_progress"',
+        '"active"',
+    )
+    require_symbols(
+        args.upscaler / "nodes/minimax_h3_refine.py",
+        functions=(
+            "_resolve_refine_contract",
+            "_model_with_refinement_contract",
+            "build_clean_h3_upscale",
+            "run_h3_refinement",
+        ),
+        classes=("MinimaxH3LatentUpscaler3DRefine",),
+    )
+    require(
+        args.upscaler / "nodes/minimax_h3_refine.py",
+        '"H3_CONTINUUM_REFINE_STATE"',
+        "transformer_options[H3_REFINEMENT_REQUEST_KEY]",
+        "resize_h3_target_conditioning",
+        'noise_mask = latent.get("noise_mask")',
+        "denoise_mask=noise_mask",
+    )
+    refdelta_text = "\n".join(path.read_text(encoding="utf-8") for path in args.refdelta.rglob("*.py"))
+    for name in ("sa_solver", "sa_solver_pece", "seeds_2", "seeds_3", "er_sde"):
+        if name not in refdelta_text:
+            raise SystemExit(f"{args.refdelta}: missing sampler contract {name}")
+    print("Pinned ComfyUI/H3 sibling contracts validated")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_source_contracts.py
+++ b/tools/check_source_contracts.py
@@ -110,12 +110,20 @@ def main() -> None:
     )
     require(
         args.spectrum / "comfyui_spectrum_h3/sampling.py",
+        'BINDING_KEY = "spectrum_h3_binding"',
         'ACTUAL_KEY = "spectrum_h3_actual"',
         'SOLVER_PHASE_KEY = "spectrum_h3_solver_phase"',
         'OUTER_STEP_ID_KEY = "spectrum_h3_outer_step_id"',
+        "class SpectrumH3Binding:",
         "def copy_model_options_with_step(",
         'transformer_options[ACTUAL_KEY] = bool(decision["actual"])',
         "return executor(x, timestep, patched, seed)",
+    )
+    require(
+        args.spectrum / "comfyui_spectrum_h3/runtime.py",
+        "def last_completed_mode(",
+        "def last_completed_step_id(",
+        "def active_run_id(",
     )
     require(
         args.continuum / "model_patch.py",

--- a/workflows/benchmark-matrix.json
+++ b/workflows/benchmark-matrix.json
@@ -1,0 +1,206 @@
+{
+  "schema_version": 3,
+  "project": "MiniMax-H3-Flow-Aligned-Regenerate",
+  "media_gate": "decoded_video_and_audio",
+  "grid_order": "width,height",
+  "comparison_policy": "Within each scenario/area/denoise slice, all comparable rows use identical prompts, references, graph settings, and fixed seeds.",
+  "seed_set": [
+    0,
+    1,
+    2
+  ],
+  "matrix_axes": {
+    "area_regimes": [
+      {
+        "id": "base_0p55mp",
+        "source_grid": [
+          54,
+          40
+        ],
+        "source_pixels": [
+          864,
+          640
+        ],
+        "source_megapixels": 0.55296,
+        "target_grid": [
+          64,
+          48
+        ],
+        "target_pixels": [
+          1024,
+          768
+        ],
+        "target_megapixels": 0.786432
+      },
+      {
+        "id": "base_0p70mp",
+        "source_grid": [
+          62,
+          44
+        ],
+        "source_pixels": [
+          992,
+          704
+        ],
+        "source_megapixels": 0.698368,
+        "target_grid": [
+          64,
+          48
+        ],
+        "target_pixels": [
+          1024,
+          768
+        ],
+        "target_megapixels": 0.786432
+      }
+    ],
+    "refine_denoise": [
+      {
+        "value": 0.25,
+        "role": "primary"
+      },
+      {
+        "value": 0.3,
+        "role": "secondary"
+      }
+    ],
+    "scenarios": [
+      {
+        "id": "motion_scene_change",
+        "requirement": "difficult motion with at least one scene or shot change"
+      },
+      {
+        "id": "small_people_faces",
+        "requirement": "small or distant people/faces whose structure is visible in the final decode"
+      },
+      {
+        "id": "fine_text",
+        "requirement": "legible fine text or similarly high-frequency structured detail"
+      },
+      {
+        "id": "reference_heavy",
+        "requirement": "multiple image/video/reference inputs with prompt-dependent identity or composition constraints"
+      }
+    ]
+  },
+  "fixed": [
+    "continuum_chunks",
+    "loras",
+    "diffaid",
+    "untwist",
+    "sampler",
+    "scheduler",
+    "audio_lock",
+    "decode"
+  ],
+  "run_axis_rules": {
+    "A": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": false
+    },
+    "B": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": true
+    },
+    "C6": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": true
+    },
+    "C5": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": true
+    },
+    "C4": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": true
+    },
+    "D": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": false
+    },
+    "E": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": false
+    }
+  },
+  "runs": [
+    {
+      "id": "A",
+      "mode": "native",
+      "generation_grid": "area_regime.target_grid",
+      "target_grid": "area_regime.target_grid"
+    },
+    {
+      "id": "B",
+      "mode": "learned_upscale_baseline",
+      "source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "outer_steps": 6,
+      "denoise": "refine_denoise.value"
+    },
+    {
+      "id": "C6",
+      "mode": "flow_aligned",
+      "source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "outer_steps": 6,
+      "denoise": "refine_denoise.value"
+    },
+    {
+      "id": "C5",
+      "mode": "flow_aligned",
+      "source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "outer_steps": 5,
+      "denoise": "refine_denoise.value"
+    },
+    {
+      "id": "C4",
+      "mode": "flow_aligned",
+      "source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "outer_steps": 4,
+      "denoise": "refine_denoise.value"
+    },
+    {
+      "id": "D",
+      "mode": "progressive_target_input",
+      "continuum_grid": "area_regime.target_grid",
+      "internal_source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "handoff_coordinate": 0.35
+    },
+    {
+      "id": "E",
+      "mode": "resolution_shift_only",
+      "generation_grid": "area_regime.target_grid",
+      "shift_reference_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "resolution_shift": "resolution_aware"
+    }
+  ],
+  "required_outputs": [
+    "workflow_json",
+    "metrics_json",
+    "decoded_media",
+    "decoded_sha256",
+    "sampler_timing",
+    "peak_vram",
+    "host_ram",
+    "review_sheet"
+  ]
+}

--- a/workflows/benchmark-matrix.json
+++ b/workflows/benchmark-matrix.json
@@ -3,7 +3,7 @@
   "project": "MiniMax-H3-Flow-Aligned-Regenerate",
   "media_gate": "decoded_video_and_audio",
   "grid_order": "width,height",
-  "comparison_policy": "Within each scenario/area/denoise slice, all comparable rows use identical prompts, references, graph settings, and fixed seeds.",
+  "comparison_policy": "Within each scenario/area/denoise slice, all comparable rows use identical prompts, references, graph settings, fixed seeds, and a 7-step first pass. Refine-step reduction is the only B/C7/C6/C5 step-count variable.",
   "seed_set": [
     0,
     1,
@@ -106,6 +106,12 @@
       "seed": true,
       "refine_denoise": true
     },
+    "C7": {
+      "area_regime": true,
+      "scenario": true,
+      "seed": true,
+      "refine_denoise": true
+    },
     "C6": {
       "area_regime": true,
       "scenario": true,
@@ -113,12 +119,6 @@
       "refine_denoise": true
     },
     "C5": {
-      "area_regime": true,
-      "scenario": true,
-      "seed": true,
-      "refine_denoise": true
-    },
-    "C4": {
       "area_regime": true,
       "scenario": true,
       "seed": true,
@@ -149,7 +149,17 @@
       "mode": "learned_upscale_baseline",
       "source_grid": "area_regime.source_grid",
       "target_grid": "area_regime.target_grid",
-      "outer_steps": 6,
+      "base_outer_steps": 7,
+      "refine_outer_steps": 7,
+      "denoise": "refine_denoise.value"
+    },
+    {
+      "id": "C7",
+      "mode": "flow_aligned",
+      "source_grid": "area_regime.source_grid",
+      "target_grid": "area_regime.target_grid",
+      "base_outer_steps": 7,
+      "refine_outer_steps": 7,
       "denoise": "refine_denoise.value"
     },
     {
@@ -157,7 +167,8 @@
       "mode": "flow_aligned",
       "source_grid": "area_regime.source_grid",
       "target_grid": "area_regime.target_grid",
-      "outer_steps": 6,
+      "base_outer_steps": 7,
+      "refine_outer_steps": 6,
       "denoise": "refine_denoise.value"
     },
     {
@@ -165,15 +176,8 @@
       "mode": "flow_aligned",
       "source_grid": "area_regime.source_grid",
       "target_grid": "area_regime.target_grid",
-      "outer_steps": 5,
-      "denoise": "refine_denoise.value"
-    },
-    {
-      "id": "C4",
-      "mode": "flow_aligned",
-      "source_grid": "area_regime.source_grid",
-      "target_grid": "area_regime.target_grid",
-      "outer_steps": 4,
+      "base_outer_steps": 7,
+      "refine_outer_steps": 5,
       "denoise": "refine_denoise.value"
     },
     {
@@ -202,5 +206,14 @@
     "peak_vram",
     "host_ram",
     "review_sheet"
-  ]
+  ],
+  "step_reduction_gate": {
+    "baseline": "C7",
+    "already_validated_smoke": "C7",
+    "sequence": [
+      "C6",
+      "C5"
+    ],
+    "stopping_rule": "Run C6 next. Run C5 only if C6 decoded video/audio remains acceptable. Further reductions are exploratory rather than a required gate."
+  }
 }

--- a/workflows/flow-aligned-two-pass.overlay.json
+++ b/workflows/flow-aligned-two-pass.overlay.json
@@ -1,0 +1,72 @@
+{
+  "schema_version": 2,
+  "kind": "comfyui_workflow_overlay",
+  "purpose": "Apply flow-aligned guidance to each current Continuum V3.4 base-plus-integrated-refine chunk",
+  "continuum": {
+    "node": "H3 Continuum Sampler V3.4",
+    "required_widget": {
+      "emit_refine_conditioning": true,
+      "run_storage": "Off"
+    }
+  },
+  "shared_handle": {
+    "node": "H3FlowTrajectory",
+    "widgets": {
+      "storage": "system_ram",
+      "max_runs": 16
+    }
+  },
+  "base_model_patch": {
+    "node": "H3TrajectoryCapture",
+    "inputs": {
+      "trajectory": "shared_handle"
+    },
+    "widgets": {
+      "capture_forecasts": false
+    },
+    "placement": "after DiffAid/Untwist/Spectrum MODEL patches and before the H3 Continuum Sampler V3.4 MODEL input"
+  },
+  "refine_state_patch": {
+    "node": "H3FlowAlignedRefineState",
+    "inputs": {
+      "trajectory": "shared_handle",
+      "refine_state": "matching Continuum chunk refine_state",
+      "metrics": "base_model_patch.metrics"
+    },
+    "widgets": {
+      "guidance_mode": "direction",
+      "direction_weight": 0.35,
+      "acceleration_weight": 0,
+      "consistency_weight": 0,
+      "low_frequency_cutoff": 0.25
+    },
+    "placement": "between each Continuum refine_state output and MiniMax H3 Latent Upscaler + Refine (3D).refine_state"
+  },
+  "integrated_refine": {
+    "node": "MiniMax H3 Latent Upscaler + Refine (3D)",
+    "keep_existing_inputs": [
+      "video_latents",
+      "audio_latents",
+      "RandomNoise",
+      "SAMPLER",
+      "partial SIGMAS"
+    ],
+    "note": "The flow adapter patches the public refine_state.model and preserves refine_state.positive. Continuum's captured sampler mask is not emitted in public refine_state; it is restored on the parallel video/audio LATENT outputs, which the integrated refiner uses for its actual denoise mask and which therefore remain direct."
+  },
+  "invariants": {
+    "audio": "locked_by_existing_refine_graph",
+    "target_pixels": [
+      1024,
+      768
+    ],
+    "target_latent_wh": [
+      64,
+      48
+    ],
+    "forecast_anchors": false,
+    "decoded_media_required": true,
+    "trajectory_history": "max_runs >= physical refine item count; default 16 covers current Continuum maximum",
+    "run_storage": "off for initial trajectory/refine validation; reused chunks do not replay base trajectory capture",
+    "metrics": "feed Trajectory Capture metrics into Flow-Aligned Refine State so base/refine events share one sink"
+  }
+}

--- a/workflows/progressive-handoff.overlay.json
+++ b/workflows/progressive-handoff.overlay.json
@@ -1,0 +1,68 @@
+{
+  "schema_version": 2,
+  "kind": "comfyui_workflow_overlay",
+  "purpose": "Replace each Continuum chunk's base-plus-separate-refine path with a target-sized split sampler whose early H3 stage runs internally at the base grid",
+  "continuum": {
+    "node": "H3 Continuum Sampler V3.4",
+    "widgets": {
+      "width": 1024,
+      "height": 768,
+      "run_storage": "Off"
+    },
+    "note": "Continuum must remain configured on the final grid so chunk/session/native-mask state is 64x48 across the whole sequence."
+  },
+  "shared_handle": {
+    "node": "H3FlowTrajectory",
+    "widgets": {
+      "storage": "system_ram",
+      "max_runs": 16
+    }
+  },
+  "model_patch": {
+    "node": "H3ProgressiveTargetInputHandoff",
+    "inputs": {
+      "trajectory": "shared_handle"
+    },
+    "widgets": {
+      "source_mode": "pixels",
+      "source_scale": 0.84,
+      "source_width": 864,
+      "source_height": 640,
+      "handoff_coordinate": 0.35,
+      "handoff_selection": "fixed",
+      "guidance_mode": "direction",
+      "direction_weight": 0.25,
+      "acceleration_weight": 0,
+      "consistency_weight": 0,
+      "low_frequency_cutoff": 0.25
+    },
+    "placement": "after DiffAid/Untwist/Spectrum MODEL patches and before the Continuum MODEL input"
+  },
+  "sampler": {
+    "reuse_existing_sampler_and_full_sigma_schedule": true,
+    "remove_separate_learned_upscale_and_high_resolution_refine": true,
+    "expected_visible_extra_nfe": "one low-grid exact handoff probe",
+    "high_grid_actual_anchor": "mandatory"
+  },
+  "invariants": {
+    "continuum_input_and_output_latent_wh": [
+      64,
+      48
+    ],
+    "internal_low_stage_latent_wh": [
+      54,
+      40
+    ],
+    "target_pixels": [
+      1024,
+      768
+    ],
+    "audio": "target-grid audio noise/latent/mask preserved; no spatial transform",
+    "native_masked_continuation": "previous target-grid context remains exact in Continuum; only the private low-stage copy is downscaled",
+    "denoise_mask": "ComfyUI-prepared full-channel target mask retained for high stage; prepared video mask privately resized for low/probe",
+    "target_keyframes": "target originals retained for high stage; private copies resized only for low/probe; minimax_refs unchanged",
+    "run_storage": "off for first media validation; persistence must be validated separately before enabling",
+    "decoded_media_required": true,
+    "protected_noise": "target-input protected regions retain Continuum's original sampler noise for MiniMax H3 scale_latent_inpaint"
+  }
+}


### PR DESCRIPTION
Temporary validation PR stacked on #1. Corrects the benchmark plan to the real 7-step first-pass / 7-step refine baseline, makes C6 the 7+6 reduction test and C5 conditional, and fixes MiniMax H3 Metrics JSON so the file allocated before refine is atomically refreshed after later sampler completion with guidance/counter state. Close after CI and fold into #1 as one commit.