### PR TITLE
Refocus README and split detailed documentation

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -240,7 +240,7 @@ These are executable/source contracts rather than merely conceptual citations.
 
 Those projects are not vendored by this Flow package. The actual runtime dependency boundary is the companion `H3_LATENT_UPSCALER` provider API; upstream model/code licenses remain their own.
 
-The exact executable revisions pinned by CI are listed in `README.md` and `docs/RESEARCH.md`.
+The exact executable revisions pinned by CI are listed in `docs/DEVELOPMENT.md` and `docs/RESEARCH.md`.
 
 ## Research implementation revisions audited
 

--- a/README.md
+++ b/README.md
@@ -1,56 +1,64 @@
 # MiniMax H3 Flow-Aligned Regenerate
 
-Research-grade ComfyUI nodes for H3-native coarse-to-fine generation: transactional low-resolution trajectory capture, time-aligned high-resolution guidance, and an in-flight spatial-resolution handoff.
+Training-free ComfyUI nodes for reusing low-resolution MiniMax H3 generation structure while moving toward a higher-resolution result.
+
+The project has two main goals:
+
+- **guide a high-resolution/refine pass with the actual low-resolution H3 denoising trajectory**, instead of treating the low-resolution result as only a final latent;
+- **move from a smaller video grid to the final grid inside one sampling schedule**, so more H3 work can happen at the cheaper resolution before the expensive high-resolution stage begins.
+
+Native H3 generation directly on the final high-resolution grid can be more expensive and, depending on the workflow, less robust than generating smaller and refining after a learned latent upscale. The ordinary upscale/refine approach solves that by starting a second H3 sampling pass. These nodes explore two alternatives: make that second pass reuse the first pass's trajectory, or avoid a complete second pass by carrying one trajectory across a controlled spatial-resolution handoff.
 
 > [!IMPORTANT]
-> This project is an independent, training-free approximation informed by public research. It does **not** reproduce MiniMax's closed H3-Regenerate-2K model or its unreleased sparse-attention topology. Decoded media, not latent telemetry alone, is the quality gate.
+> This is an independent research implementation informed by public work. It does **not** reproduce MiniMax's closed H3-Regenerate-2K implementation or its unreleased sparse-attention topology.
 
-## Research lineage and credits
+Full node-by-node research and implementation attribution is in [CREDITS.md](CREDITS.md).
 
-This repository builds on published ideas rather than presenting flow-aligned guidance, mixed-resolution sampling, temporal correspondence, or high-resolution attention research as original inventions. **HiFlow** is the primary credit for trajectory/direction/acceleration alignment; **FrescoDiffusion** for a low-resolution video trajectory as a high-resolution prior; **RALU**, **Self-Cascade**, **CineScale**, and **Just-in-Time** for coarse-to-fine / spatial-transition reasoning; **simple diffusion** and **Scaling Rectified Flow Transformers** for resolution-dependent schedule research; and **FreeSwim**, **HRDiT**, and **ResDiT** for high-resolution DiT attention/receptive-field analysis. Temporal correspondence experiments additionally draw on **TokenFlow**, **FRESCO**, **MoVideo**, **Upscale-A-Video**, and **LatentWarp**.
+## What the nodes do
 
-See **[CREDITS.md](CREDITS.md)** for node-by-node attribution, paper authors, official paper/project/code links, inspected research-code commit snapshots, licensing notes, and the exact boundary between published methods and this H3-specific implementation. [docs/RESEARCH.md](docs/RESEARCH.md) records the corresponding transfer assumptions and experimental outcomes.
+### 1. Flow-aligned second-pass guidance
 
-## Why this exists
-
-Native H3 generation at the final high-resolution grid can be weaker than a lower-resolution generation followed by learned latent upscale/refinement, but the latter repeats part of the denoising trajectory. This repository tests whether H3 can reuse low-resolution trajectory information or change spatial resolution during one schedule without paying for a full second pass.
-
-H3 is treated as its actual joint AV model: 24-channel video, 32-channel two-track audio, 16x spatial VAE compression, a `(1, 2, 2)` DiT patch, video/audio flow shifts 12/3, and a packed `text | conditioning/reference | audio | video` transformer sequence.
-
-## Status
-
-The implementation, guards, instrumentation, workflow specifications, and synthetic test suite are complete. Real decoded-media validation has now covered the integrated two-pass path and the important public Progressive Target Input settings.
-
-### Validated media results
-
-- **Integrated two-pass flow guidance:** C7=7+7, C6=7+6, C5=7+5, and exploratory C4=7+4 all completed acceptable difficult-motion smokes. This path remains useful when keeping the learned latent upscaler/refiner.
-- **Progressive Target Input:** the accepted D10 direction-only run validated the Continuum-safe split topology and restored quality to roughly baseline level after the earlier under-budgeted 7-step progressive attempt.
-- **Step-budget sweep:** on the later matched square difficult-motion setup (736x736 private source -> 896x896 target), direction-only improved perceptually from 10 -> 12 -> 14 SA-Solver-PECE outer steps. The 14-step run is the current tested direction-only quality operating point.
-- **14-step topology:** fixed handoff 0.35 snapped to unshifted coordinate ~0.358 / index 9, giving 54 logical calls, 36 actual H3 NFEs, and 18 Spectrum forecasts across two chunks. The split is effectively 9 low-grid + 5 high-grid outer steps per chunk.
-- **Learned handoff around 1 MP:** `source_scale=0.70` at 10 progressive outer steps was decoded-media positive through ~1.061 MP. In the final run, 832x640 -> 1184x896 completed in 621.63 s end-to-end with 38 logical / 28 actual H3 NFE / 10 Spectrum forecast calls. Against the historical proper 960x704 -> 1184x864 two-pass 7+6 upscale/refine workflow at ~777 s, this is an observed ~20% end-to-end wall-time reduction while producing ~3.7% more final pixels. This is a workflow-level reference, not a formal matched A/B.
-- **Auto handoff:** functional. On the matched 46x46 -> 56x56 latent setup, `auto_compute` selected 0.2875 and snapped to ~0.30/index 7, reallocating work toward the low grid. Media changed but showed no clear quality advantage over fixed 0.35.
-- **Downsample consistency:** functional at weight 0.25 and produced measurable latent corrections, but no meaningful decoded-media improvement. Do not prefer it over direction guidance from current evidence.
-- **HiFlow-style acceleration:** corrected PECE semantics are validated, but the decoded-media result is neutral/inconclusive for the fast-motion clothing/newly revealed background artifact class.
-- **Temporal correspondence:** the final matched 14-step standard-VAE `direction+temporal` run was perceptually indistinguishable from 14-step direction-only. The matcher was active but extremely sparse, so temporal remains experimental and is not promoted.
-- **Resolution-aware refine SIGMAS:** matched E0/E1 learned-refine runs completed. The mapping worked structurally, but E1 showed no relevant quality improvement over the exact-identity control. Keep this mode off/experimental.
-
-The conservative direction-only quality-sweep reference is therefore:
+The low-resolution H3 pass is captured as a time-indexed trajectory. A later high-resolution or learned-refine pass can then be guided toward the matching low-resolution predicted-clean state at the same flow coordinate.
 
 ```text
-outer_steps = 14
-source_mode = scale
-source_scale = 0.83
-handoff_selection = fixed
-handoff_coordinate = 0.35
-guidance_mode = direction
-direction_weight = 0.25
-acceleration_weight = 0
-temporal_weight = 0
-consistency_weight = 0
-low_frequency_cutoff = 0.25
+low-resolution H3
+      |
+      +-> Trajectory Capture -> H3_FLOW_TRAJECTORY
+                                  |
+learned upscale / refine input ---+
+                                  |
+                         Flow-Aligned Regenerate
+                                  |
+                         high-resolution H3
 ```
 
-This is a **tested operating point**, not a universal optimum. For lower latency, 10 or 12 outer steps remain valid operating points; 12 was already perceptually better than 10 in the matched direction-only quality sweep. The learned `learned_3d` path has a separate tested quality/compute point around 1 MP at 10 outer steps and `source_scale=0.70`, documented below; those latest learned runs used `direction+acceleration` and therefore do not replace the conservative direction-only guidance recommendation.
+This keeps the existing two-pass workflow, but lets the second H3 pass reuse information from the full first-pass trajectory rather than only the upscaled endpoint.
+
+For H3 Continuum refinement, **Flow-Aligned Refine State** applies the same guidance directly to each Continuum `refine_state`.
+
+### 2. Progressive resolution handoff
+
+The progressive nodes keep early denoising on a smaller video grid and switch to the target grid later in the same schedule.
+
+```text
+early schedule                     late schedule
+
+private/source grid  ------------>  target grid
+        H3            handoff           H3
+```
+
+The handoff is not a blind resize of noisy state. The wrapper performs an exact low-grid probe, transfers the predicted-clean video state, reconstructs the target-grid conditional state, resets sampler/forecast histories that cannot safely cross the geometry change, and continues sampling at the final resolution.
+
+For **Continuum**, use **MiniMax H3 Progressive Handoff (Target Input)**. Continuum stays configured for the final target size while the node privately runs the early stage on a smaller video grid.
+
+### 3. Optional learned handoff
+
+**Progressive Handoff (Target Input)** supports:
+
+- `bicubic` — built-in compatibility path;
+- `learned_3d` — one learned clean-video spatial transfer using the companion [MiniMax H3 Latent Upscaler](https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler).
+
+The learned provider replaces only the clean-video spatial transfer at the handoff. It does not add a second H3 sampling pass, does not spatially transform audio, and adds no H3 transformer NFE by itself.
 
 ## Install
 
@@ -60,238 +68,124 @@ From `ComfyUI/custom_nodes`:
 git clone https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate.git
 ```
 
-Restart ComfyUI. PyTorch is supplied by ComfyUI. Sibling custom nodes are not imported by this package, although the benchmark workflow uses the surrounding H3 ecosystem described below.
+Restart ComfyUI.
 
-## Nodes
+The core package has no runtime dependency on the sibling H3 custom nodes. The optional `learned_3d` transfer requires the companion latent-upscaler package above.
 
-Research attribution for every research-facing public node is mapped explicitly in [CREDITS.md](CREDITS.md); the node names below are implementation names, not claims of algorithmic originality.
+## Recommended Continuum path
 
-| Node | Purpose | Posture |
-|---|---|---|
-| MiniMax H3 Flow Trajectory | Explicit `H3_FLOW_TRAJECTORY` handle with RAM/VRAM policy | Stable infrastructure |
-| MiniMax H3 Trajectory Capture | Transactionally records denoised estimates and provenance | Stable infrastructure |
-| MiniMax H3 Flow-Aligned Regenerate | Time-matched low-frequency guidance for an explicit second pass | Direction is conservative default |
-| MiniMax H3 Flow-Aligned Refine State | Patches Continuum V3.4 per-chunk refine state for integrated learned refinement | Direction is conservative default |
-| MiniMax H3 Progressive Handoff | Source-grid sampler input grows to target grid during one schedule | Experimental |
-| MiniMax H3 Progressive Handoff (Target Input) | Continuum-safe target-sized topology with a private low-grid early stage; optional learned 3D clean-state transfer | Bicubic compatibility path; learned transfer decoded-media validated / experimental |
-| MiniMax H3 Refine Target Geometry | Mirrors downstream learned-refine target sizing for sigma experiments | Experimental |
-| MiniMax H3 Resolution-Aware Sigmas | Relative H3-native resolution/time remap | Off / experimental |
-| MiniMax H3 Reference Budget | Direct-reference row diagnostics/cap | Native |
-| MiniMax H3 Attention Lab | Packed-layout diagnostics and guarded sparse-attention experiment | Native |
-| MiniMax H3 Runtime Metrics Probe | Passive sampler/model-call instrumentation | On demand |
-| MiniMax H3 Metrics JSON | Structured counters/events and autosaved benchmark artifact | On demand |
-
-## Progressive Target Input wiring
-
-For Continuum, use the Target Input node rather than the source-input progressive node:
+When the surrounding H3 patches used by the validated workflow are present, keep this model-patch order:
 
 ```text
 DiffAid
-  -> Untwist
+  -> Untwisting RoPE
   -> Spectrum
   -> Progressive Handoff (Target Input)
   -> Continuum
 ```
 
-Create one **Flow Trajectory** handle and connect it to Progressive Handoff (Target Input). The progressive node captures the low-grid trajectory internally; a separate **Trajectory Capture** node is not required on this path.
+DiffAid, Untwisting RoPE, and Spectrum are optional external integrations, not requirements of this package. Omit any that are not part of your workflow; when Spectrum is used, keep Progressive Handoff downstream of it.
 
-Continuum remains configured on the final target grid. The wrapper creates a private low-grid video state for the early stage, performs an exact low-grid handoff probe, rebuilds target-grid conditioning, and starts a fresh sampler lifetime on the high grid. Audio is never spatially transformed. SA/PECE Adams history and Spectrum feature history are deliberately reset across the geometry boundary, and the first high-grid H3 call is forced actual.
+Create one **MiniMax H3 Flow Trajectory** and connect it to **Progressive Handoff (Target Input)**. A separate **Trajectory Capture** node is not required on this path because the progressive wrapper captures its private low-grid trajectory internally.
 
-`handoff_transfer=bicubic` remains the compatibility default. For the validated learned path,
-install the companion latent upscaler, create **MiniMax H3 Latent Upscaler Provider (3D) [Experimental]**,
-connect its `H3_LATENT_UPSCALER` output to the Target Input node, and select
-`handoff_transfer=learned_3d`. The learned CNN replaces only the exact-probe clean-video spatial
-transfer. Conditional re-noising, deterministic target noise, sampler/Spectrum history boundaries,
-the mandatory first high-grid actual call, caller audio, masks, and all H3 model-call semantics remain
-unchanged. One learned inference is added per physical chunk and no extra H3 NFE is added.
+Continuum remains on the target geometry. Only the video grid changes internally; audio remains in the native joint H3 path.
 
-Decoded-media validation now covers substantially more aggressive transitions than the original
-46×46→56×56 D14 plan. Around a 0.995 MP target, bicubic at roughly a 0.55 MP private source produced
-visible body/spatial handoff artifacts in the tested difficult prompt; replacing only that boundary with
-`learned_3d` fixed the majority of those artifacts. At the same target, `source_scale=0.70` resolved to
-800×608→1152×864 and was judged excellent, while `0.65` resolved to 736×576→1152×864 and began losing
-reference likeness / tonal stability. The final higher-resolution gate kept `source_scale=0.70` and
-resolved 832×640→1184×896 (~1.061 MP target); the generated action was different but the result was
-again judged very good. Its two BF16 CUDA learned calls took about 0.60 s and 0.77 s and added zero H3
-NFEs. These latest learned-transfer media runs used `direction+acceleration`; they are not evidence for
-promoting acceleration over direction-only.
+Detailed parameter guidance, tested starting points, `source_scale` behavior, handoff selection, learned-provider setup, and sampler requirements are in [docs/USAGE.md](docs/USAGE.md).
 
-### Observed performance versus proper two-pass upscale + refine
+## Two-pass path
 
-The useful legacy comparison is the established **7 first-pass + 6 learned-refine outer-step** workflow,
-not the old 3-step high-ratio refine experiments. At nominal 0.7 MP, that proper two-pass path resolved
-approximately 960×704 (0.676 MP) -> 1184×864 (1.023 MP) and took about 777 s end-to-end in the observed
-run. The historical full-quality setup was 7+7; no equally clean ~1 MP raw timing has been recovered for
-that exact 7+7 case, so no larger speedup is claimed from it.
+Use the explicit two-pass nodes when you want to keep an existing low-resolution generation + learned upscale/refine workflow:
 
-| Path | Base/private grid | Final grid | Sampling structure | Observed full workflow |
-|---|---:|---:|---|---:|
-| Proper two-pass upscale + refine | 960×704 (0.676 MP) | 1184×864 (1.023 MP) | 7 base + 6 learned-refine outer steps | ~777 s (~12:57) |
-| Progressive + `learned_3d` | 832×640 (0.532 MP) | 1184×896 (1.061 MP) | 10 progressive outer steps; 38 logical / 28 actual / 10 forecast | 621.63 s (10:21.6) |
+1. Create one **Flow Trajectory**.
+2. Patch the first-pass model with **Trajectory Capture**.
+3. Run the low-resolution generation.
+4. Perform the existing learned latent upscale / refine initialization.
+5. Patch the second-pass model with **Flow-Aligned Regenerate**.
+6. For Continuum-integrated refinement, patch the emitted `refine_state` with **Flow-Aligned Refine State** instead.
 
-Relative to that proper 6-step-refine baseline, the progressive learned-handoff run used ~21.2% fewer
-private/source pixels, produced ~3.7% more final pixels, and saved about 155 s end-to-end: roughly a
-**20% wall-time reduction / 1.25× observed workflow speedup**. The learned CNN itself was not the source
-of the saving: its two calls totaled only ~1.37 s of inference (~1.43 s including transfer bookkeeping)
-and added zero H3 NFEs. The saving comes from performing more of the trajectory on the cheaper private
-grid and avoiding a complete second low-sigma H3 refine pass.
+The same trajectory handle must be used by capture and guidance.
 
-This timing comparison is a practical observed-workflow reference rather than a controlled same-seed
-microbenchmark. The old and new runs differ slightly in final geometry and were recorded at different
-points in development, so use the ~20% figure as measured evidence for this workflow, not a universal
-speed claim or a quality-superiority percentage. See [docs/PERFORMANCE.md](docs/PERFORMANCE.md) for the
-full accounting and caveats.
+## Nodes
 
-For roughly 1 MP targets, `0.70` is therefore the current tested quality/compute sweet spot for this
-prompt, not a universal optimum. `0.65` is below the current useful quality floor in this case, while
-higher source scales remain the safer choice when preserving source-grid fidelity matters more than
-compute. Keep bicubic available for compatibility and matched controls rather than silently changing
-existing workflows. Provider mode fails instead of silently falling back when its configured inference
-device is unavailable.
+### Core generation nodes
 
-Use a complete 1-to-0 H3 sigma schedule. Partial low-sigma refinement schedules are rejected because their absolute flow origin is ambiguous for a progressive split.
+| Node | What it is for |
+|---|---|
+| **MiniMax H3 Flow Trajectory** | Shared mutable trajectory handle used by capture, guidance, and progressive sampling. Storage can live in system RAM or VRAM. |
+| **MiniMax H3 Trajectory Capture** | Patches an H3 model so first-pass predicted-clean trajectory states and provenance are recorded. |
+| **MiniMax H3 Flow-Aligned Regenerate** | Guides a later H3 pass from the matching captured low-resolution trajectory. |
+| **MiniMax H3 Flow-Aligned Refine State** | Continuum version of Flow-Aligned Regenerate; patches each `H3_CONTINUUM_REFINE_STATE`. |
+| **MiniMax H3 Progressive Handoff** | Starts from a source-sized workflow input and grows the video grid to a target resolution during sampling. |
+| **MiniMax H3 Progressive Handoff (Target Input)** | Target-sized/Continuum-safe variant: the public workflow stays at final geometry while the early H3 stage runs privately on a smaller grid. Supports optional `learned_3d` transfer. |
 
-### Choosing `source_scale` when target MP changes
+### Experimental research nodes
 
-With `source_mode=scale`, `source_scale` is a **linear H/W scale**, not a megapixel fraction. Before H3-safe geometry snapping, the private low-stage area therefore follows approximately:
+| Node | What it is for |
+|---|---|
+| **MiniMax H3 Refine Target Geometry [Experimental]** | Mirrors the companion learned-refiner's target sizing so schedule experiments can use the same geometry metadata. It does not upscale latents. |
+| **MiniMax H3 Resolution-Aware Sigmas [Experimental]** | Tests a resolution-dependent remap of the downstream learned-refine sigma schedule. Default/recommended mode remains `off`. |
+| **MiniMax H3 Reference Budget [Experimental]** | Reports direct-reference row growth and provides a guarded experimental direct-reference cap. |
+| **MiniMax H3 Attention Lab [Experimental]** | H3 packed-layout diagnostics plus a guarded sparse/local attention experiment. It is not MiniMax's proprietary sparse-attention implementation. |
 
-```text
-source_MP ~= target_MP * source_scale^2
-```
+### Diagnostics
 
-If you want to preserve the same relative low/high resolution ratio as target MP increases, leave `source_scale` unchanged. The low stage then grows proportionally with the final target and becomes more expensive as well.
+| Node | What it is for |
+|---|---|
+| **MiniMax H3 Runtime Metrics Probe** | Passive sampler/model-call instrumentation without enabling trajectory guidance or progressive handoff. |
+| **MiniMax H3 Metrics JSON** | Saves structured H3/Spectrum/sampler/geometry metrics to a JSON artifact. |
 
-If instead you want to preserve roughly the tested private low-stage size (~736x736, ~0.54 MP) while increasing final MP, reduce `source_scale` approximately as:
+## Guidance modes
 
-```text
-source_scale ~= sqrt(desired_source_MP / target_MP)
-```
+| Mode | Purpose | Current posture |
+|---|---|---|
+| `direction` | Low-frequency alignment toward the matched captured predicted-clean state | **Preferred/default guidance path** |
+| `direction+acceleration` | Adds adjacent denoising-time velocity-change alignment inspired by HiFlow | Experimental; structurally valid, no consistent media advantage established |
+| `direction+temporal` | Adds conservative adjacent-frame latent correspondence | Experimental; functioning, currently neutral in matched decoded-media testing |
+| `downsample_consistency` | Compares the target clean estimate against the captured low-grid state after downsampling | Experimental; measurable but not currently preferred |
+| `off` | Disable trajectory correction while retaining the surrounding wrapper/metrics path | Control/debug use |
 
-For a desired private stage around ~0.54 MP:
+Exact settings and evidence are intentionally kept out of the main README. See [docs/USAGE.md](docs/USAGE.md) for practical configuration and [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for the decoded-media evidence ledger.
 
-| Target MP | Approx. `source_scale` |
-|---:|---:|
-| 0.84 | 0.80 |
-| 0.90 | 0.78 |
-| 1.00 | 0.74 |
-| 1.10 | 0.70 |
-| 1.20 | 0.67 |
+## Current practical status
 
-The actual source dimensions are snapped to valid H3 latent geometry, so these values are starting points rather than exact pixel guarantees. Check the `handoff_plan` metrics event for the resolved source/target latent dimensions. With fixed handoff, increasing MP alone does not require changing `handoff_coordinate`; keep the tested 0.35 initially and adjust `source_scale` separately to control the low-stage compute budget.
+The core paths are usable and have been exercised with real decoded H3 media:
 
-The table is a geometry heuristic, not a quality guarantee. At approximately 1 MP, real decoded media showed that `source_scale=0.70` can work very well with `learned_3d`, while `0.65` crossed the tested prompt's fidelity/tonal floor. Because H3 snaps both axes, compare the resolved `handoff_plan` geometry rather than assuming two nearby decimal scales produce a smooth change.
+- **two-pass flow-aligned guidance** is functional with the learned upscale/refine workflow;
+- **Progressive Handoff (Target Input)** is the main single-schedule coarse-to-fine path for Continuum;
+- **direction-only guidance** remains the conservative recommendation;
+- **learned `learned_3d` handoff** has shown a clear benefit over bicubic for aggressive transitions in the tested ~1 MP workflow;
+- the resolution-aware sigma, temporal, acceleration, reference-budget, and attention experiments remain research features rather than promoted defaults.
 
-## Two-pass flow-aligned use
-
-1. Create one **Flow Trajectory** handle.
-2. Patch the low-resolution H3 model with **Trajectory Capture** and run the base sample.
-3. Perform the existing learned latent upscale/initialization.
-4. Patch the high-resolution model with **Flow-Aligned Regenerate**, or patch each Continuum `refine_state` with **Flow-Aligned Refine State** when using the integrated learned upscaler/refiner.
-5. Feed the capture metrics object into the downstream adapter's optional `metrics` input when one combined benchmark artifact is desired.
-6. Keep pass-one audio locked in the surrounding workflow.
-
-Trajectory identity includes bounded conditioning fingerprints. Exact H3 evaluations are preferred as trajectory anchors; Spectrum forecasts retain provenance and are excluded from trustworthy anchors by default.
-
-## Experimental guidance modes
-
-### `direction`
-
-The currently preferred mode. It aligns the target predicted-clean estimate toward the matched low-resolution trajectory only in low spatial frequencies and decays the correction through the high stage.
-
-### `direction+acceleration`
-
-Adapts HiFlow's adjacent velocity-difference idea to H3 by reconstructing native flow velocity from `x0 = x - sigma * v`. The PECE implementation explicitly keeps the previous **distinct-coordinate** anchor across predictor and same-coordinate corrector calls. The implementation is structurally correct, but current decoded-media evidence does not show a meaningful advantage over direction-only.
-
-### `direction+temporal`
-
-Uses bounded local adjacent-frame correspondence on captured low-grid H3 clean-state latents. Minimum similarity, best-vs-second-best margin, and exact reverse-cycle consistency are hard gates; ambiguous/disoccluded locations receive no temporal copy.
-
-The final matched D14 temporal run kept the same 54 logical / 36 actual / 18 forecast topology as D14 direction-only, but valid correspondence support was only ~0.295% in chunk 1 and ~0.084% in chunk 2. Mean temporal correction RMS was ~0.104% of baseline RMS versus ~2.19% for direction. The user saw no perceptual difference, so temporal stays experimental at reference weight 0.20 rather than being promoted or weight-swept.
-
-Earlier patterned temporal media from the TensorRT `w4a16_awq` VAE is excluded from attribution; that decoder, not temporal guidance, caused the repeated pattern.
-
-### `downsample_consistency`
-
-Compares the downsampled target predicted-clean estimate against the matched low-grid clean state and lifts the error back to the target grid. It is implemented and measurable, but the 0.25 decoded-media smoke was neutral.
-
-## Resolution-aware refine SIGMAS
-
-The resolution-aware node is a downstream learned-refine experiment. Correct placement is:
-
-```text
-existing refine scheduler SIGMAS
-            -> Resolution-Aware Sigmas
-            -> MiniMax H3 Latent Upscaler + Refine (3D).sigmas
-```
-
-Do **not** feed its output into Continuum SIGMAS. Continuum keeps its ordinary MP/base geometry. **Refine Target Geometry** may mirror the downstream refine node's scale/align calculation to supply target metadata only.
-
-The mapping composes a relative area-derived factor with H3's native video shift 12 while deriving audio sigma from the same shared flow coordinate. E0/E1 matched media showed no relevant improvement, so `mode=off` remains the recommendation.
-
-## Metrics and benchmarking
-
-Runtime events distinguish:
-
-- sampler logical calls;
-- actual H3 transformer evaluations;
-- Spectrum forecasts and promotions;
-- low/probe/high progressive stage;
-- sigma and unshifted coordinate;
-- packed layout rows;
-- trajectory transactions;
-- guidance mode/component RMS ratios;
-- handoff plan and exact probe;
-- history/reset boundaries;
-- sampler/stage wall time;
-- resolution sigma maps and fallbacks.
-
-Use [docs/BENCHMARKS.md](docs/BENCHMARKS.md), [docs/PERFORMANCE.md](docs/PERFORMANCE.md), and [workflows/benchmark-matrix.json](workflows/benchmark-matrix.json) for the evidence ledger, observed timing accounting, and the broader optional formal matrix. Decoded video and audio remain the pass/fail criterion.
+The current observed performance comparison for the learned progressive path is documented separately in [docs/PERFORMANCE.md](docs/PERFORMANCE.md). It is workflow-specific and not a universal speed or quality claim.
 
 ## Compatibility
 
-- **ComfyUI:** fails closed if the native H3 24/32-channel, `(1,2,2)`, shift-12/3 contract is absent.
-- **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** sampler objects are preserved; progressive low/probe/high stages use independent sampler lifetimes.
-- **Spectrum:** no import dependency. Actual/forecast and solver phase/outer-step metadata are consumed when available.
-- **Continuum V3.4:** multi-chunk progressive use should use Target Input so session/native-mask geometry stays target-sized.
-- **DiffAid / Untwisting RoPE:** patches stay upstream of the progressive wrapper. The high stage publishes the `h3_refinement` exact-anchor contract.
-- **Parallel multi-GPU model calls:** mutable capture/guidance/progressive state currently fails closed until an ordering contract is reviewed.
+The implementation is designed around native MiniMax H3 joint audio/video sampling rather than treating video as an isolated tensor path.
 
-## Validated source revisions
+- **Continuum:** use **Progressive Handoff (Target Input)** for multi-chunk progressive generation. **Flow-Aligned Refine State** is available for explicit two-pass Continuum refinement.
+- **Spectrum:** actual/forecast provenance is preserved. Feature-history state is reset across a progressive geometry boundary, and the first target-grid call is forced actual.
+- **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** sampler objects are preserved; progressive stages use separate sampler lifetimes where required by the geometry change.
+- **DiffAid / Untwisting RoPE:** keep these upstream of the progressive wrapper when used.
+- **Learned H3 latent upscaler:** optional provider for `learned_3d`; not bundled with this repository.
 
-Pinned executable/source contracts:
+More detailed wiring rules and failure conditions are in [docs/USAGE.md](docs/USAGE.md).
 
-- ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`
-- Spectrum `beb32dd210ef9e95520453107f158241d4f2ecf3`
-- Continuum `bf25353d8bec44afea22c89717c4301ce13c2036`
-- DiffAid `ba9d9efbcf7e64c755e068cb76547d8cc85481eb`
-- RefDelta `034e4c4c14c56bf76813cee4765e7164b0c7e0db`
-- Untwisting RoPE `299d4c56a3f057a97b3140d2136189bcd1e7d6bb`
-- H3 latent upscaler/refine and learned-handoff provider `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` (merged provider revision; released by companion v0.2.0)
+## Documentation
 
-MiniMax-H3 main was additionally inspected at `d21241f0a4b3acbb34c97dae47fa417b7065e438`.
+- **[docs/USAGE.md](docs/USAGE.md)** — practical wiring, settings, handoff behavior, guidance modes, learned transfer, metrics, and compatibility rules.
+- **[CREDITS.md](CREDITS.md)** — node-by-node research and implementation attribution.
+- **[docs/RESEARCH.md](docs/RESEARCH.md)** — research-transfer rationale and empirical conclusions.
+- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — internal H3 contracts and implementation architecture.
+- **[docs/BENCHMARKS.md](docs/BENCHMARKS.md)** — decoded-media validation ledger and benchmark protocol.
+- **[docs/PERFORMANCE.md](docs/PERFORMANCE.md)** — measured workflow-level timing evidence and limits.
+- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** — development setup, CI/test scope, source pins, and maintenance rules.
+- **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — release history.
 
-## Development
+## Scope and limitations
 
-```bash
-python -m pip install -e '.[test]' build
-ruff check .
-ruff format --check .
-pytest
-python -m compileall -q .
-python -m build
-```
-
-See [CREDITS.md](CREDITS.md), [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), [docs/RESEARCH.md](docs/RESEARCH.md), [docs/BENCHMARKS.md](docs/BENCHMARKS.md), and [docs/PERFORMANCE.md](docs/PERFORMANCE.md).
-
-## Limitations
-
-- The current quality recommendation comes from a limited difficult-motion workflow and is not a broad cross-prompt benchmark claim.
-- The 14-step quality sweep used the later matched square 736x736 -> 896x896 progressive setup; the earlier rectangular D10 reference remains a separate validated topology case.
-- The ~20% observed end-to-end timing reduction is against the proper historical 7+6 two-pass workflow at similar final resolution; it is not a formal same-seed benchmark and must not be generalized to every prompt, target MP, model residency state, or reference budget.
-- The progressive exact handoff probe costs one visible H3 NFE per chunk.
-- Target Input derives private low-grid **video** noise from a documented standard-Gaussian CPU generator keyed by graph seed; arbitrary custom/non-Gaussian private-grid video-noise semantics cannot be preserved.
-- Progressive handoff rejects sampler objects with an explicit external `noise_sampler` closure because mutable RNG/history cannot safely cross the geometry reset.
-- Masked progressive behavior is synthetic-tested but still has less decoded-media coverage than the unmasked difficult-motion path.
-- Reference budgeting cannot retroactively change already-encoded Qwen3-VL tokens.
-- Sparse attention remains investigative and is not a reconstruction of MiniMax's proprietary sparse topology.
-- Model assets and sibling custom nodes are not bundled.
+- This is research-grade tooling, not an official MiniMax implementation.
+- Progressive handoff changes only the **video** spatial grid; audio is never spatially resized.
+- Progressive sampling requires a complete H3 sigma schedule whose absolute flow origin is known.
+- Arbitrary external sampler RNG/history closures cannot be safely carried across a geometry reset and may be rejected.
+- Mutable capture/guidance/progressive state currently fails closed for unsupported parallel multi-GPU model-call ordering.
+- Quality and speed depend on prompt, references, geometry, sampler, Spectrum policy, model residency, and hardware. Use decoded media rather than metrics alone as the final quality test.

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -1,0 +1,189 @@
+# Development and maintenance
+
+This document contains repository-maintenance, test, CI, source-pin, and packaging information. It is intentionally separate from the user-facing README.
+
+## Scope
+
+The package is an H3-specific ComfyUI custom-node implementation with no declared runtime Python dependencies of its own. ComfyUI supplies PyTorch and the surrounding execution environment.
+
+The code assumes native MiniMax H3 joint audio/video behavior rather than a generic image/video diffusion contract. Runtime compatibility checks fail closed when critical H3 assumptions are absent or ambiguous.
+
+The current package metadata is defined in `pyproject.toml`:
+
+```text
+project = comfyui-minimax-h3-flow-aligned-regenerate
+python >= 3.10
+build backend = hatchling
+```
+
+## Local development
+
+From the repository root:
+
+```bash
+python -m pip install -e '.[test]' build
+ruff check .
+ruff format --check .
+pytest
+python -m compileall -q .
+python -m build
+```
+
+The test extra currently installs NumPy, pytest, Ruff, and PyTorch. Runtime dependencies remain empty in `pyproject.toml` because this custom node is executed inside ComfyUI.
+
+## CI
+
+`.github/workflows/ci.yml` runs on pushes and pull requests.
+
+### Python matrix
+
+The main test job runs on Python:
+
+```text
+3.10
+3.11
+3.12
+3.13
+```
+
+Each lane performs:
+
+1. editable install with test/build dependencies;
+2. `ruff check .`;
+3. `ruff format --check .`;
+4. `pytest`;
+5. `python -m compileall -q .`;
+6. `python -m build`;
+7. isolated wheel-install/import validation.
+
+The isolated wheel check verifies that the built package imports outside the repository checkout and exposes the expected trajectory API.
+
+### Source-contract job
+
+A separate CI job fetches pinned upstream/sibling repositories and runs `tools/check_source_contracts.py` against the exact revisions listed below.
+
+This job exists because several important integration assumptions cannot be validated from this repository alone. It checks current source structure/contracts rather than relying only on comments or README claims.
+
+## Pinned executable/source contracts
+
+The current CI pins are:
+
+| Source | Revision |
+|---|---|
+| ComfyUI | `1af040bf022569d7a890241c8dd79b296cda483f` |
+| ComfyUI-Spectrum-MiniMax-H3 | `beb32dd210ef9e95520453107f158241d4f2ecf3` |
+| ComfyUI-H3-Continuum | `bf25353d8bec44afea22c89717c4301ce13c2036` |
+| ComfyUI-DiffAid-Patches | `ba9d9efbcf7e64c755e068cb76547d8cc85481eb` |
+| ComfyUI-MiniMax-H3-RefDelta-Solver | `034e4c4c14c56bf76813cee4765e7164b0c7e0db` |
+| ComfyUI-Untwisting-RoPE | `299d4c56a3f057a97b3140d2136189bcd1e7d6bb` |
+| Comfyui_Minimax_h3_latent_Upscaler | `bdc670e5926bcefbe4022e17fe8b171fbfcf15de` |
+
+MiniMax-H3 main was additionally inspected at:
+
+```text
+d21241f0a4b3acbb34c97dae47fa417b7065e438
+```
+
+The companion upscaler revision above includes the learned-handoff provider API used by `handoff_transfer=learned_3d`.
+
+## Updating a source pin
+
+Do not update a pin solely because a newer upstream commit exists.
+
+For each pin update:
+
+1. inspect the relevant upstream changes between the old and proposed revisions;
+2. identify whether H3 packing, model-wrapper, sampler, mask, conditioning, geometry, RoPE, Spectrum provenance, Continuum state, or learned-provider contracts changed;
+3. update the CI checkout revision;
+4. update `tools/check_source_contracts.py` when the legitimate contract changed;
+5. run the complete Python matrix and source-contract job;
+6. run targeted runtime/decoded-media validation if the change can affect generation behavior;
+7. update `docs/USAGE.md`, `docs/ARCHITECTURE.md`, `docs/BENCHMARKS.md`, or `docs/PERFORMANCE.md` when user-visible behavior/evidence changes.
+
+A green source-contract test proves compatibility with the asserted structural contract. It does **not** prove decoded-media quality.
+
+## What the tests establish
+
+The repository test suite is primarily for structural and behavioral invariants such as:
+
+- package/custom-node registration;
+- H3 trajectory transaction and provenance behavior;
+- flow-coordinate matching;
+- sampler predictor/corrector handling;
+- progressive source/target geometry transitions;
+- exact handoff probes and history boundaries;
+- deterministic target/private noise contracts;
+- audio preservation across spatial transitions;
+- mask and conditioning reconstruction;
+- learned-provider API validation and target-shape enforcement;
+- Spectrum actual/forecast provenance;
+- reference-budget and attention-experiment guards;
+- metrics counters/events and autosave behavior;
+- resolution-aware sigma identity/remap behavior;
+- failure-closed behavior for unsupported or ambiguous execution paths.
+
+Passing unit tests, source-contract tests, lint, build, and packaging checks establishes implementation consistency. It does **not** establish that an experimental guidance mode improves generated media.
+
+## Media validation policy
+
+Decoded video and audio are the quality gate for claims about perceptual behavior.
+
+When comparing two generation modes, keep unrelated variables fixed where possible:
+
+- seed;
+- prompt;
+- reference media/conditioning;
+- LoRAs;
+- sampler/scheduler;
+- Spectrum policy;
+- DiffAid / Untwisting RoPE state;
+- VAE;
+- Continuum chunk/session settings;
+- masks;
+- audio behavior;
+- crop/decode path.
+
+Use `docs/BENCHMARKS.md` for the evidence ledger and benchmark protocol. Use `docs/PERFORMANCE.md` for timing claims.
+
+Telemetry can prove that a correction, handoff, reset, forecast, or sigma remap executed. It cannot by itself prove a perceptual improvement.
+
+## Documentation ownership
+
+Keep information in the document that matches its purpose:
+
+| Document | Purpose |
+|---|---|
+| `README.md` | What the project/nodes do, installation, core workflows, concise current posture |
+| `docs/USAGE.md` | Detailed user wiring, settings, mode behavior, compatibility, practical starting points |
+| `docs/ARCHITECTURE.md` | Internal H3 contracts and implementation design |
+| `docs/RESEARCH.md` | Research-transfer rationale and conclusions |
+| `docs/BENCHMARKS.md` | Media-validation ledger, test matrix, exact experiment topology |
+| `docs/PERFORMANCE.md` | Performance measurements and claim boundaries |
+| `CREDITS.md` | Research/implementation attribution and provenance |
+| `RELEASE_NOTES.md` | Release history and user-visible release changes |
+| `docs/DEVELOPMENT.md` | Development setup, CI, tests, source pins, maintenance rules |
+
+Do not copy long benchmark logs, CI details, source SHA lists, or development commands back into the main README.
+
+## Research-derived changes
+
+When a new paper or repository materially influences a node, algorithm, heuristic, or default:
+
+1. add it to `CREDITS.md`;
+2. state what idea transferred and what did not;
+3. update `docs/RESEARCH.md` when the transfer changes the research rationale;
+4. preserve upstream copyright/license notices if source code is incorporated rather than independently reimplemented;
+5. record the relevant upstream source revision when code was materially audited;
+6. validate the implementation structurally and, for quality claims, with decoded media.
+
+## Release checks
+
+Before a release that changes runtime behavior:
+
+1. ensure the final branch is based on current `main`;
+2. run the complete CI matrix and source-contract checks;
+3. verify package versioning and build output;
+4. update `RELEASE_NOTES.md`;
+5. update README/usage documentation only for actual user-visible behavior;
+6. update benchmark/performance documents only when new evidence supports the change;
+7. avoid promoting experimental behavior solely because structural tests are green.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1,0 +1,394 @@
+# Usage guide
+
+This document contains the detailed wiring and configuration information intentionally kept out of the main README.
+
+The repository exposes two main generation paths:
+
+1. **flow-aligned two-pass guidance** — capture a low-resolution H3 trajectory and use it to guide a later high-resolution/refine pass;
+2. **progressive handoff** — keep the early part of one schedule on a smaller video grid, then transition once to the target grid and continue sampling.
+
+For H3 Continuum, **Progressive Handoff (Target Input)** is the preferred progressive topology because the public workflow/session stays at target geometry while only the node's private early video state is smaller.
+
+## Common concepts
+
+### Flow trajectory
+
+**MiniMax H3 Flow Trajectory** is a mutable execution handle shared by the nodes participating in one generation. It stores captured predicted-clean trajectory samples and provenance.
+
+- `storage=system_ram` keeps captured trajectory tensors off VRAM where practical;
+- `storage=vram` avoids host transfer at the cost of additional VRAM;
+- `max_runs` bounds retained trajectory runs inside one handle.
+
+Create one handle per workflow execution and reuse that same handle across capture/guidance nodes that are supposed to communicate.
+
+### Flow coordinate
+
+Guidance and progressive handoff match states by H3's shared flow coordinate rather than by raw sampler call index. This matters for samplers such as SA-Solver/PECE where predictor/corrector calls can occur at the same sigma and where logical calls are not equivalent to distinct denoising coordinates.
+
+### Video vs audio
+
+H3 is a joint audio/video model. The progressive path changes only the **video spatial grid**. Audio is never spatially resized and remains on the native joint H3 path.
+
+## Progressive Handoff (Target Input)
+
+### Wiring with Continuum
+
+Use this order for the model patch chain:
+
+```text
+DiffAid
+  -> Untwisting RoPE
+  -> Spectrum
+  -> Progressive Handoff (Target Input)
+  -> Continuum
+```
+
+Create one **Flow Trajectory** and connect it to **Progressive Handoff (Target Input)**.
+
+Do **not** add a separate Trajectory Capture node on this path. The progressive wrapper captures the private low-grid trajectory internally.
+
+Continuum remains configured for the final target width/height. The wrapper creates a private smaller video state for the early stage, performs the handoff, rebuilds target-grid conditioning, and continues at the final grid.
+
+### What happens at the handoff
+
+At the selected handoff point the wrapper:
+
+1. completes an exact low-grid H3 probe at the boundary;
+2. obtains the predicted-clean video state;
+3. transfers that clean video state to the target H/W;
+4. reconstructs the target conditional state with deterministic target noise;
+5. keeps audio on its existing path;
+6. resets sampler history that is invalid after a spatial-shape change;
+7. resets Spectrum feature history;
+8. starts the target-grid stage with a forced actual H3 evaluation.
+
+This is why the progressive path is not equivalent to resizing a noisy latent in place.
+
+### Source geometry
+
+`source_mode` controls how the private early-stage grid is selected:
+
+- `scale` — derive the private grid from the final target geometry;
+- `pixels` — request an explicit private source width/height, which is then snapped to H3-safe latent geometry.
+
+With `source_mode=scale`, `source_scale` is a **linear width/height scale**, not an area or megapixel fraction:
+
+```text
+source_MP ~= target_MP * source_scale^2
+```
+
+For example, a `source_scale` of `0.70` means the private H/W are roughly 70% of the final dimensions before H3 geometry snapping, so the private area is roughly 49% of the target area.
+
+If the goal is to keep approximately the same private area while increasing target megapixels:
+
+```text
+source_scale ~= sqrt(desired_source_MP / target_MP)
+```
+
+A rough geometry-only guide for keeping the private stage near ~0.54 MP is:
+
+| Target MP | Approx. `source_scale` |
+|---:|---:|
+| 0.84 | 0.80 |
+| 0.90 | 0.78 |
+| 1.00 | 0.74 |
+| 1.10 | 0.70 |
+| 1.20 | 0.67 |
+
+These are starting points, not quality guarantees. H3-safe geometry snapping can make nearby decimal values resolve to the same or non-linearly different W/H. Inspect the `handoff_plan` metrics event when exact resolved geometry matters.
+
+### Handoff position
+
+`handoff_selection` supports:
+
+- `fixed` — use the requested `handoff_coordinate` and snap it to an available schedule point;
+- `auto_compute` — derive a geometry-aware earlier/later handoff from the source/target area relationship.
+
+`fixed` at `handoff_coordinate=0.35` is the current tested reference. `auto_compute` is functional but did not show a clear decoded-media advantage in the matched smoke used during development, so it is not the preferred quality setting.
+
+### Sigma schedule requirement
+
+Progressive handoff requires a complete H3 schedule whose absolute flow origin is known. Use a full 1-to-0 schedule.
+
+Partial low-sigma refinement schedules are rejected for progressive sampling because the wrapper cannot safely infer the original absolute flow coordinate from an arbitrary tail schedule.
+
+## Handoff transfer modes
+
+### `bicubic`
+
+`bicubic` is the built-in compatibility/default transfer. It resizes the exact-probe predicted-clean video state to the target grid before target-state reconstruction.
+
+### `learned_3d`
+
+The optional learned path uses the companion repository:
+
+https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler
+
+Create **MiniMax H3 Latent Upscaler Provider (3D) [Experimental]**, connect its `H3_LATENT_UPSCALER` output to the progressive Target Input node, and select:
+
+```text
+handoff_transfer = learned_3d
+```
+
+The learned provider changes only the exact-probe **clean video** spatial transfer.
+
+It does not change:
+
+- audio;
+- target noise semantics;
+- the conditional re-noise equation;
+- masks;
+- sampler/Spectrum history boundaries;
+- the mandatory first target-grid actual call;
+- H3 model-call semantics.
+
+One learned CNN inference is added per physical chunk and it adds no H3 transformer NFE by itself.
+
+Provider mode fails instead of silently falling back if the configured learned-upscaler device/model is unavailable.
+
+### Current learned-transfer evidence
+
+Around a ~1 MP target, decoded-media testing found a meaningful benefit from `learned_3d` when the private-to-target transition was aggressive enough for bicubic to introduce visible body/spatial handoff artifacts.
+
+The strongest tested quality/compute point for that specific difficult-motion prompt used approximately:
+
+```text
+source_scale = 0.70
+handoff_selection = fixed
+handoff_coordinate = 0.35
+handoff_transfer = learned_3d
+outer_steps = 10 SA-Solver-PECE
+```
+
+The final gate resolved approximately `832x640 -> 1184x896`. A `0.65` source scale at the same general target regime began losing reference likeness and tonal stability in that prompt.
+
+This is not a universal source-scale optimum. Larger source scales are safer when source-grid fidelity is more important than reducing high-resolution work.
+
+The latest learned-transfer media runs used `direction+acceleration`; that fact must **not** be interpreted as evidence that acceleration guidance is better than direction-only.
+
+See [BENCHMARKS.md](BENCHMARKS.md) and [PERFORMANCE.md](PERFORMANCE.md) for the exact evidence and timing accounting.
+
+## Progressive Handoff (source-input variant)
+
+**MiniMax H3 Progressive Handoff** is the source-sized version of the same general idea. The incoming workflow starts on the smaller grid and the node grows the video state toward either:
+
+- a target scale; or
+- explicit target pixel dimensions.
+
+Use this variant when the surrounding workflow can legitimately begin at source geometry.
+
+For Continuum, prefer **Progressive Handoff (Target Input)** because Continuum's session, native masks, crop/decode bookkeeping, and external graph geometry are target-sized.
+
+## Flow-aligned two-pass guidance
+
+The explicit two-pass path preserves an existing low-resolution generation + learned upscale/refine workflow and adds trajectory guidance to the second H3 pass.
+
+### Generic two-pass wiring
+
+1. Create one **MiniMax H3 Flow Trajectory**.
+2. Patch the low-resolution H3 model with **MiniMax H3 Trajectory Capture**.
+3. Run the first-pass generation.
+4. Perform the existing learned latent upscale / second-pass initialization.
+5. Patch the high-resolution H3 model with **MiniMax H3 Flow-Aligned Regenerate**.
+6. Use the same trajectory handle for capture and guidance.
+
+When one combined metrics artifact is wanted, feed the `metrics` output from Trajectory Capture into the downstream Flow-Aligned Regenerate node.
+
+### Continuum + integrated learned refinement
+
+For Continuum's integrated learned-refine path:
+
+1. place **Trajectory Capture** as the final H3 model patch before Continuum so the emitted `refine_state` carries the correct trajectory provenance;
+2. run Continuum's first pass;
+3. feed each `H3_CONTINUUM_REFINE_STATE` through **Flow-Aligned Refine State** using the same trajectory handle;
+4. feed the patched refine state into the companion integrated latent upscaler/refiner.
+
+The refine-state adapter checks the captured run identity and conditioning provenance and fails closed if the state cannot be matched safely.
+
+### Capturing Spectrum forecasts
+
+`capture_forecasts=False` is the conservative default. Exact H3 evaluations are the preferred trajectory anchors.
+
+When forecast capture is deliberately enabled for research, forecast provenance remains marked and is not silently treated as an exact model evaluation.
+
+## Guidance modes
+
+### `direction`
+
+The preferred mode. It aligns the target predicted-clean estimate toward the matched captured low-resolution predicted-clean state in low spatial frequencies and decays the correction through the later high-resolution stage.
+
+Progressive nodes currently default to:
+
+```text
+direction_weight = 0.25
+low_frequency_cutoff = 0.25
+```
+
+The explicit two-pass regenerate node exposes a slightly stronger public default (`direction_weight=0.35`). Treat these as starting points, not model-independent optima.
+
+### `direction+acceleration`
+
+Adds HiFlow-inspired adjacent denoising-time velocity-change alignment.
+
+The H3 implementation reconstructs native flow velocity from the predicted-clean relationship and preserves the previous **distinct-coordinate** anchor across same-coordinate PECE predictor/corrector calls.
+
+The implementation is structurally validated, but matched decoded-media testing has not shown a consistent quality advantage over direction-only. Keep `acceleration_weight=0` unless deliberately testing the research mode.
+
+### `direction+temporal`
+
+Adds bounded local adjacent-frame correspondence on captured low-grid H3 clean-state video latents.
+
+The matcher uses:
+
+- local cosine search;
+- minimum similarity gating;
+- best-vs-second-best uniqueness margin;
+- reverse-cycle consistency;
+- zero temporal copy for ambiguous/disoccluded locations.
+
+It is functioning, but the final matched test showed extremely sparse valid support and no visible difference from direction-only. It remains experimental rather than a promoted default.
+
+### `downsample_consistency`
+
+Downsamples the target predicted-clean state to the low-grid reference geometry, measures the mismatch, and lifts the correction back to target resolution.
+
+The term was measurable in telemetry but did not produce a useful decoded-media improvement in the matched smoke. It remains experimental.
+
+### `off`
+
+Disables trajectory correction while leaving the surrounding wrapper/metrics setup available for controls and debugging.
+
+## Current tested direction-only reference
+
+The final matched direction-only quality sweep used:
+
+```text
+outer_steps = 14
+source_mode = scale
+source_scale = 0.83
+handoff_selection = fixed
+handoff_coordinate = 0.35
+guidance_mode = direction
+direction_weight = 0.25
+acceleration_weight = 0
+temporal_weight = 0
+consistency_weight = 0
+low_frequency_cutoff = 0.25
+```
+
+That particular benchmark resolved roughly `736x736 -> 896x896` and improved subjectively from 10 to 12 to 14 SA-Solver-PECE outer steps.
+
+This is a tested operating point for that difficult-motion setup, not a universal recommendation that every prompt needs 14 steps or `source_scale=0.83`.
+
+## Resolution-aware refine SIGMAS
+
+This is a separate downstream learned-refine experiment. It is **not** part of the recommended progressive handoff path.
+
+Correct wiring:
+
+```text
+MP/base sizing ---------------------------> Continuum width/height
+       \
+        -> Refine Target Geometry --------> Resolution-Aware Sigmas target metadata
+
+existing refine scheduler SIGMAS
+        -> Resolution-Aware Sigmas
+        -> MiniMax H3 Latent Upscaler + Refine (3D).sigmas
+```
+
+Do not feed **Refine Target Geometry** dimensions back into Continuum, and do not feed **Resolution-Aware Sigmas** into Continuum's main SIGMAS input.
+
+`mode=off` is the current recommendation. The resolution-aware remap was structurally valid but did not show a relevant quality improvement in the completed matched E0/E1 media pair.
+
+`source_width=source_height=0` means the node derives the H3-native analytic reference canvas for the target aspect ratio. It does **not** request a physical low-resolution sampling pass.
+
+## Metrics
+
+### Runtime Metrics Probe
+
+**MiniMax H3 Runtime Metrics Probe** installs passive sampler/model-call instrumentation without enabling capture, guidance, progressive handoff, or attention changes.
+
+Place it after Spectrum when exact/forecast provenance is required.
+
+If a shared `H3_FLOW_METRICS` object already exists, connect it to the optional `metrics` input to append to that artifact. Otherwise the probe creates its own metrics object.
+
+### Metrics JSON
+
+**MiniMax H3 Metrics JSON** autosaves structured metrics under ComfyUI's output directory and refreshes the same file as later sampler events complete.
+
+Useful events/counters include:
+
+- logical sampler/model calls;
+- actual H3 transformer evaluations;
+- Spectrum forecasts/promotions;
+- low/probe/high progressive stage;
+- sigma and unshifted flow coordinate;
+- resolved handoff/source/target geometry;
+- trajectory commits and provenance;
+- guidance component RMS ratios;
+- sampler/history reset boundaries;
+- sampler/stage wall time;
+- resolution sigma-map diagnostics.
+
+Metrics establish whether the intended path executed. They do not replace decoded video/audio review as the quality criterion.
+
+## Compatibility and ordering
+
+### Spectrum
+
+Spectrum can remain upstream of the progressive wrapper. Across the handoff, feature-history state is reset because cached transformer features from one spatial shape cannot be reused at another. The first target-grid call is forced actual.
+
+### SA-Solver/PECE and other samplers
+
+SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES sampler objects are preserved. Progressive low/probe/high stages use independent sampler lifetimes where the spatial geometry boundary invalidates multistep/RNG history.
+
+A sampler object carrying an explicit external `noise_sampler` closure can be rejected because arbitrary mutable RNG/history semantics cannot be reconstructed safely across the geometry reset.
+
+### DiffAid / Untwisting RoPE
+
+Keep these patches upstream of the progressive wrapper. The target-grid stage publishes the exact refinement-anchor contract expected by compatible downstream patches.
+
+### Continuum masks and chunks
+
+Target Input keeps Continuum-facing geometry at the final target size. The wrapper reconstructs the private/target video state internally and preserves audio. Masked behavior is structurally tested, but it has less decoded-media coverage than the main unmasked difficult-motion path.
+
+### Private low-grid noise
+
+Target Input derives private low-grid video noise from a documented standard-Gaussian CPU generator keyed by the graph seed. Arbitrary custom/non-Gaussian private-grid video-noise semantics cannot be preserved across this internally generated source state.
+
+### Parallel multi-GPU ordering
+
+The capture/guidance/progressive state is mutable and ordered. Unsupported parallel multi-GPU model-call ordering currently fails closed rather than risking trajectory corruption.
+
+## Reference Budget and Attention Lab
+
+These are research/diagnostic nodes, not required for normal flow-aligned or progressive generation.
+
+### Reference Budget
+
+Modes:
+
+- `native` — pass conditioning through unchanged;
+- `diagnostic` — report direct-reference row growth without changing conditioning;
+- `decoupled_direct_experimental` — apply the guarded experimental direct-video-row cap.
+
+The node cannot retroactively change Qwen3-VL tokens that have already been encoded into conditioning.
+
+### Attention Lab
+
+Modes:
+
+- `native` — no attention change;
+- `diagnostic` — inspect the selected H3 blocks/layout path;
+- `experimental_sparse` — guarded research experiment with selected layers, local window size, global heads, and sequence cap.
+
+This is not an implementation of MiniMax's unreleased H3 sparse-attention topology and should not be treated as a production acceleration path.
+
+## Evidence documents
+
+For exact runs and measured outcomes, use the dedicated evidence documents rather than extending the main README:
+
+- [BENCHMARKS.md](BENCHMARKS.md) — decoded-media smoke ledger, tested operating points, topology, metrics, and optional formal matrix;
+- [PERFORMANCE.md](PERFORMANCE.md) — observed progressive learned-handoff versus proper two-pass timing comparison;
+- [RESEARCH.md](RESEARCH.md) — research-transfer rationale and conclusions;
+- [../CREDITS.md](../CREDITS.md) — full research and implementation provenance.


### PR DESCRIPTION
## Summary

Refocus the root README on what the MiniMax H3 Flow-Aligned Regenerate nodes actually do, why the project exists, and how users should choose/wire the main paths. Move development/test detail and deep configuration material into dedicated documentation instead of making the README serve as an experiment log and maintainer notebook.

## What changed

- rewrite `README.md` around the two actual generation goals:
  - flow-aligned second-pass guidance from a captured low-resolution H3 trajectory;
  - progressive source/private-grid -> target-grid handoff inside one sampling schedule;
- explain the optional `learned_3d` handoff without burying the feature under benchmark telemetry;
- make the Continuum and explicit two-pass wiring paths clear near the top;
- reorganize the node list into core generation, experimental research, and diagnostics, with a direct description of what each node is for;
- keep only a concise guidance-mode/status/compatibility summary in the README;
- add `docs/USAGE.md` for detailed wiring, parameter semantics, tested starting points, source-scale geometry, handoff behavior, learned-provider setup, guidance modes, metrics, and compatibility/failure conditions;
- add `docs/DEVELOPMENT.md` for local development, CI/test scope, source-contract pins, maintenance policy, documentation ownership, source-pin updates, and release checks;
- leave exact decoded-media experiments and call-count evidence in the existing `docs/BENCHMARKS.md` and timing claims in `docs/PERFORMANCE.md` instead of duplicating them in the README;
- update `CREDITS.md` so executable source-pin references point to the new maintenance documentation rather than the README.

## README posture after this change

The root README is now intended to answer, in order:

1. What problem is this project trying to solve?
2. What do flow-aligned guidance and progressive handoff actually do?
3. Which path should I use with Continuum or a two-pass workflow?
4. What does each public node do?
5. Which guidance modes/features are recommended versus experimental?
6. Where do I go for detailed usage, research evidence, credits, benchmarks, performance, or development information?

It no longer contains the development command block, CI/source revision dump, long validation ledger, exact sampler/NFE telemetry, repeated benchmark settings, or detailed experiment archaeology.

## Validation / risk

- documentation-only change;
- no Python/runtime/node/workflow/package behavior changed;
- one commit over current `main`;
- existing benchmark/performance/research evidence is preserved rather than deleted;
- detailed user settings were relocated to `docs/USAGE.md`, not discarded;
- development/test/source-pin material was relocated to `docs/DEVELOPMENT.md`.
