### PR TITLE
Document proper two-pass vs progressive learned-handoff performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,16 @@ The implementation, guards, instrumentation, workflow specifications, and synthe
 
 - **Integrated two-pass flow guidance:** C7=7+7, C6=7+6, C5=7+5, and exploratory C4=7+4 all completed acceptable difficult-motion smokes. This path remains useful when keeping the learned latent upscaler/refiner.
 - **Progressive Target Input:** the accepted D10 direction-only run validated the Continuum-safe split topology and restored quality to roughly baseline level after the earlier under-budgeted 7-step progressive attempt.
-- **Step-budget sweep:** on the later matched square difficult-motion setup (736x736 private source -> 896x896 target), direction-only improved perceptually from 10 -> 12 -> 14 SA-Solver-PECE outer steps. The 14-step run is the current tested quality operating point.
+- **Step-budget sweep:** on the later matched square difficult-motion setup (736x736 private source -> 896x896 target), direction-only improved perceptually from 10 -> 12 -> 14 SA-Solver-PECE outer steps. The 14-step run is the current tested direction-only quality operating point.
 - **14-step topology:** fixed handoff 0.35 snapped to unshifted coordinate ~0.358 / index 9, giving 54 logical calls, 36 actual H3 NFEs, and 18 Spectrum forecasts across two chunks. The split is effectively 9 low-grid + 5 high-grid outer steps per chunk.
+- **Learned handoff around 1 MP:** `source_scale=0.70` at 10 progressive outer steps was decoded-media positive through ~1.061 MP. In the final run, 832x640 -> 1184x896 completed in 621.63 s end-to-end with 38 logical / 28 actual H3 NFE / 10 Spectrum forecast calls. Against the historical proper 960x704 -> 1184x864 two-pass 7+6 upscale/refine workflow at ~777 s, this is an observed ~20% end-to-end wall-time reduction while producing ~3.7% more final pixels. This is a workflow-level reference, not a formal matched A/B.
 - **Auto handoff:** functional. On the matched 46x46 -> 56x56 latent setup, `auto_compute` selected 0.2875 and snapped to ~0.30/index 7, reallocating work toward the low grid. Media changed but showed no clear quality advantage over fixed 0.35.
 - **Downsample consistency:** functional at weight 0.25 and produced measurable latent corrections, but no meaningful decoded-media improvement. Do not prefer it over direction guidance from current evidence.
 - **HiFlow-style acceleration:** corrected PECE semantics are validated, but the decoded-media result is neutral/inconclusive for the fast-motion clothing/newly revealed background artifact class.
 - **Temporal correspondence:** the final matched 14-step standard-VAE `direction+temporal` run was perceptually indistinguishable from 14-step direction-only. The matcher was active but extremely sparse, so temporal remains experimental and is not promoted.
 - **Resolution-aware refine SIGMAS:** matched E0/E1 learned-refine runs completed. The mapping worked structurally, but E1 showed no relevant quality improvement over the exact-identity control. Keep this mode off/experimental.
 
-The current practical recommendation from the tested difficult-motion workflow is therefore:
+The conservative direction-only quality-sweep reference is therefore:
 
 ```text
 outer_steps = 14
@@ -43,7 +44,7 @@ consistency_weight = 0
 low_frequency_cutoff = 0.25
 ```
 
-This is a **tested operating point**, not a universal optimum. For lower latency, 10 or 12 outer steps remain valid operating points; 12 was already perceptually better than 10 in the matched quality sweep.
+This is a **tested operating point**, not a universal optimum. For lower latency, 10 or 12 outer steps remain valid operating points; 12 was already perceptually better than 10 in the matched direction-only quality sweep. The learned `learned_3d` path has a separate tested quality/compute point around 1 MP at 10 outer steps and `source_scale=0.70`, documented below; those latest learned runs used `direction+acceleration` and therefore do not replace the conservative direction-only guidance recommendation.
 
 ## Install
 
@@ -64,7 +65,7 @@ Restart ComfyUI. PyTorch is supplied by ComfyUI. Sibling custom nodes are not im
 | MiniMax H3 Flow-Aligned Regenerate | Time-matched low-frequency guidance for an explicit second pass | Direction is conservative default |
 | MiniMax H3 Flow-Aligned Refine State | Patches Continuum V3.4 per-chunk refine state for integrated learned refinement | Direction is conservative default |
 | MiniMax H3 Progressive Handoff | Source-grid sampler input grows to target grid during one schedule | Experimental |
-| MiniMax H3 Progressive Handoff (Target Input) | Continuum-safe target-sized topology with a private low-grid early stage; optional learned 3D clean-state transfer | Bicubic validated; learned transfer experimental |
+| MiniMax H3 Progressive Handoff (Target Input) | Continuum-safe target-sized topology with a private low-grid early stage; optional learned 3D clean-state transfer | Bicubic compatibility path; learned transfer decoded-media validated / experimental |
 | MiniMax H3 Refine Target Geometry | Mirrors downstream learned-refine target sizing for sigma experiments | Experimental |
 | MiniMax H3 Resolution-Aware Sigmas | Relative H3-native resolution/time remap | Off / experimental |
 | MiniMax H3 Reference Budget | Direct-reference row diagnostics/cap | Native |
@@ -106,6 +107,32 @@ resolved 832×640→1184×896 (~1.061 MP target); the generated action was diffe
 again judged very good. Its two BF16 CUDA learned calls took about 0.60 s and 0.77 s and added zero H3
 NFEs. These latest learned-transfer media runs used `direction+acceleration`; they are not evidence for
 promoting acceleration over direction-only.
+
+### Observed performance versus proper two-pass upscale + refine
+
+The useful legacy comparison is the established **7 first-pass + 6 learned-refine outer-step** workflow,
+not the old 3-step high-ratio refine experiments. At nominal 0.7 MP, that proper two-pass path resolved
+approximately 960×704 (0.676 MP) -> 1184×864 (1.023 MP) and took about 777 s end-to-end in the observed
+run. The historical full-quality setup was 7+7; no equally clean ~1 MP raw timing has been recovered for
+that exact 7+7 case, so no larger speedup is claimed from it.
+
+| Path | Base/private grid | Final grid | Sampling structure | Observed full workflow |
+|---|---:|---:|---|---:|
+| Proper two-pass upscale + refine | 960×704 (0.676 MP) | 1184×864 (1.023 MP) | 7 base + 6 learned-refine outer steps | ~777 s (~12:57) |
+| Progressive + `learned_3d` | 832×640 (0.532 MP) | 1184×896 (1.061 MP) | 10 progressive outer steps; 38 logical / 28 actual / 10 forecast | 621.63 s (10:21.6) |
+
+Relative to that proper 6-step-refine baseline, the progressive learned-handoff run used ~21.2% fewer
+private/source pixels, produced ~3.7% more final pixels, and saved about 155 s end-to-end: roughly a
+**20% wall-time reduction / 1.25× observed workflow speedup**. The learned CNN itself was not the source
+of the saving: its two calls totaled only ~1.37 s of inference (~1.43 s including transfer bookkeeping)
+and added zero H3 NFEs. The saving comes from performing more of the trajectory on the cheaper private
+grid and avoiding a complete second low-sigma H3 refine pass.
+
+This timing comparison is a practical observed-workflow reference rather than a controlled same-seed
+microbenchmark. The old and new runs differ slightly in final geometry and were recorded at different
+points in development, so use the ~20% figure as measured evidence for this workflow, not a universal
+speed claim or a quality-superiority percentage. See [docs/PERFORMANCE.md](docs/PERFORMANCE.md) for the
+full accounting and caveats.
 
 For roughly 1 MP targets, `0.70` is therefore the current tested quality/compute sweet spot for this
 prompt, not a universal optimum. `0.65` is below the current useful quality floor in this case, while
@@ -210,7 +237,7 @@ Runtime events distinguish:
 - sampler/stage wall time;
 - resolution sigma maps and fallbacks.
 
-Use [docs/BENCHMARKS.md](docs/BENCHMARKS.md) and [workflows/benchmark-matrix.json](workflows/benchmark-matrix.json) for the evidence ledger and the broader optional formal matrix. Decoded video and audio remain the pass/fail criterion.
+Use [docs/BENCHMARKS.md](docs/BENCHMARKS.md), [docs/PERFORMANCE.md](docs/PERFORMANCE.md), and [workflows/benchmark-matrix.json](workflows/benchmark-matrix.json) for the evidence ledger, observed timing accounting, and the broader optional formal matrix. Decoded video and audio remain the pass/fail criterion.
 
 ## Compatibility
 
@@ -231,7 +258,7 @@ Pinned executable/source contracts:
 - DiffAid `ba9d9efbcf7e64c755e068cb76547d8cc85481eb`
 - RefDelta `034e4c4c14c56bf76813cee4765e7164b0c7e0db`
 - Untwisting RoPE `299d4c56a3f057a97b3140d2136189bcd1e7d6bb`
-- H3 latent upscaler/refine and learned-handoff provider `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` (draft provider PR #12)
+- H3 latent upscaler/refine and learned-handoff provider `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` (merged provider revision; released by companion v0.2.0)
 
 MiniMax-H3 main was additionally inspected at `d21241f0a4b3acbb34c97dae47fa417b7065e438`.
 
@@ -246,12 +273,13 @@ python -m compileall -q .
 python -m build
 ```
 
-See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/RESEARCH.md](docs/RESEARCH.md), and [docs/BENCHMARKS.md](docs/BENCHMARKS.md).
+See [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/RESEARCH.md](docs/RESEARCH.md), [docs/BENCHMARKS.md](docs/BENCHMARKS.md), and [docs/PERFORMANCE.md](docs/PERFORMANCE.md).
 
 ## Limitations
 
 - The current quality recommendation comes from a limited difficult-motion workflow and is not a broad cross-prompt benchmark claim.
 - The 14-step quality sweep used the later matched square 736x736 -> 896x896 progressive setup; the earlier rectangular D10 reference remains a separate validated topology case.
+- The ~20% observed end-to-end timing reduction is against the proper historical 7+6 two-pass workflow at similar final resolution; it is not a formal same-seed benchmark and must not be generalized to every prompt, target MP, model residency state, or reference budget.
 - The progressive exact handoff probe costs one visible H3 NFE per chunk.
 - Target Input derives private low-grid **video** noise from a documented standard-Gaussian CPU generator keyed by graph seed; arbitrary custom/non-Gaussian private-grid video-noise semantics cannot be preserved.
 - Progressive handoff rejects sampler objects with an explicit external `noise_sampler` closure because mutable RNG/history cannot safely cross the geometry reset.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,129 @@
+# Performance evidence: progressive learned handoff vs two-pass upscale + refine
+
+## Evidence status
+
+This document records the current **observed workflow-level timing reference** around a ~1 MP final target. It is not a formal same-seed microbenchmark and it is not a universal speed claim.
+
+The useful legacy baseline is the established proper learned upscale + H3 refine workflow:
+
+- 7 first-pass SA-Solver-PECE outer steps;
+- 6 learned-refine outer steps for the accepted practical baseline;
+- denoise around 0.25;
+- audio locked during the spatial refine;
+- historical full-quality baseline: 7 + 7 outer steps.
+
+Old 3-step high-ratio refine experiments are excluded from performance claims because three refine steps were a legacy under-refined setting and are not a quality-equivalent comparison.
+
+## Compared runs
+
+### Historical proper two-pass baseline
+
+At the higher nominal 0.7 MP setting, the recorded workflow resolved approximately:
+
+```text
+base/source: 960 x 704 = 0.675840 MP
+final:       1184 x 864 = 1.022976 MP
+sampling:    7 base + 6 learned-refine outer steps
+workflow:    ~777 s end-to-end (~12:57)
+```
+
+This is the proper 6-step-refine baseline used for the timing comparison. The historical 7+7 workflow remains the fuller refine budget, but an equally clean ~1 MP raw timing for that exact case has not been recovered, so no exact 7+7 speedup is claimed.
+
+### Progressive learned-handoff final gate
+
+The final learned-transfer gate resolved:
+
+```text
+private/source: 832 x 640 = 0.532480 MP
+final:          1184 x 896 = 1.060864 MP
+source_scale:   0.70
+outer_steps:    10 SA-Solver-PECE
+handoff:        fixed 0.35 -> index 6
+coordinate:     ~0.400000016
+sigma:          ~0.888888896
+transfer:       learned_3d
+workflow:       621.63 s end-to-end (10:21.6)
+Continuum node: 573.90 s
+sampler walls:  239.935 s + 319.949 s = 559.884 s
+```
+
+The decoded video was different in action/content from earlier runs but was judged very good. The run used `direction+acceleration`; this does **not** establish an acceleration advantage over direction-only.
+
+Exact H3/Spectrum telemetry across the two physical chunks:
+
+| Stage | Logical calls | Actual H3 NFEs | Spectrum forecasts |
+|---|---:|---:|---:|
+| Low/private | 22 | 16 | 6 |
+| Exact probes | 2 | 2 | 0 |
+| High/final | 14 | 10 | 4 |
+| **Total** | **38** | **28** | **10** |
+
+The run also recorded 6 progressive sampler invocations, 4 history boundaries, copied audio, rebuilt high-grid conditioning, and an actual first high-grid H3 call in both chunks.
+
+## Observed wall-time comparison
+
+| Path | Base/private grid | Final grid | Sampling structure | Full workflow |
+|---|---:|---:|---|---:|
+| Proper two-pass upscale + refine | 960×704 (0.676 MP) | 1184×864 (1.023 MP) | 7 base + 6 refine | ~777 s |
+| Progressive + `learned_3d` | 832×640 (0.532 MP) | 1184×896 (1.061 MP) | 10 progressive outer steps | 621.63 s |
+
+Derived from the actual resolved geometries and observed wall times:
+
+- private/source area: 0.675840 -> 0.532480 MP, **21.2% fewer source pixels**;
+- final area: 1.022976 -> 1.060864 MP, **3.7% more final pixels**;
+- end-to-end wall time: ~777 -> 621.63 s, about **155 s saved**;
+- observed reduction: approximately **20% less end-to-end wall time**;
+- equivalent observed speedup: approximately **1.25x**.
+
+The final output is therefore slightly larger, not smaller, despite the lower total observed wall time.
+
+## Learned-transfer overhead
+
+The learned 3D CNN itself is not responsible for the speedup. Its measured BF16 CUDA costs were:
+
+```text
+chunk 1 learned inference: 602.1 ms
+chunk 2 learned inference: 771.1 ms
+sum learned inference:     ~1.373 s
+
+chunk 1 transfer wall:     627.8 ms
+chunk 2 transfer wall:     801.9 ms
+sum transfer wall:         ~1.430 s
+```
+
+It added **zero H3 NFEs**.
+
+The architectural saving comes from carrying one progressive trajectory across the spatial handoff: more H3 work remains on the cheaper private grid, then the sampler performs only the required exact probe/high-grid continuation instead of finishing a complete low-resolution generation and launching a separate low-sigma H3 refine pass.
+
+## Model-call accounting relative to the old 7+6 path
+
+The ~777 s historical run predates the current combined metrics artifact, so its total H3 call accounting is reconstructed from the validated SA-Solver-PECE budgets rather than claimed as direct telemetry from that exact log:
+
+- 7-step base: later validated telemetry shows 9 actual + 4 Spectrum forecast calls per physical chunk (13 logical);
+- 6-step refine: the established baseline contract is 11 logical calls per chunk, approximately 7 actual + 4 Spectrum forecasts;
+- across two physical chunks, that reconstructs approximately **48 logical / 32 actual / 16 forecast** calls for a 7+6 two-pass workflow;
+- the new progressive learned run directly measured **38 logical / 28 actual / 10 forecast**.
+
+At target resolution specifically, the old 6-step refine budget implies about 14 actual H3 evaluations across two chunks. The progressive run directly measured 10 high-stage actual evaluations plus 2 exact target-grid probes = 12 target-resolution actual H3 evaluations. Treat the old totals as reconstructed accounting, not as exact counters from the ~777 s run.
+
+## Excluded comparisons
+
+Do not use the old ~1.75x / 3-step refine experiments as the headline baseline. They can be useful for implementation archaeology, but three refine steps are not enough for the established quality target and make the progressive path look artificially expensive.
+
+Likewise, the repeated ~0.6 MP -> ~0.79 MP two-pass runs around 544-546 s are useful scaling context but are not directly comparable to the ~1.06 MP final progressive gate because their final target is substantially smaller.
+
+## Interpretation and limits
+
+The defensible statement is:
+
+> In the observed ~1 MP workflow, the 10-step progressive learned-handoff path completed in 621.63 s versus about 777 s for the proper historical 7+6 two-pass upscale/refine workflow, an observed ~20% end-to-end wall-time reduction while producing ~3.7% more final pixels.
+
+Do **not** turn this into:
+
+- a universal 20% speedup claim;
+- a claim that progressive output is universally higher quality;
+- a matched-A/B quality percentage;
+- an exact speedup over the historical 7+7 workflow without a comparable raw timing;
+- evidence that acceleration guidance is better.
+
+Runtime depends on target geometry, private/source geometry, reference-conditioning load, model residency/loading, VAE/decode cost, sampler/Spectrum policy, chunk lengths, and hardware state. Decoded media remains the quality gate.


### PR DESCRIPTION
## Summary

- document the proper historical two-pass performance baseline as **7 first-pass + 6 learned-refine outer steps**, explicitly excluding legacy 3-step refine experiments from quality-equivalent comparisons
- add the final ~1.061 MP progressive `learned_3d` timing/topology and a conservative observed wall-time comparison against the ~1.023 MP two-pass run
- add `docs/PERFORMANCE.md` with the full accounting, reconstructed old call-budget caveat, learned-transfer overhead, exclusions, and claim limits
- clarify the README distinction between the 14-step direction-only quality-sweep reference and the separate 10-step / `source_scale=0.70` learned-handoff quality/compute point
- fix the stale provider wording now that the companion provider revision is merged/released

## Measured comparison

Historical proper two-pass reference:
- 960×704 base (~0.676 MP) -> 1184×864 (~1.023 MP)
- 7 base + 6 learned-refine SA-Solver-PECE outer steps
- ~777 s observed end-to-end

Final progressive learned-handoff gate:
- 832×640 private source (~0.532 MP) -> 1184×896 (~1.061 MP)
- 10 progressive SA-Solver-PECE outer steps
- 38 logical / 28 actual H3 NFE / 10 Spectrum forecast calls
- 621.63 s end-to-end
- learned CNN inference ~1.37 s total / transfer wall ~1.43 s total, zero added H3 NFE

Derived workflow-level result: about **155 s saved / ~20% lower end-to-end wall time / ~1.25× observed speedup**, while final area is ~3.7% larger. This is explicitly documented as an observed workflow reference, not a formal same-seed benchmark or universal speed claim.

## Guardrails

- no performance claim is based on the old 3-step high-ratio refine runs
- no exact speedup is claimed for the historical 7+7 full-quality workflow because a clean comparable ~1 MP raw timing has not been recovered
- old 7+6 call totals are marked as reconstructed from validated SA-Solver-PECE budgets rather than direct counters from the ~777 s log
- latest learned-handoff media used `direction+acceleration`; the timing result is not used to promote acceleration over direction-only
- no runtime/sampling implementation changes

## Topology

One commit over current `main` (`1b7bcbf8e22b51f0301be29908153197d7229401`), changing only `README.md` and `docs/PERFORMANCE.md`.