### PR TITLE
Release v0.2.0 learned progressive handoff

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,121 @@
+name: release
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.repository }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tested commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          ref: ${{ github.event.workflow_run.head_sha }}
+
+      - name: Read package version
+        id: version
+        shell: bash
+        run: |
+          version="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.][0-9A-Za-z.-]+)?$ ]]; then
+            echo "Invalid project version: ${version}" >&2
+            exit 1
+          fi
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+          echo "tag=v${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Build release archive
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          mkdir -p dist
+          archive="MiniMax-H3-Flow-Aligned-Regenerate-v${VERSION}.zip"
+          git archive \
+            --format=zip \
+            --prefix="MiniMax-H3-Flow-Aligned-Regenerate-v${VERSION}/" \
+            --output="dist/${archive}" \
+            HEAD
+          (cd dist && sha256sum "${archive}" > SHA256SUMS)
+
+      - name: Extract current release notes
+        shell: bash
+        run: |
+          awk '/^---$/ { exit } { print }' RELEASE_NOTES.md > CURRENT_RELEASE_NOTES.md
+          test -s CURRENT_RELEASE_NOTES.md
+
+      - name: Publish or refresh GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RELEASE_SHA: ${{ github.event.workflow_run.head_sha }}
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+        shell: bash
+        run: |
+          if gh release view "${TAG}" >/dev/null 2>&1; then
+            current_main="$(gh api "repos/${GITHUB_REPOSITORY}/commits/main" --jq '.sha')"
+            if [[ "${RELEASE_SHA}" != "${current_main}" ]]; then
+              echo "Tested commit ${RELEASE_SHA} is no longer current main (${current_main}); refusing to refresh an existing release from a stale workflow run."
+              exit 0
+            fi
+
+            if ! git fetch --force --no-tags --depth=1 origin "refs/tags/${TAG}:refs/tags/${TAG}"; then
+              echo "Failed to fetch existing release tag ${TAG}; refusing to refresh release notes." >&2
+              exit 1
+            fi
+            if ! existing_target="$(git rev-parse "${TAG}^{commit}")"; then
+              echo "Failed to resolve ${TAG} to a commit; refusing to refresh release notes." >&2
+              exit 1
+            fi
+
+            if [[ "${existing_target}" != "${RELEASE_SHA}" ]]; then
+              changed_file_list="$(mktemp)"
+              if ! git diff --name-only "${existing_target}" "${RELEASE_SHA}" > "${changed_file_list}"; then
+                echo "Failed to compare existing release commit ${existing_target} with tested commit ${RELEASE_SHA}; refusing to refresh release notes." >&2
+                rm -f "${changed_file_list}"
+                exit 1
+              fi
+              mapfile -t changed_files < "${changed_file_list}"
+              rm -f "${changed_file_list}"
+
+              docs_only=true
+              for path in "${changed_files[@]}"; do
+                case "${path}" in
+                  README.md|RELEASE_NOTES.md|.github/workflows/release.yml) ;;
+                  *) docs_only=false ;;
+                esac
+              done
+
+              if [[ "${docs_only}" != "true" ]]; then
+                echo "Release ${TAG} already exists and the tested commit contains non-documentation changes; leaving the published release unchanged."
+                exit 0
+              fi
+            fi
+
+            gh release edit "${TAG}" \
+              --title "MiniMax H3 Flow-Aligned Regenerate ${TAG}" \
+              --notes-file CURRENT_RELEASE_NOTES.md
+            echo "Refreshed release notes for ${TAG}; existing tag target and assets were preserved."
+            exit 0
+          fi
+
+          gh release create "${TAG}" \
+            dist/MiniMax-H3-Flow-Aligned-Regenerate-v${VERSION}.zip \
+            dist/SHA256SUMS \
+            --target "${RELEASE_SHA}" \
+            --title "MiniMax H3 Flow-Aligned Regenerate ${TAG}" \
+            --notes-file CURRENT_RELEASE_NOTES.md

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,62 @@
+# MiniMax H3 Flow-Aligned Regenerate v0.2.0
+
+v0.2.0 adds an optional learned 3D transfer at the Progressive Target Input handoff boundary, backed by the versioned API-v1 provider from `Comfyui_Minimax_h3_latent_Upscaler`.
+
+## Learned progressive handoff
+
+- Adds `handoff_transfer=learned_3d` to **MiniMax H3 Progressive Handoff (Target Input)**.
+- Keeps `handoff_transfer=bicubic` as the compatibility default for existing workflows.
+- Consumes the API-v1 `H3_LATENT_UPSCALER` clean-video provider rather than importing sibling-node internals.
+- Replaces only the exact-probe clean-video spatial transfer. Deterministic target noise, conditional re-noising, caller audio, masks, target conditioning, sampler/Spectrum history boundaries, and the mandatory first high-grid actual H3 call remain unchanged.
+- Learned CNN work is tracked separately and does not increase H3 model-call/NFE counters.
+
+The coordinated provider is released in `Comfyui_Minimax_h3_latent_Upscaler` v0.2.0. The exact provider revision validated by this release is `bdc670e5926bcefbe4022e17fe8b171fbfcf15de`.
+
+## Decoded-media validation
+
+The learned-transfer path was validated on aggressive progressive transitions around 1 MP rather than only on synthetic shape/contract tests.
+
+- Around a `1152×864` (~0.995 MP) target, an aggressive bicubic handoff from roughly a ~0.55 MP private source showed substantial body/spatial handoff artifacts in the tested difficult prompt.
+- Replacing only that boundary with `learned_3d` fixed the majority of the observed artifacts.
+- `source_scale=0.70` resolved to `800×608 → 1152×864` and was judged excellent.
+- `source_scale=0.65` resolved to `736×576 → 1152×864` and began losing reference likeness / tonal stability, so it is not promoted.
+- The final higher-resolution gate used `source_scale=0.70` at `832×640 → 1184×896` (~1.061 MP). The generated action differed, but decoded quality was again judged very good.
+- That final run preserved `38 logical / 28 actual H3 NFE / 10 Spectrum forecast` calls across two physical chunks, with 2 exact probes, 6 progressive sampler invocations, 4 history boundaries, copied audio, rebuilt high-grid conditioning, and an actual first high-grid H3 call in both chunks.
+- BF16 CUDA learned inference took about 0.60 s and 0.77 s for the two chunks and added zero H3 NFEs.
+
+For this prompt around 1 MP, `source_scale=0.70` is the current tested quality/compute point and `0.65` is below the observed fidelity floor. These values are not claimed as universal optima.
+
+## Guidance interpretation
+
+The latest learned-transfer media sweep used `direction+acceleration`. It does not establish an acceleration advantage over direction-only. The earlier matched evidence still supports `direction` as the conservative preferred guidance mode; acceleration, temporal correspondence, downsample consistency, auto handoff, and resolution-aware refine sigmas remain experimental controls unless future matched media shows a clear benefit.
+
+## Compatibility and validation
+
+- Existing bicubic Progressive Target Input workflows retain their prior behavior.
+- Full 1-to-0 H3 sigma schedules remain required for progressive handoff.
+- CI validates Python 3.10–3.13, Ruff and formatting, 142 unit/synthetic tests, `compileall`, package build, isolated wheel import, and pinned native/sibling source contracts.
+- The source-contract gate pins the merged learned-provider revision and checks its API/kind constants, helper, provider classes, callable surface, and ComfyUI type.
+
+---
+
+# MiniMax H3 Flow-Aligned Regenerate v0.1.0
+
+Initial public release of MiniMax H3 Flow-Aligned Regenerate.
+
+## Highlights
+
+- H3-native low-resolution trajectory capture and time-aligned high-resolution guidance.
+- Progressive Target Input handoff for Continuum: early H3 sampling can run on a private lower-resolution grid before switching to the final grid without a separate learned-refine replay.
+- Integrated Continuum refine-state guidance for the existing MiniMax H3 Latent Upscaler + Refine path.
+- Experimental resolution-aware refine sigmas, temporal correspondence, acceleration, downsample consistency, reference-budget diagnostics, and attention diagnostics.
+- Runtime metrics distinguish logical sampler calls, actual H3 NFEs, Spectrum forecasts, handoff probes, guidance events, and resolution-map events.
+
+## Tested operating point
+
+The strongest matched difficult-motion result tested during v0.1.0 development used 14 SA-Solver-PECE outer steps, a 736×736 private source to 896×896 target, `source_scale=0.83`, fixed handoff 0.35, direction guidance 0.25, and 54 logical / 36 actual H3 NFE / 18 Spectrum forecast calls across two chunks.
+
+D12 was judged better than D10, and D14 slightly better again. These are tested quality/speed tradeoffs, not universal optima.
+
+## Scope
+
+This project is an independent, training-free research implementation informed by public work. It does not reproduce MiniMax's closed H3-Regenerate-2K model or unreleased sparse-attention topology. Decoded media remains the quality gate.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "comfyui-minimax-h3-flow-aligned-regenerate"
-version = "0.1.0"
+version = "0.2.0"
 description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- bump `MiniMax-H3-Flow-Aligned-Regenerate` from `0.1.0` to `0.2.0`
- add release notes for the learned 3D Progressive Target Input handoff and the completed decoded-media gate
- add a permanent CI-gated GitHub release workflow that publishes a source archive plus `SHA256SUMS` and only the current release-note section

## Release scope

v0.2.0 is the coordinated feature release for `handoff_transfer=learned_3d`. `bicubic` remains the compatibility default. The release preserves the exact-probe/re-noise/audio/mask/history/first-high-actual invariants established in #11.

The notes record the tested ~1.0–1.06 MP learned-transfer results and explicitly keep `source_scale=0.70` / `0.65` as prompt-specific evidence rather than universal defaults. The latest learned sweep used `direction+acceleration`; it is not used to claim an acceleration advantage over direction-only.

## Dependency/order

Release the companion `Comfyui_Minimax_h3_latent_Upscaler` v0.2.0 first. This release pins its validated API-v1 provider revision `bdc670e5926bcefbe4022e17fe8b171fbfcf15de`.

## Release automation

After merge, a successful `CI` push run on `main` will create `v0.2.0`, attach `MiniMax-H3-Flow-Aligned-Regenerate-v0.2.0.zip` and `SHA256SUMS`, and use the v0.2.0 section of `RELEASE_NOTES.md`. Existing-tag refreshes are fenced against stale workflow runs and non-documentation changes.

## Topology

One commit over current `main` (`cc5cc9441082c1b29ef9f2d8a265d162094c9214`).