### PR TITLE
Add Apache-2.0 licensing and distribution metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,26 @@ jobs:
       - run: pytest
       - run: python -m compileall -q .
       - run: python -m build
+      - name: Validate distribution license metadata
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+          import tarfile
+          from zipfile import ZipFile
+
+          wheel = next(Path("dist").glob("*.whl"))
+          with ZipFile(wheel) as archive:
+              names = archive.namelist()
+              metadata_path = next(name for name in names if name.endswith(".dist-info/METADATA"))
+              metadata = archive.read(metadata_path).decode("utf-8")
+              assert "License-Expression: Apache-2.0" in metadata
+              assert "License-File: LICENSE" in metadata
+              assert any(name.endswith(".dist-info/licenses/LICENSE") for name in names)
+
+          sdist = next(Path("dist").glob("*.tar.gz"))
+          with tarfile.open(sdist, "r:gz") as archive:
+              assert any(member.name.endswith("/LICENSE") for member in archive.getmembers())
+          PY
       - name: Validate built wheel in an isolated environment
         run: |
           WHEEL="$(pwd)/$(ls dist/*.whl | head -n 1)"

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -180,6 +180,15 @@ More detailed wiring rules and failure conditions are in [docs/USAGE.md](docs/US
 - **[docs/PERFORMANCE.md](docs/PERFORMANCE.md)** — measured workflow-level timing evidence and limits.
 - **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** — development setup, CI/test scope, source pins, and maintenance rules.
 - **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — release history.
+- **[LICENSE](LICENSE)** — Apache License 2.0 terms for this project.
+
+## License
+
+MiniMax H3 Flow-Aligned Regenerate is licensed under the [Apache License 2.0](LICENSE).
+
+Copyright 2026 xmarre.
+
+Research references and implementation provenance are documented in [CREDITS.md](CREDITS.md). Those references are attribution, not relicensing: third-party projects retain their own copyrights and licenses, and referenced research repositories are not bundled into this project unless explicitly stated otherwise.
 
 ## Scope and limitations
 

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -14,7 +14,24 @@ The current package metadata is defined in `pyproject.toml`:
 project = comfyui-minimax-h3-flow-aligned-regenerate
 python >= 3.10
 build backend = hatchling
+license = Apache-2.0
 ```
+
+## Licensing and provenance
+
+Project-authored source code and documentation are distributed under the Apache License 2.0. `LICENSE` is the canonical license text, while `pyproject.toml` declares the SPDX expression and `license-files` metadata so built distributions carry the same licensing information.
+
+Research papers, upstream repositories, and sibling integrations cited in `CREDITS.md` are attribution and provenance references, not bundled code and not relicensed by this project. Their original copyrights and license terms continue to apply to their own works.
+
+When incorporating third-party source rather than independently reimplementing an idea or interoperating through an API:
+
+1. verify that the source license is compatible with the intended distribution;
+2. preserve required copyright, license, attribution, and NOTICE material;
+3. record the incorporated component, exact source revision, affected local paths, and licensing obligations in `CREDITS.md`;
+4. update distribution metadata or notices when the third-party license requires it;
+5. do not describe copied or translated source as an independent implementation.
+
+A top-level `NOTICE` file is intentionally not created merely for research citations. Add one only when this project itself needs project-level attribution notices or when incorporated third-party material creates a NOTICE/attribution obligation that should travel with distributions.
 
 ## Local development
 
@@ -160,6 +177,7 @@ Keep information in the document that matches its purpose:
 | `docs/BENCHMARKS.md` | Media-validation ledger, test matrix, exact experiment topology |
 | `docs/PERFORMANCE.md` | Performance measurements and claim boundaries |
 | `CREDITS.md` | Research/implementation attribution and provenance |
+| `LICENSE` | Canonical Apache License 2.0 terms for project-authored work |
 | `RELEASE_NOTES.md` | Release history and user-visible release changes |
 | `docs/DEVELOPMENT.md` | Development setup, CI, tests, source pins, maintenance rules |
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,11 +9,14 @@ description = "H3-native flow-aligned and progressive-resolution regeneration fo
 readme = "README.md"
 requires-python = ">=3.10"
 authors = [{ name = "xmarre" }]
+license = "Apache-2.0"
+license-files = ["LICENSE"]
 keywords = ["comfyui", "minimax-h3", "rectified-flow", "video", "audio"]
 dependencies = []
 
 [project.urls]
 Repository = "https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate"
+License = "https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/blob/main/LICENSE"
 
 [tool.comfy]
 PublisherId = "xmarre"

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -10,6 +10,22 @@ def test_package_import_without_comfyui():
     assert h3_flow_regenerate.H3FlowTrajectory.api_version == 1
 
 
+def test_project_declares_apache_license_and_tracks_license_file():
+    root = Path(__file__).parents[1]
+    pyproject = (root / "pyproject.toml").read_text(encoding="utf-8")
+    license_text = (root / "LICENSE").read_text(encoding="utf-8")
+    readme = (root / "README.md").read_text(encoding="utf-8")
+
+    assert 'license = "Apache-2.0"' in pyproject
+    assert 'license-files = ["LICENSE"]' in pyproject
+    assert 'License = "https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate/blob/main/LICENSE"' in pyproject
+    assert license_text.startswith("Apache License\n                           Version 2.0, January 2004")
+    assert "TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION" in license_text
+    assert "END OF TERMS AND CONDITIONS" in license_text
+    assert "[Apache License 2.0](LICENSE)" in readme
+    assert "Copyright 2026 xmarre." in readme
+
+
 def test_custom_node_root_registration_smoke():
     root = Path(__file__).parents[1] / "__init__.py"
     spec = importlib.util.spec_from_file_location(


### PR DESCRIPTION
## Summary

- add the canonical Apache License 2.0 text at the repository root
- declare `Apache-2.0` via PEP 639 metadata and explicitly include `LICENSE` in built distributions
- expose the license URL in package metadata and document the project copyright/license in the README
- document the licensing/provenance boundary for research references, sibling integrations, and any future incorporated third-party source
- add packaging tests plus CI checks that verify wheel/sdist license inclusion and `License-Expression` / `License-File` metadata

## Licensing boundary

`CREDITS.md` already distinguishes research attribution from code relicensing and states that the referenced research repositories are not vendored dependencies. This PR keeps that boundary explicit: project-authored code/documentation are Apache-2.0; third-party works retain their own terms. No top-level `NOTICE` file is added because the current project does not identify bundled third-party material requiring a repository-level NOTICE obligation.

## Validation

Branch topology: 1 commit on current `main`, 0 behind, mergeable.

CI run `33891214959` passed completely:

- Python 3.10, 3.11, 3.12, and 3.13 lanes
- Ruff lint and format checks
- pytest and compileall
- wheel + sdist build
- explicit wheel/sdist license inclusion and PEP 639 metadata checks
- isolated built-wheel import validation
- pinned native/sibling source-contract validation

No runtime, sampling, guidance, handoff, Continuum, Spectrum, or model behavior changes are included.