### PR TITLE
Default progressive source geometry to automatic scaling

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,9 @@ is ambiguous for a progressive split.
 
 Use **Progressive Handoff** when the sampler input itself is the low grid and changing the workflow's
 output latent geometry is acceptable. Use **Progressive Handoff (Target Input)** for Continuum V3.4:
-configure Continuum on the final target grid, set the progressive source to the intended private low
-grid, and patch the MODEL entering Continuum. The formal benchmark uses 1024x768 target with 864x640
+configure Continuum on the final target grid, use **source_mode=scale** so the private low grid is
+derived automatically from that live target geometry, and patch the MODEL entering Continuum. Explicit
+source width/height are fallback controls only for deliberately fixed-grid experiments. The formal benchmark uses 1024x768 target with 864x640
 internal source; the first feature smoke deliberately reuses the existing 928x928 target with 768x768
 internal source so prompt/seed/references stay matched to the accepted C4 run. The wrapper derives a fresh low-grid video noise tensor, downsizes the
 target-grid latent/mask/keyframes for the low and probe stages, then returns to the untouched target

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -47,10 +47,13 @@ remain identical across rows within one scenario/area/denoise/seed slice.
 Row D must use **Progressive Handoff (Target Input)** in the two-chunk Continuum graph: Continuum is configured at 64x48 while the wrapper's internal source is 54x40. This preserves target-sized session and native-mask geometry between chunks. The source-input progressive node is a standalone control and is not the Continuum benchmark topology.
 
 Before spending the formal matrix, validate D on the already-used difficult-motion smoke graph so the
-only structural change is the generation path. For that smoke, keep the current final grid at 58x58
-(928x928), set the progressive internal source to 48x48 (768x768), keep the same full 7-outer-step
-SA-Solver-PECE schedule, seed, prompt, references, DiffAid, Untwist, Spectrum and Continuum chunking,
-and remove the separate learned-upscale/refine branch entirely. Use fixed handoff coordinate 0.35,
+only structural change is the generation path. For that smoke, keep the current final grid unchanged and set **source_mode=scale** with
+**source_scale=0.83**. The node derives the private source directly from the live target latent geometry,
+so no source width/height needs to be copied from reference-image preprocessing. On a 58x58 target this
+resolves to 48x48 (768x768); on a non-square target the private source follows that target aspect ratio
+subject to H3's required even latent grid. Keep the same full 7-outer-step SA-Solver-PECE schedule,
+seed, prompt, references, DiffAid, Untwist, Spectrum and Continuum chunking, and remove the separate
+learned-upscale/refine branch entirely. Use fixed handoff coordinate 0.35,
 direction guidance 0.25, acceleration/consistency 0, and low-frequency cutoff 0.25. Continuum Run
 Storage stays off. A passing smoke must show target-grid Continuum chunks throughout, a private low
 stage at 48x48, one exact handoff probe, a fresh high-stage sampler lifetime whose first H3 call is

--- a/h3_flow_regenerate/nodes.py
+++ b/h3_flow_regenerate/nodes.py
@@ -309,8 +309,8 @@ class H3ProgressiveTargetInputHandoff:
             "required": {
                 "model": ("MODEL",),
                 "trajectory": ("H3_FLOW_TRAJECTORY",),
-                "source_mode": (["pixels", "scale"], {"default": "pixels"}),
-                "source_scale": ("FLOAT", {"default": 0.84, "min": 0.1, "max": 0.99, "step": 0.01}),
+                "source_mode": (["scale", "pixels"], {"default": "scale"}),
+                "source_scale": ("FLOAT", {"default": 0.83, "min": 0.1, "max": 0.99, "step": 0.01}),
                 "source_width": ("INT", {"default": 864, "min": 32, "max": 8192, "step": 32}),
                 "source_height": ("INT", {"default": 640, "min": 32, "max": 8192, "step": 32}),
                 "handoff_coordinate": ("FLOAT", {"default": 0.35, "min": 0.01, "max": 0.99, "step": 0.01}),

--- a/workflows/progressive-handoff.overlay.json
+++ b/workflows/progressive-handoff.overlay.json
@@ -24,8 +24,8 @@
       "trajectory": "shared_handle"
     },
     "widgets": {
-      "source_mode": "pixels",
-      "source_scale": 0.84,
+      "source_mode": "scale",
+      "source_scale": 0.83,
       "source_width": 864,
       "source_height": 640,
       "handoff_coordinate": 0.35,
@@ -36,7 +36,8 @@
       "consistency_weight": 0,
       "low_frequency_cutoff": 0.25
     },
-    "placement": "after DiffAid/Untwist/Spectrum MODEL patches and before the Continuum MODEL input"
+    "placement": "after DiffAid/Untwist/Spectrum MODEL patches and before the Continuum MODEL input",
+    "note": "Use scale mode for normal operation so the private source follows the live Continuum target aspect ratio automatically. Explicit source_width/source_height are fallback controls only when source_mode=pixels."
   },
   "sampler": {
     "reuse_existing_sampler_and_full_sigma_schedule": true,
@@ -102,6 +103,9 @@
       "separate learned latent upscale",
       "separate high-resolution refine"
     ],
-    "run_storage": "Off"
+    "run_storage": "Off",
+    "source_mode": "scale",
+    "source_scale": 0.83,
+    "note": "Do not derive the progressive source from reference-image preprocessing dimensions. Scale mode derives it from the live target latent geometry."
   }
 }


### PR DESCRIPTION
Temporary validation PR stacked on #1. Switch the Target Input node default from explicit pixel dimensions to live-target scale mode, use 0.83 for the current D smoke, and document that reference-image preprocessing dimensions are unrelated to the private progressive source geometry.