### PR TITLE
Add optional learned 3D progressive handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
           git clone --filter=blob:none https://github.com/xmarre/ComfyUI-Untwisting-RoPE.git .contracts/Untwist
           git -C .contracts/Untwist checkout 299d4c56a3f057a97b3140d2136189bcd1e7d6bb
           git clone --filter=blob:none https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler.git .contracts/Upscaler
-          git -C .contracts/Upscaler checkout 2c707492084962f7ed665e8817a05a11b14dab27
+          git -C .contracts/Upscaler checkout bdc670e5926bcefbe4022e17fe8b171fbfcf15de
       - name: Validate native and sibling contracts
         run: >-
           python tools/check_source_contracts.py

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Restart ComfyUI. PyTorch is supplied by ComfyUI. Sibling custom nodes are not im
 | MiniMax H3 Flow-Aligned Regenerate | Time-matched low-frequency guidance for an explicit second pass | Direction is conservative default |
 | MiniMax H3 Flow-Aligned Refine State | Patches Continuum V3.4 per-chunk refine state for integrated learned refinement | Direction is conservative default |
 | MiniMax H3 Progressive Handoff | Source-grid sampler input grows to target grid during one schedule | Experimental |
-| MiniMax H3 Progressive Handoff (Target Input) | Continuum-safe target-sized topology with a private low-grid early stage | Validated experimental path |
+| MiniMax H3 Progressive Handoff (Target Input) | Continuum-safe target-sized topology with a private low-grid early stage; optional learned 3D clean-state transfer | Bicubic validated; learned transfer experimental |
 | MiniMax H3 Refine Target Geometry | Mirrors downstream learned-refine target sizing for sigma experiments | Experimental |
 | MiniMax H3 Resolution-Aware Sigmas | Relative H3-native resolution/time remap | Off / experimental |
 | MiniMax H3 Reference Budget | Direct-reference row diagnostics/cap | Native |
@@ -87,6 +87,32 @@ DiffAid
 Create one **Flow Trajectory** handle and connect it to Progressive Handoff (Target Input). The progressive node captures the low-grid trajectory internally; a separate **Trajectory Capture** node is not required on this path.
 
 Continuum remains configured on the final target grid. The wrapper creates a private low-grid video state for the early stage, performs an exact low-grid handoff probe, rebuilds target-grid conditioning, and starts a fresh sampler lifetime on the high grid. Audio is never spatially transformed. SA/PECE Adams history and Spectrum feature history are deliberately reset across the geometry boundary, and the first high-grid H3 call is forced actual.
+
+`handoff_transfer=bicubic` remains the compatibility default. For the validated learned path,
+install the companion latent upscaler, create **MiniMax H3 Latent Upscaler Provider (3D) [Experimental]**,
+connect its `H3_LATENT_UPSCALER` output to the Target Input node, and select
+`handoff_transfer=learned_3d`. The learned CNN replaces only the exact-probe clean-video spatial
+transfer. Conditional re-noising, deterministic target noise, sampler/Spectrum history boundaries,
+the mandatory first high-grid actual call, caller audio, masks, and all H3 model-call semantics remain
+unchanged. One learned inference is added per physical chunk and no extra H3 NFE is added.
+
+Decoded-media validation now covers substantially more aggressive transitions than the original
+46×46→56×56 D14 plan. Around a 0.995 MP target, bicubic at roughly a 0.55 MP private source produced
+visible body/spatial handoff artifacts in the tested difficult prompt; replacing only that boundary with
+`learned_3d` fixed the majority of those artifacts. At the same target, `source_scale=0.70` resolved to
+800×608→1152×864 and was judged excellent, while `0.65` resolved to 736×576→1152×864 and began losing
+reference likeness / tonal stability. The final higher-resolution gate kept `source_scale=0.70` and
+resolved 832×640→1184×896 (~1.061 MP target); the generated action was different but the result was
+again judged very good. Its two BF16 CUDA learned calls took about 0.60 s and 0.77 s and added zero H3
+NFEs. These latest learned-transfer media runs used `direction+acceleration`; they are not evidence for
+promoting acceleration over direction-only.
+
+For roughly 1 MP targets, `0.70` is therefore the current tested quality/compute sweet spot for this
+prompt, not a universal optimum. `0.65` is below the current useful quality floor in this case, while
+higher source scales remain the safer choice when preserving source-grid fidelity matters more than
+compute. Keep bicubic available for compatibility and matched controls rather than silently changing
+existing workflows. Provider mode fails instead of silently falling back when its configured inference
+device is unavailable.
 
 Use a complete 1-to-0 H3 sigma schedule. Partial low-sigma refinement schedules are rejected because their absolute flow origin is ambiguous for a progressive split.
 
@@ -117,6 +143,8 @@ For a desired private stage around ~0.54 MP:
 | 1.20 | 0.67 |
 
 The actual source dimensions are snapped to valid H3 latent geometry, so these values are starting points rather than exact pixel guarantees. Check the `handoff_plan` metrics event for the resolved source/target latent dimensions. With fixed handoff, increasing MP alone does not require changing `handoff_coordinate`; keep the tested 0.35 initially and adjust `source_scale` separately to control the low-stage compute budget.
+
+The table is a geometry heuristic, not a quality guarantee. At approximately 1 MP, real decoded media showed that `source_scale=0.70` can work very well with `learned_3d`, while `0.65` crossed the tested prompt's fidelity/tonal floor. Because H3 snaps both axes, compare the resolved `handoff_plan` geometry rather than assuming two nearby decimal scales produce a smooth change.
 
 ## Two-pass flow-aligned use
 
@@ -203,7 +231,7 @@ Pinned executable/source contracts:
 - DiffAid `ba9d9efbcf7e64c755e068cb76547d8cc85481eb`
 - RefDelta `034e4c4c14c56bf76813cee4765e7164b0c7e0db`
 - Untwisting RoPE `299d4c56a3f057a97b3140d2136189bcd1e7d6bb`
-- integrated H3 latent upscaler/refine `2c707492084962f7ed665e8817a05a11b14dab27`
+- H3 latent upscaler/refine and learned-handoff provider `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` (draft provider PR #12)
 
 MiniMax-H3 main was additionally inspected at `d21241f0a4b3acbb34c97dae47fa417b7065e438`.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -374,6 +374,21 @@ standard-Gaussian low-grid video tensor from the graph seed while preserving the
 The handoff high-frequency video noise uses a separate domain offset. Both generators are isolated
 from the sampler RNG.
 
+Target-input transfer is a pluggable clean-state boundary with `bicubic` as the compatibility default.
+The optional versioned `H3_LATENT_UPSCALER` provider receives only the unpacked, post-`process_latent_in`
+24-channel exact-probe video estimate and the already-resolved target latent H/W. For current pinned H3,
+`process_latent_in` leaves video numerically unchanged and applies the packed internal scaling only to
+audio, so this is the same clean-video latent domain used by the standalone learned 3D upscaler. Audio
+never enters the provider. The provider must preserve B/C/T, return the exact target H/W, a floating
+finite tensor, and API/kind metadata; violations fail before the high sampler starts.
+
+After either transfer, the same deterministic target-grid Gaussian tensor and conditional rectified-flow
+equation construct the handoff state. Thus learned mode changes one spatial clean-state transform, adds
+one CNN inference per physical chunk, and does not alter the exact probe, sigma, H3 NFE count, masks,
+conditioning rebuild, first-high actual anchor, or sampler/Spectrum lifetime boundaries. Metrics record
+the mode, provider/checkpoint, source/target HWT, input/output dtype/device, configured and resolved
+inference device, precision, elapsed time, and offload policy.
+
 `auto_compute` is a deterministic, bounded handoff heuristic that moves the base coordinate later
 as the target/source area ratio grows. It uses no model calls and is reported in metrics. It is a
 compute-allocation probe, not a learned quality criterion; fixed `0.35` remains the reproducible

--- a/docs/BENCHMARKS.md
+++ b/docs/BENCHMARKS.md
@@ -24,6 +24,7 @@ Attach **MiniMax H3 Metrics JSON** to experimental paths. The autosaved JSON is 
 | D12-direction | Square matched run, fixed 0.35, direction 0.25 | Perceptually better than D10 |
 | D14-direction | Square matched run, fixed 0.35, direction 0.25 | Again slightly better; current tested quality point |
 | D14-temporal | Same D14 topology plus temporal 0.20 | No perceptual difference from D14 direction-only |
+| Learned-transfer media | Progressive Target Input around 1.0–1.06 MP; aggressive source scales; learned 3D clean-state transfer | Decoded-media positive; 0.70 strongest tested quality/compute point, 0.65 begins fidelity loss |
 | E0/E1 | Learned-refine SIGMAS identity control vs resolution-aware remap | Structurally valid; no relevant E1 quality improvement |
 
 Earlier temporal media generated with the accidental TensorRT `w4a16_awq` VAE is excluded from media conclusions.
@@ -65,6 +66,38 @@ D14 fixed handoff selected schedule index 9 at unshifted coordinate ~0.35799987 
 - sampler failures: 0.
 
 This is effectively 9 low-grid + 5 high-grid outer steps per chunk. It is not equivalent to a separate 7+7 learned-refine workflow, but it is a useful quality/compute comparison because the majority of the trajectory runs on the cheaper low grid.
+
+### Learned 3D transfer decoded-media validation
+
+The original strict 46×46→56×56 D14 A/B plan was superseded by a more informative aggressive-handoff
+sweep around 1 MP. The learned-transfer conclusion comes from decoded media; synthetic contract tests
+remain supporting structural evidence only.
+
+The useful progression was:
+
+- around `1152×864` (~0.995 MP) target, a bicubic handoff from roughly a ~0.55 MP private source showed
+  substantial body/spatial artifacts in the difficult-motion prompt;
+- replacing only the exact-probe clean-state resize with `learned_3d` fixed the majority of those
+  artifacts while preserving the same sampler boundary semantics;
+- `source_scale=0.70` resolved to `800×608 → 1152×864` and was judged excellent;
+- `source_scale=0.65` resolved to `736×576 → 1152×864` and began losing reference-picture likeness and
+  tonal stability, so it is not promoted;
+- the final higher-resolution gate used `source_scale=0.70` at `832×640 → 1184×896` (~1.061 MP target).
+  The video was different in action/content but was again judged very good.
+
+The final ~1.061 MP run used 10 SA-Solver-PECE outer steps, fixed handoff 0.35 snapping to schedule index
+6 / unshifted coordinate ~0.400000016 / sigma ~0.888888896, and `direction+acceleration` guidance. Across
+two physical chunks it recorded 38 logical H3 calls / 28 actual transformer NFEs / 10 Spectrum
+forecasts: low 22/16/6, exact probes 2/2/0, high 14/10/4. It also recorded 6 progressive sampler
+invocations, 4 history boundaries, copied audio, rebuilt high-grid conditioning, and an actual first
+high-grid H3 call for both chunks. The BF16 CUDA learned provider took about 602 ms and 771 ms; total
+learned-transfer wall time was about 628 ms and 802 ms. No sampler failure occurred and the CNN added no
+H3 NFE.
+
+This does not establish universal learned-transfer superiority or a universal source-scale optimum.
+For this prompt around 1 MP, `0.70` is the current tested quality/compute sweet spot; `0.65` is below the
+observed quality floor. The latest learned runs had acceleration enabled, so they must not be cited as
+new direction-only or acceleration-promotion evidence.
 
 The D12 predecessor used fixed 0.35 -> ~0.334/index 8 and recorded 46 logical / 32 actual / 14 forecast calls. The user judged D12 better than D10 and D14 again a bit better than D12. Stop the current step sweep at 14 unless a future scenario gives a specific reason to test higher budgets.
 

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -23,6 +23,28 @@ The strongest practical result is the Continuum-safe **Progressive Handoff (Targ
 
 The reset is essential: SA-Solver/PECE Adams history and Spectrum hidden-feature history do not cross the spatial geometry boundary. Audio stays at target representation and is never spatially resized.
 
+The Target Input boundary now also permits an experimental learned 3D transfer supplied by the
+companion latent-upscaler package. It consumes the exact-probe clean 24-channel video latent and emits
+the exact target H/W before the existing conditional re-noise equation. This is deliberately narrower
+than the companion integrated refine node: it adds one CNN call, no second H3 sampling pass, and never
+touches audio. Bicubic remains the default and the prior evidence baseline.
+
+Decoded media now validates the learned boundary beyond the originally planned D14 46×46→56×56
+control. Around a 0.995 MP target, an aggressive bicubic transition showed substantial body/spatial
+artifacts in the tested difficult prompt; changing only the exact-probe clean-video transfer to the
+versioned learned 3D provider fixed the majority of them. At that target, `source_scale=0.70` resolved
+to 800×608→1152×864 and was judged excellent, whereas `0.65` resolved to 736×576→1152×864 and began
+losing reference likeness / tonal stability.
+
+A final `source_scale=0.70` higher-resolution gate resolved 832×640→1184×896 (~1.061 MP). The generated
+action was different but the decoded result was again judged very good. The run preserved the expected
+38 logical / 28 actual / 10 forecast topology, two exact probes, six sampler invocations, four history
+boundaries, copied audio, and actual high-grid anchors. Learned BF16 CUDA inference cost about 0.60 s
+and 0.77 s for the two physical chunks and added no H3 NFE. These learned-transfer media runs used
+`direction+acceleration`, so they do not change the earlier conclusion that acceleration has not shown
+a clear matched advantage over direction-only. Around 1 MP, 0.70 is the current tested learned-transfer
+quality/compute sweet spot for this prompt; no cross-prompt optimum is claimed.
+
 The original difficult-motion D10 reference established the topology at a rectangular 736x768 private source -> 896x928 target. A later matched square quality sweep used 736x736 -> 896x896 and showed a consistent subjective improvement from 10 -> 12 -> 14 SA-Solver-PECE outer steps with fixed handoff 0.35 and direction weight 0.25.
 
 At 14 outer steps, fixed 0.35 snapped to unshifted coordinate ~0.358 / schedule index 9. Across two chunks the run recorded 54 logical model calls, 36 actual H3 NFEs, and 18 Spectrum forecasts, effectively allocating 9 low-grid and 5 high-grid outer steps per chunk. The user judged it again slightly better than the 12-step result. This is the current tested quality operating point, while 10/12 remain valid faster points.
@@ -128,6 +150,6 @@ CI checks executable contracts at:
 - DiffAid `ba9d9efbcf7e64c755e068cb76547d8cc85481eb`
 - RefDelta `034e4c4c14c56bf76813cee4765e7164b0c7e0db`
 - Untwisting RoPE `299d4c56a3f057a97b3140d2136189bcd1e7d6bb`
-- integrated H3 latent upscaler/refine `2c707492084962f7ed665e8817a05a11b14dab27`
+- H3 latent upscaler/refine and learned-handoff provider `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` (draft provider PR #12)
 
 MiniMax-H3 main was additionally inspected at `d21241f0a4b3acbb34c97dae47fa417b7065e438`. Updating a source pin requires re-running the source audit and compatibility tests.

--- a/h3_flow_regenerate/guidance.py
+++ b/h3_flow_regenerate/guidance.py
@@ -694,6 +694,19 @@ def conditional_renoise_alignment(
     if not 0 <= sigma <= 1:
         raise ValueError("sigma must be in [0, 1]")
     ref = resize_video(reference_x0, target_h, target_w, mode=transfer_mode).to(noise)
+    return conditional_renoise_target(ref, sigma=sigma, noise=noise)
+
+
+def conditional_renoise_target(
+    target_x0: torch.Tensor,
+    *,
+    sigma: float,
+    noise: torch.Tensor,
+) -> torch.Tensor:
+    """Reconstruct x_t from an already target-sized clean state and target noise."""
+    if not 0 <= sigma <= 1:
+        raise ValueError("sigma must be in [0, 1]")
+    ref = target_x0.to(noise)
     if ref.shape != noise.shape:
         raise ValueError("initialization reference and noise shapes differ")
     return (1.0 - sigma) * ref + sigma * noise

--- a/h3_flow_regenerate/handoff.py
+++ b/h3_flow_regenerate/handoff.py
@@ -1,13 +1,59 @@
 from __future__ import annotations
 
 import math
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, field
+from typing import Any
 
 import torch
 
 from .geometry import normalize_target_geometry, pack_streams, unpack_streams, validate_av
-from .guidance import conditional_renoise_alignment
+from .guidance import conditional_renoise_alignment, conditional_renoise_target
 from .sigma import H3_VIDEO_SHIFT, normalized_coordinate
+
+H3_LATENT_UPSCALER_API_VERSION = 1
+H3_LATENT_UPSCALER_KIND = "minimax_h3_learned_latent_upscaler"
+
+
+def validate_learned_upscaler_provider(provider: Any) -> dict[str, Any]:
+    if provider is None:
+        raise ValueError("learned_3d handoff requires a connected H3_LATENT_UPSCALER provider")
+    api_version = getattr(provider, "api_version", None)
+    if api_version != H3_LATENT_UPSCALER_API_VERSION:
+        raise ValueError(
+            f"unsupported H3 latent-upscaler provider API {api_version!r}; expected {H3_LATENT_UPSCALER_API_VERSION}"
+        )
+    kind = getattr(provider, "kind", None)
+    if kind != H3_LATENT_UPSCALER_KIND:
+        raise ValueError(f"unsupported H3 latent-upscaler provider kind {kind!r}")
+    upscale = getattr(provider, "upscale_clean_video", None)
+    if not callable(upscale):
+        raise TypeError("H3 latent-upscaler provider is missing callable upscale_clean_video")
+    model_name = getattr(provider, "model_name", None)
+    device = getattr(provider, "device", None)
+    precision = getattr(provider, "precision", None)
+    offload = getattr(provider, "offload_after_upscale", None)
+    inference_device = getattr(provider, "inference_device", device)
+    if not isinstance(model_name, str) or not model_name:
+        raise ValueError("H3 latent-upscaler provider is missing a checkpoint identity")
+    if device not in {"cuda", "cpu"}:
+        raise ValueError("H3 latent-upscaler provider device must be cuda or cpu")
+    if precision not in {"fp32", "fp16", "bf16"}:
+        raise ValueError("H3 latent-upscaler provider precision must be fp32, fp16, or bf16")
+    if not isinstance(offload, bool):
+        raise TypeError("H3 latent-upscaler provider offload_after_upscale must be boolean")
+    if inference_device not in {"cuda", "cpu"}:
+        raise ValueError("H3 latent-upscaler provider inference_device must be cuda or cpu")
+    return {
+        "api_version": api_version,
+        "kind": kind,
+        "model_name": model_name,
+        "device": device,
+        "inference_device": inference_device,
+        "precision": precision,
+        "offload_after_upscale": offload,
+        "upscale": upscale,
+    }
 
 
 @dataclass(frozen=True, slots=True)
@@ -43,6 +89,8 @@ class ProgressiveHandoffConfig:
             raise ValueError("automatic handoff bounds must lie inside (0, 1)")
         if self.matching_mode != "conditional_renoise":
             raise ValueError("only the derived conditional_renoise handoff is currently supported")
+        if self.transfer_mode != "bicubic":
+            raise ValueError("source-input progressive handoff currently supports bicubic transfer only")
         if self.min_high_steps < 1:
             raise ValueError("min_high_steps must be positive")
 
@@ -92,6 +140,7 @@ class ProgressiveTargetInputConfig:
     seed_offset: int = 0x4833464C4F57
     source_noise_offset: int = 0x48334C4F574C52
     min_high_steps: int = 2
+    learned_upscaler: Any | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
         explicit = self.source_latent_h is not None or self.source_latent_w is not None
@@ -112,6 +161,10 @@ class ProgressiveTargetInputConfig:
             raise ValueError("automatic handoff bounds must lie inside (0, 1)")
         if self.matching_mode != "conditional_renoise":
             raise ValueError("only the derived conditional_renoise handoff is currently supported")
+        if self.transfer_mode not in {"bicubic", "learned_3d"}:
+            raise ValueError("target-input handoff transfer must be bicubic or learned_3d")
+        if self.transfer_mode == "learned_3d":
+            validate_learned_upscaler_provider(self.learned_upscaler)
         if self.min_high_steps < 1:
             raise ValueError("min_high_steps must be positive")
 
@@ -186,6 +239,8 @@ def build_handoff_state(
     target_w: int,
     seed: int,
     transfer_mode: str = "bicubic",
+    learned_upscaler: Any | None = None,
+    transfer_metrics: dict[str, Any] | None = None,
 ) -> tuple[torch.Tensor, list[tuple[int, ...]]]:
     if len(source_shapes) != 2:
         raise ValueError("progressive H3 handoff requires exactly video and audio streams")
@@ -204,14 +259,72 @@ def build_handoff_state(
         device=source_video.device,
         dtype=source_video.dtype,
     )
-    target_video = conditional_renoise_alignment(
-        x0_video,
-        target_h=target_h,
-        target_w=target_w,
-        sigma=float(sigma),
-        noise=noise,
-        transfer_mode=transfer_mode,
-    )
+    if transfer_mode == "bicubic":
+        target_video = conditional_renoise_alignment(
+            x0_video,
+            target_h=target_h,
+            target_w=target_w,
+            sigma=float(sigma),
+            noise=noise,
+            transfer_mode="bicubic",
+        )
+        report = {"transfer_mode": "bicubic"}
+    elif transfer_mode == "learned_3d":
+        provider = validate_learned_upscaler_provider(learned_upscaler)
+        learned_started = time.perf_counter()
+        learned_x0 = provider["upscale"](
+            x0_video,
+            target_h=int(target_h),
+            target_w=int(target_w),
+        )
+        learned_elapsed_ms = (time.perf_counter() - learned_started) * 1000.0
+        if not isinstance(learned_x0, torch.Tensor):
+            raise TypeError("H3 latent-upscaler provider returned a non-tensor value")
+        expected_shape = (
+            int(x0_video.shape[0]),
+            int(x0_video.shape[1]),
+            int(x0_video.shape[2]),
+            int(target_h),
+            int(target_w),
+        )
+        if tuple(learned_x0.shape) != expected_shape:
+            raise RuntimeError(
+                f"H3 latent-upscaler provider returned shape {tuple(learned_x0.shape)}; expected {expected_shape}"
+            )
+        if not learned_x0.is_floating_point():
+            raise TypeError("H3 latent-upscaler provider returned a non-floating tensor")
+        if not bool(torch.isfinite(learned_x0).all().item()):
+            raise RuntimeError("H3 latent-upscaler provider returned NaN or Inf values")
+        target_video = conditional_renoise_target(
+            learned_x0,
+            sigma=float(sigma),
+            noise=noise,
+        )
+        report = {
+            "transfer_mode": "learned_3d",
+            "provider_api_version": provider["api_version"],
+            "provider_kind": provider["kind"],
+            "model_name": provider["model_name"],
+            "source_hw": tuple(int(value) for value in x0_video.shape[-2:]),
+            "target_hw": (int(target_h), int(target_w)),
+            "temporal_length": int(x0_video.shape[2]),
+            "input_dtype": str(x0_video.dtype),
+            "input_device": str(x0_video.device),
+            "inference_precision": provider["precision"],
+            "configured_device": provider["device"],
+            "inference_device": provider["inference_device"],
+            "learned_upscale_elapsed_ms": learned_elapsed_ms,
+            "offload_after_upscale": provider["offload_after_upscale"],
+            "offloaded_after_upscale": bool(
+                provider["offload_after_upscale"] and provider["inference_device"] == "cuda"
+            ),
+            "output_dtype": str(learned_x0.dtype),
+            "output_device": str(learned_x0.device),
+        }
+    else:
+        raise ValueError(f"unsupported progressive handoff transfer mode {transfer_mode!r}")
+    if transfer_metrics is not None:
+        transfer_metrics.update(report)
     # The packed sampler carries audio on the video sigma schedule. Its state is
     # preserved byte-for-byte across a purely spatial video transition.
     target_packed, target_shapes = pack_streams((target_video, source_audio.clone()))

--- a/h3_flow_regenerate/nodes.py
+++ b/h3_flow_regenerate/nodes.py
@@ -169,7 +169,9 @@ class H3FlowAlignedRefineState:
                 "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
                 "temporal_weight": ("FLOAT", {"default": 0.20, "min": 0.0, "max": 1.0, "step": 0.01}),
             },
-            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+            "optional": {
+                "metrics": ("H3_FLOW_METRICS",),
+            },
         }
 
     RETURN_TYPES = ("H3_CONTINUUM_REFINE_STATE", "H3_FLOW_METRICS")
@@ -339,8 +341,21 @@ class H3ProgressiveTargetInputHandoff:
                 "consistency_weight": ("FLOAT", {"default": 0.0, "min": 0.0, "max": 2.0, "step": 0.01}),
                 "low_frequency_cutoff": ("FLOAT", {"default": 0.25, "min": 0.02, "max": 1.0, "step": 0.01}),
                 "temporal_weight": ("FLOAT", {"default": 0.20, "min": 0.0, "max": 1.0, "step": 0.01}),
+                "handoff_transfer": (
+                    ["bicubic", "learned_3d"],
+                    {
+                        "default": "bicubic",
+                        "tooltip": (
+                            "bicubic preserves the released handoff. learned_3d applies one connected "
+                            "H3 latent-upscaler provider to the exact-probe clean video state."
+                        ),
+                    },
+                ),
             },
-            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+            "optional": {
+                "metrics": ("H3_FLOW_METRICS",),
+                "learned_upscaler": ("H3_LATENT_UPSCALER",),
+            },
         }
 
     RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
@@ -365,12 +380,16 @@ class H3ProgressiveTargetInputHandoff:
         low_frequency_cutoff,
         metrics=None,
         temporal_weight=0.20,
+        handoff_transfer="bicubic",
+        learned_upscaler=None,
     ):
         if source_mode == "scale":
             progressive = ProgressiveTargetInputConfig(
                 source_scale=source_scale,
                 handoff_coordinate=handoff_coordinate,
                 handoff_selection=handoff_selection,
+                transfer_mode=handoff_transfer,
+                learned_upscaler=learned_upscaler,
             )
         else:
             source_h, source_w = pixel_to_safe_latent(source_height, source_width)
@@ -379,6 +398,8 @@ class H3ProgressiveTargetInputHandoff:
                 source_latent_w=source_w,
                 handoff_coordinate=handoff_coordinate,
                 handoff_selection=handoff_selection,
+                transfer_mode=handoff_transfer,
+                learned_upscaler=learned_upscaler,
             )
         guidance = GuidanceConfig(
             mode=guidance_mode,

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -942,6 +942,7 @@ def _run_progressive(
         requested_coordinate=config.handoff_coordinate,
         selected_coordinate=selected_coordinate,
         selection=config.handoff_selection,
+        transfer_mode=config.transfer_mode,
         input_mode="target_grid" if target_input else "source_grid",
         source_shape=source_shapes[0],
         target_hw=(target_h, target_w),
@@ -1036,6 +1037,7 @@ def _run_progressive(
     try:
         source_x0 = _process_latent_in(base_model, source_x0, source_shapes)
         transfer_started = time.perf_counter()
+        transfer_metrics: dict[str, Any] = {}
         target_raw, target_shapes = build_handoff_state(
             source_packed_state=source_raw,
             source_x0_packed=source_x0,
@@ -1045,7 +1047,29 @@ def _run_progressive(
             target_w=target_w,
             seed=int(seed or 0) + config.seed_offset,
             transfer_mode=config.transfer_mode,
+            learned_upscaler=getattr(config, "learned_upscaler", None),
+            transfer_metrics=transfer_metrics,
         )
+        if config.transfer_mode == "learned_3d":
+            binding.metrics.event(
+                "handoff_learned_upscale_wall",
+                elapsed_ms=transfer_metrics["learned_upscale_elapsed_ms"],
+                provider_api_version=transfer_metrics["provider_api_version"],
+                provider_kind=transfer_metrics["provider_kind"],
+                model_name=transfer_metrics["model_name"],
+                source_hw=transfer_metrics["source_hw"],
+                target_hw=transfer_metrics["target_hw"],
+                temporal_length=transfer_metrics["temporal_length"],
+                input_dtype=transfer_metrics["input_dtype"],
+                input_device=transfer_metrics["input_device"],
+                inference_precision=transfer_metrics["inference_precision"],
+                configured_device=transfer_metrics["configured_device"],
+                inference_device=transfer_metrics["inference_device"],
+                offload_after_upscale=transfer_metrics["offload_after_upscale"],
+                offloaded_after_upscale=transfer_metrics["offloaded_after_upscale"],
+                output_dtype=transfer_metrics["output_dtype"],
+                output_device=transfer_metrics["output_device"],
+            )
         if target_input and target_shapes != input_shapes:
             raise RuntimeError("target-input progressive handoff changed the caller-visible AV geometry")
         if target_input:
@@ -1123,6 +1147,7 @@ def _run_progressive(
             high_stage_first_call_actual=first_high_actual,
             high_stage_model_calls=len(high_model_calls),
             conditioning_rebuilt_for_high_grid=True,
+            transfer_mode=config.transfer_mode,
             input_mode="target_grid" if target_input else "source_grid",
         )
         return result

--- a/tests/test_attention_reference_runtime.py
+++ b/tests/test_attention_reference_runtime.py
@@ -1412,6 +1412,28 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
     )
     calls = []
 
+    class LearnedProvider:
+        api_version = 1
+        kind = "minimax_h3_learned_latent_upscaler"
+        model_name = "fake.safetensors"
+        device = "cpu"
+        precision = "fp32"
+        offload_after_upscale = False
+
+        def __init__(self):
+            self.calls = []
+
+        def upscale_clean_video(self, video, *, target_h, target_w):
+            self.calls.append((video.clone(), target_h, target_w))
+            return torch.nn.functional.interpolate(
+                video.float(),
+                size=(video.shape[2], target_h, target_w),
+                mode="trilinear",
+                align_corners=False,
+            ).to(video)
+
+    learned_provider = LearnedProvider()
+
     class Executor:
         class_obj = guider
 
@@ -1462,7 +1484,13 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
         Executor(),
         guider,
         binding,
-        ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4, handoff_coordinate=0.3),
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            handoff_coordinate=0.3,
+            transfer_mode="learned_3d",
+            learned_upscaler=learned_provider,
+        ),
         target_noise,
         target_latent,
         sampler,
@@ -1490,11 +1518,19 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
     assert result.shape == target_latent.shape
     assert binding.trajectory.latest.geometry.latent_h == 4
     assert binding.trajectory.latest.geometry.latent_w == 4
+    assert len(learned_provider.calls) == 1
+    assert torch.equal(learned_provider.calls[0][0], source_video)
+    assert learned_provider.calls[0][1:] == (8, 6)
     handoff = [event for event in binding.metrics.events if event.kind == "handoff_complete"][-1]
+    learned = [event for event in binding.metrics.events if event.kind == "handoff_learned_upscale_wall"][-1]
     assert handoff.fields["high_stage_first_call_actual"] is True
     assert handoff.fields["high_stage_model_calls"] == 1
     assert handoff.fields["sampler_invocation_count"] == 3
     assert handoff.fields["history_boundary_count"] == 2
+    assert handoff.fields["transfer_mode"] == "learned_3d"
+    assert learned.fields["provider_api_version"] == 1
+    assert learned.fields["source_hw"] == (4, 4)
+    assert learned.fields["target_hw"] == (8, 6)
 
     calls.clear()
     callback_shapes.clear()
@@ -1502,7 +1538,12 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
         Executor(),
         guider,
         binding,
-        ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4, handoff_coordinate=0.3),
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            handoff_coordinate=0.3,
+            learned_upscaler=learned_provider,
+        ),
         target_noise,
         target_latent,
         sampler,
@@ -1518,6 +1559,7 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
     assert second_handoff.fields["history_boundary_count"] == 2
     assert binding.metrics.counters["progressive_sampler_invocations"] == 6
     assert binding.metrics.counters["progressive_history_boundaries"] == 4
+    assert len(learned_provider.calls) == 1
 
 
 def test_progressive_high_failure_invalidates_committed_low_trajectory(monkeypatch):
@@ -1589,6 +1631,97 @@ def test_progressive_high_failure_invalidates_committed_low_trajectory(monkeypat
     assert len(trajectory.runs) == 1
     assert not trajectory.runs[0].complete
     assert "progressive continuation failed" in trajectory.runs[0].abort_reason
+    assert any(event.kind == "trajectory_invalidate" for event in binding.metrics.events)
+
+
+def test_learned_provider_failure_invalidates_committed_low_trajectory(monkeypatch):
+    class KSampler:
+        def __init__(self, function, inpaint_options=None):
+            self.sampler_function = function
+            self.extra_options = {}
+            self.inpaint_options = dict(inpaint_options or {})
+
+    fake_samplers = ModuleType("comfy.samplers")
+    fake_samplers.KSAMPLER = KSampler
+    fake_comfy = ModuleType("comfy")
+    fake_comfy.samplers = fake_samplers
+    monkeypatch.setitem(sys.modules, "comfy", fake_comfy)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake_samplers)
+
+    target_video = torch.randn(1, 24, 1, 8, 6)
+    audio = torch.randn(1, 32, 2, 5)
+    target_packed, target_shapes = pack_streams((target_video, audio))
+    source_packed, _ = pack_streams((torch.randn(1, 24, 1, 4, 4), audio))
+    sigmas = torch.tensor([1.0, 0.8, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_euler"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=MiniMaxH3()),
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+        conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+    calls = 0
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, call_sampler, call_sigmas, *args, latent_shapes):
+            nonlocal calls
+            del noise, latent, args, latent_shapes
+            calls += 1
+            if call_sampler.sampler_function.__name__ == "_h3_flow_exact_probe":
+                return source_packed
+            return source_packed / (1.0 - call_sigmas[-1])
+
+    class FailingProvider:
+        api_version = 1
+        kind = "minimax_h3_learned_latent_upscaler"
+        model_name = "failing.safetensors"
+        device = "cpu"
+        precision = "fp32"
+        offload_after_upscale = False
+
+        def upscale_clean_video(self, video, *, target_h, target_w):
+            del video, target_h, target_w
+            raise RuntimeError("synthetic provider failure")
+
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(
+        trajectory=trajectory,
+        guidance=GuidanceConfig(mode="off"),
+        capture_enabled=True,
+    )
+    with pytest.raises(RuntimeError, match="synthetic provider failure"):
+        _run_progressive(
+            Executor(),
+            guider,
+            binding,
+            ProgressiveTargetInputConfig(
+                source_latent_h=4,
+                source_latent_w=4,
+                handoff_coordinate=0.3,
+                transfer_mode="learned_3d",
+                learned_upscaler=FailingProvider(),
+            ),
+            torch.randn_like(target_packed),
+            target_packed,
+            sampler,
+            sigmas,
+            None,
+            None,
+            True,
+            7,
+            list(target_shapes),
+        )
+    assert calls == 2
+    assert len(trajectory.runs) == 1
+    assert not trajectory.runs[0].complete
+    assert "synthetic provider failure" in trajectory.runs[0].abort_reason
     assert any(event.kind == "trajectory_invalidate" for event in binding.metrics.events)
 
 

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -12,6 +12,30 @@ from h3_flow_regenerate.handoff import (
 from h3_flow_regenerate.sigma import flow_shift
 
 
+class FakeLearnedProvider:
+    api_version = 1
+    kind = "minimax_h3_learned_latent_upscaler"
+    model_name = "fake.safetensors"
+    device = "cpu"
+    precision = "fp32"
+    offload_after_upscale = False
+
+    def __init__(self, output=None):
+        self.output = output
+        self.calls = []
+
+    def upscale_clean_video(self, video, *, target_h, target_w):
+        self.calls.append((video.clone(), target_h, target_w))
+        if self.output is not None:
+            return self.output
+        return torch.full(
+            (*video.shape[:-2], target_h, target_w),
+            5.0,
+            dtype=video.dtype,
+            device=video.device,
+        )
+
+
 def packed(h=4, w=4):
     video = torch.randn(1, 24, 2, h, w)
     audio = torch.randn(1, 32, 2, 7)
@@ -52,6 +76,107 @@ def test_handoff_geometry_audio_and_determinism():
     assert target_video.shape == (1, 24, 2, 8, 6)
     assert torch.equal(target_audio, audio)
     assert torch.equal(first, second)
+
+
+def test_bicubic_default_never_invokes_connected_learned_provider():
+    state, x0, shapes, _, _ = packed()
+    provider = FakeLearnedProvider()
+    build_handoff_state(
+        source_packed_state=state,
+        source_x0_packed=x0,
+        source_shapes=shapes,
+        sigma=0.4,
+        target_h=8,
+        target_w=6,
+        seed=123,
+        transfer_mode="bicubic",
+        learned_upscaler=provider,
+    )
+    assert provider.calls == []
+
+
+def test_learned_handoff_uses_exact_probe_video_once_and_preserves_audio():
+    source_video = torch.full((1, 24, 2, 4, 4), -3.0)
+    exact_x0_video = torch.full_like(source_video, 2.0)
+    audio = torch.randn(1, 32, 2, 7)
+    state, shapes = pack_streams((source_video, audio))
+    x0, _ = pack_streams((exact_x0_video, torch.full_like(audio, 99.0)))
+    provider = FakeLearnedProvider()
+    report = {}
+
+    target, target_shapes = build_handoff_state(
+        source_packed_state=state,
+        source_x0_packed=x0,
+        source_shapes=shapes,
+        sigma=0.4,
+        target_h=8,
+        target_w=6,
+        seed=123,
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        transfer_metrics=report,
+    )
+
+    target_video, target_audio = unpack_streams(target, target_shapes)
+    expected_noise = deterministic_video_noise(
+        target_video.shape,
+        seed=123,
+        device=target_video.device,
+        dtype=target_video.dtype,
+    )
+    assert len(provider.calls) == 1
+    assert torch.equal(provider.calls[0][0], exact_x0_video)
+    assert provider.calls[0][1:] == (8, 6)
+    assert torch.allclose(target_video, 0.6 * torch.full_like(target_video, 5.0) + 0.4 * expected_noise)
+    assert torch.equal(target_audio, audio)
+    assert report["transfer_mode"] == "learned_3d"
+    assert report["provider_api_version"] == 1
+    assert report["source_hw"] == (4, 4)
+    assert report["target_hw"] == (8, 6)
+    assert report["temporal_length"] == 2
+
+
+@pytest.mark.parametrize(
+    "output",
+    [
+        torch.zeros(1, 23, 2, 8, 6),
+        torch.zeros(1, 24, 3, 8, 6),
+        torch.zeros(1, 24, 2, 7, 6),
+    ],
+)
+def test_learned_handoff_rejects_wrong_provider_geometry(output):
+    state, x0, shapes, _, _ = packed()
+    with pytest.raises(RuntimeError, match="returned shape"):
+        build_handoff_state(
+            source_packed_state=state,
+            source_x0_packed=x0,
+            source_shapes=shapes,
+            sigma=0.4,
+            target_h=8,
+            target_w=6,
+            seed=123,
+            transfer_mode="learned_3d",
+            learned_upscaler=FakeLearnedProvider(output),
+        )
+
+
+def test_learned_target_input_config_requires_supported_provider_contract():
+    with pytest.raises(ValueError, match="requires a connected"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            transfer_mode="learned_3d",
+        )
+
+    incompatible = FakeLearnedProvider()
+    incompatible.api_version = 2
+    with pytest.raises(ValueError, match="provider API"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            transfer_mode="learned_3d",
+            learned_upscaler=incompatible,
+        )
 
 
 def test_cpu_rng_contract_is_retry_stable_and_seed_sensitive():

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -42,6 +42,16 @@ def test_progressive_nodes_expose_all_selectable_guidance_controls():
         assert names.index("temporal_weight") > names.index("low_frequency_cutoff")
 
 
+def test_target_input_progressive_exposes_optional_learned_handoff_without_changing_default():
+    from h3_flow_regenerate.nodes import H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff
+
+    target_schema = H3ProgressiveTargetInputHandoff.INPUT_TYPES()
+    assert target_schema["required"]["handoff_transfer"][0] == ["bicubic", "learned_3d"]
+    assert target_schema["required"]["handoff_transfer"][1]["default"] == "bicubic"
+    assert target_schema["optional"]["learned_upscaler"] == ("H3_LATENT_UPSCALER",)
+    assert "handoff_transfer" not in H3ProgressiveHandoff.INPUT_TYPES()["required"]
+
+
 def test_metrics_json_output_node_saves_unique_json_and_refreshes_after_sampler(monkeypatch, tmp_path):
     from h3_flow_regenerate.metrics import H3FlowMetrics
     from h3_flow_regenerate.nodes import H3MetricsJSON

--- a/tests/test_workflow_specs.py
+++ b/tests/test_workflow_specs.py
@@ -30,3 +30,17 @@ def test_resolution_shift_matrix_preserves_base_and_refine():
     assert matrix["topology"]["forbidden_placement"] == "H3ResolutionAwareSigmas must not feed Continuum.sigmas"
     assert matrix["runs"][0]["id"] == "E0-refine-control"
     assert matrix["runs"][1]["id"] == "E1-refine-resolution-aware"
+
+
+def test_progressive_overlay_defaults_to_bicubic_and_defines_strict_learned_ab():
+    overlay = _load("workflows/progressive-handoff.overlay.json")
+    widgets = overlay["recommended_quality_operating_point"]["widgets"]
+    experiment = overlay["learned_transfer_experiment"]
+
+    assert overlay["schema_version"] == 4
+    assert widgets["handoff_transfer"] == "bicubic"
+    assert experiment["provider_node"] == "MinimaxH3LatentUpscaler3DProvider"
+    assert experiment["control_widget"] == {"handoff_transfer": "bicubic"}
+    assert experiment["treatment_widget"] == {"handoff_transfer": "learned_3d"}
+    assert experiment["strict_d14_pair"]["only_intended_difference"] == "handoff_transfer"
+    assert experiment["strict_d14_pair"]["latent_transition"] == "46x46 -> 56x56"

--- a/tools/check_source_contracts.py
+++ b/tools/check_source_contracts.py
@@ -204,6 +204,22 @@ def main() -> None:
         "w_pixel_final, h_pixel_final = _aligned_pixel_size(",
     )
     require_symbols(
+        args.upscaler / "nodes/minimax_h3_latent_upscaler_3d.py",
+        functions=("upscale_clean_video_exact",),
+    )
+    require_symbols(
+        args.upscaler / "nodes/minimax_h3_handoff_provider.py",
+        classes=("H3LatentUpscalerProvider", "MinimaxH3LatentUpscaler3DProvider"),
+    )
+    require(
+        args.upscaler / "nodes/minimax_h3_handoff_provider.py",
+        "H3_LATENT_UPSCALER_API_VERSION = 1",
+        'H3_LATENT_UPSCALER_KIND = "minimax_h3_learned_latent_upscaler"',
+        'RETURN_TYPES = ("H3_LATENT_UPSCALER",)',
+        "def upscale_clean_video(",
+        "upscale_clean_video_exact(",
+    )
+    require_symbols(
         args.upscaler / "nodes/minimax_h3_refine.py",
         functions=(
             "_resolve_refine_contract",

--- a/workflows/progressive-handoff.overlay.json
+++ b/workflows/progressive-handoff.overlay.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": 3,
+  "schema_version": 4,
   "kind": "comfyui_workflow_overlay",
   "purpose": "Continuum-safe progressive H3 sampling: keep the workflow/session on the final grid while running the early H3 trajectory internally at a smaller video grid.",
   "placement": {
@@ -37,7 +37,8 @@
       "acceleration_weight": 0,
       "temporal_weight": 0,
       "consistency_weight": 0,
-      "low_frequency_cutoff": 0.25
+      "low_frequency_cutoff": 0.25,
+      "handoff_transfer": "bicubic"
     },
     "observed_handoff": {
       "index": 9,
@@ -59,6 +60,28 @@
       "progressive_sampler_invocations": 6,
       "progressive_history_boundaries": 4
     }
+  },
+  "learned_transfer_experiment": {
+    "status": "implementation_validated_media_pending",
+    "provider_node": "MinimaxH3LatentUpscaler3DProvider",
+    "wiring": "provider.learned_upscaler -> H3ProgressiveTargetInputHandoff.learned_upscaler",
+    "treatment_widget": {"handoff_transfer": "learned_3d"},
+    "control_widget": {"handoff_transfer": "bicubic"},
+    "strict_d14_pair": {
+      "outer_steps": 14,
+      "source_scale": 0.83,
+      "handoff_coordinate": 0.35,
+      "handoff_selection": "fixed",
+      "guidance_mode": "direction",
+      "direction_weight": 0.25,
+      "acceleration_weight": 0,
+      "temporal_weight": 0,
+      "consistency_weight": 0,
+      "low_frequency_cutoff": 0.25,
+      "latent_transition": "46x46 -> 56x56",
+      "only_intended_difference": "handoff_transfer"
+    },
+    "claims": "No quality or speed win is claimed before decoded video/audio review."
   },
   "faster_operating_points": [
     {


### PR DESCRIPTION
## Summary

- add optional `handoff_transfer=learned_3d` to **Progressive Handoff (Target Input)** while preserving `bicubic` as the compatibility default
- consume the merged API-v1 `H3_LATENT_UPSCALER` side-input provider from `xmarre/Comfyui_Minimax_h3_latent_Upscaler`
- replace only the exact-probe clean-video spatial transfer; keep the existing conditional re-noise equation and deterministic target noise
- keep caller audio outside the provider and preserve masks, target caller geometry, sigma split, sampler/Spectrum history resets, and the mandatory first high-grid actual call
- emit learned-CNN/provider/geometry/dtype/device/offload telemetry without changing H3 model-call counters
- document decoded-media validation around 1.0–1.06 MP and the observed source-scale quality floor

## Dependency

Pinned merged provider commit: `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` from `xmarre/Comfyui_Minimax_h3_latent_Upscaler#12`.

The source-contract job checks the exact helper, provider classes, API/kind constants, callable, and ComfyUI type at that exact revision.

## Insertion boundary

The provider receives the unpacked 24-channel video `x0` from the existing exact low-grid probe after H3's normal `process_latent_in` path. It returns exact target H/W. The existing target-grid deterministic Gaussian and `(1-sigma) * x0 + sigma * noise` equation then build the high-stage state. Audio is cloned from the source packed state and is structurally unavailable to the provider.

## Decoded-media validation

The original strict 46×46→56×56 D14 A/B plan was superseded by a more informative aggressive-handoff sweep around 1 MP.

- Around a `1152×864` (~0.995 MP) target, aggressive bicubic transfer from roughly a ~0.55 MP private source showed substantial body/spatial artifacts in the tested difficult prompt.
- Replacing only that exact-probe clean-state resize with `learned_3d` fixed the majority of those artifacts.
- `source_scale=0.70` resolved to `800×608 → 1152×864` and was judged excellent.
- `source_scale=0.65` resolved to `736×576 → 1152×864` and began losing reference likeness / tonal stability, so it is not promoted.
- Final higher-resolution gate: `source_scale=0.70` resolved to `52×40 → 74×56` latent geometry, i.e. `832×640 → 1184×896` (~1.061 MP target). The generated action was different, but the result was again judged very good.
- Final run preserved `38 logical / 28 actual H3 NFE / 10 Spectrum forecast` topology across two physical chunks: low `22/16/6`, exact probes `2/2/0`, high `14/10/4`.
- It also preserved 2 exact probes, 6 progressive sampler invocations, 4 history boundaries, copied audio, rebuilt target conditioning, and an actual first high-grid H3 call for both chunks.
- BF16 CUDA learned inference took ~602 ms and ~771 ms; total learned-transfer wall time was ~628 ms and ~802 ms. The CNN added zero H3 NFEs and no sampler failure occurred.

Around 1 MP, `source_scale=0.70` is the current tested quality/compute sweet spot for this prompt. `0.65` is below the observed quality floor. These are prompt-specific decoded-media results, not a universal optimum. The latest learned-transfer sweep had `direction+acceleration` active, so it is not re-labeled as direction-only evidence and does not establish an acceleration advantage.

## Automated validation

- Ruff and format check
- 142 unit/synthetic tests
- compileall
- package build and isolated wheel import
- full pinned ComfyUI/H3 sibling source-contract checker, including the merged provider commit
- regression coverage for bicubic default/no provider call; provider version/shape/T/channel validation; exact-probe input; deterministic re-noise; unchanged audio/geometry/masks/call topology/history boundaries; first-high actual anchor; no extra H3 NFE; and trajectory invalidation after provider failure

## Merge state

Provider PR #12 is merged. This PR remains one commit over current `main`; merge after the refreshed final-head CI is green.