### PR TITLE
Release v0.2.1 with CI-gated Comfy Registry publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,61 @@
+name: Publish to Comfy registry
+
+on:
+  workflow_dispatch:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: registry-${{ github.repository }}-${{ github.event.workflow_run.head_sha || github.sha }}
+  cancel-in-progress: false
+
+jobs:
+  publish-node:
+    name: Publish Custom Node to registry
+    if: >-
+      github.repository_owner == 'xmarre' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.event == 'push' &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out tested commit
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+          fetch-depth: 2
+          ref: ${{ github.event.workflow_run.head_sha || github.sha }}
+
+      - name: Check whether package version changed
+        id: version
+        if: ${{ github.event_name == 'workflow_run' }}
+        shell: bash
+        run: |
+          current="$(python -c 'import pathlib, tomllib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          previous=""
+          if git cat-file -e 'HEAD^:pyproject.toml' 2>/dev/null; then
+            previous="$(git show 'HEAD^:pyproject.toml' | python -c 'import sys, tomllib; print(tomllib.loads(sys.stdin.read())["project"]["version"])')"
+          fi
+
+          echo "current=${current}"
+          echo "previous=${previous:-<none>}"
+          if [[ "${current}" == "${previous}" ]]; then
+            echo "version_changed=false" >> "${GITHUB_OUTPUT}"
+          else
+            echo "version_changed=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Publish Custom Node
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.version.outputs.version_changed == 'true' }}
+        uses: Comfy-Org/publish-node-action@0eb6cd742945443bee7f79eeddd4f732780029a1 # v1
+        with:
+          personal_access_token: ${{ secrets.REGISTRY_ACCESS_TOKEN }}

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,25 @@
+# MiniMax H3 Flow-Aligned Regenerate v0.2.1
+
+v0.2.1 adds CI-gated Comfy Registry publication. Runtime and sampling behavior are unchanged from v0.2.0.
+
+## Distribution
+
+- Adds a dedicated **Publish to Comfy registry** workflow using the pinned `Comfy-Org/publish-node-action` v1 revision already used by the companion MiniMax H3 latent-upscaler release path.
+- Registry publication runs only after a successful `CI` push run on `main` and only when the tested commit changes the package version relative to its first parent.
+- Manual `workflow_dispatch` remains available for explicit operator-controlled publication/retry.
+- The workflow checks out the exact CI-tested commit, uses read-only repository permissions and non-persistent checkout credentials, and consumes `REGISTRY_ACCESS_TOKEN` only in the publish step.
+- Publication is serialized per tested commit so overlapping workflow-run/manual attempts are not cancelled mid-publish.
+
+## Versioning
+
+The package version is bumped to `0.2.1` rather than republishing `0.2.0` from a different source commit. This keeps the GitHub release/tag and Comfy Registry package version aligned to the same source revision.
+
+## Compatibility
+
+No Python runtime, sampler, handoff, guidance, Continuum, Spectrum, metrics, or learned-upscaler integration code changes are included in v0.2.1.
+
+---
+
 # MiniMax H3 Flow-Aligned Regenerate v0.2.0
 
 v0.2.0 adds an optional learned 3D transfer at the Progressive Target Input handoff boundary, backed by the versioned API-v1 provider from `Comfyui_Minimax_h3_latent_Upscaler`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "comfyui-minimax-h3-flow-aligned-regenerate"
-version = "0.2.0"
+version = "0.2.1"
 description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

- add a dedicated Comfy Registry publication workflow using the pinned `Comfy-Org/publish-node-action` v1 revision already used by the companion latent-upscaler repository
- gate automatic registry publication on a successful `CI` push run on `main` and an actual package-version change in the tested commit
- keep explicit `workflow_dispatch` for operator-controlled publication/retry
- bump the package to `0.2.1` and add release notes; runtime/sampling code is unchanged

## Why v0.2.1

The existing GitHub `v0.2.0` release is already immutable at `8d9e7e3fdeff197820566ae55921eb17bd6d62e9`. Publishing registry `0.2.0` from a new commit would make the same version identify different source trees. This PR therefore publishes the registry-enabled tree as `0.2.1`, keeping the GitHub tag/release and Comfy Registry version aligned to the same source revision.

## Publication invariants

Automatic publication only runs when all of the following are true:

- the upstream `CI` workflow completed successfully
- that CI run was a `push` run on `main`
- the exact tested commit changes `[project].version` relative to its first parent

The publish job checks out `workflow_run.head_sha`, uses `contents: read`, disables persisted checkout credentials, serializes attempts per tested commit, and passes only `REGISTRY_ACCESS_TOKEN` to the pinned publish action. Manual dispatch remains available and intentionally bypasses the version-delta check.

## Release behavior

After merge, the `0.2.1` version bump will cause the normal CI-gated GitHub release workflow to create `v0.2.1`. The new registry workflow will independently consume the same successful CI run and publish `0.2.1` to the Comfy Registry.

## Topology

One commit over current `main` (`8d9e7e3fdeff197820566ae55921eb17bd6d62e9`).