### PR TITLE
Preserve Continuum prefixes and add VDN attention diagnostics

### DIFF
--- a/CREDITS.md
+++ b/CREDITS.md
@@ -17,7 +17,7 @@ These references are attribution, not relicensing. The research repositories lis
 | **Progressive Handoff (Target Input)** `learned_3d` | Companion **Comfyui_Minimax_h3_latent_Upscaler**; inherited **LBH-123-AI**, **ComfyUi_NNLatentUpscale**, and **LTX spatial-upscaler** lineage | A single learned clean-video spatial transform at the exact handoff boundary | Flow only consumes the companion provider API. The learned model/architecture lineage and checkpoints remain owned and credited by their upstream projects; audio, target noise, sigma law, masks, and H3 NFEs are unchanged. |
 | **MiniMax H3 Refine Target Geometry** | Companion **Comfyui_Minimax_h3_latent_Upscaler** | Mirrors the companion node's scale-by-multiplier geometry contract for schedule metadata | No latent upscale or sampling occurs in this helper. |
 | **MiniMax H3 Resolution-Aware Sigmas** | **simple diffusion**; **Scaling Rectified Flow Transformers for High-Resolution Image Synthesis** | Resolution/SNR motivation and the fractional-linear resolution-dependent flow-time map | The SD3 constant-observation derivation is only used as an experimental relative correction composed with H3's native shift; it is not claimed to be an optimal H3 schedule. |
-| **MiniMax H3 Attention Lab** | **FreeSwim**, **HRDiT**, **ResDiT**; MiniMax-H3's public sparse-attention statement | Investigating native-scale spatial receptive fields, mixed local/global attention scopes, positional/receptive-field mismatch, and heterogeneous head/layer behavior | H3 uses one packed multimodal stream. The experiment keeps non-video paths global and does not claim to reconstruct MiniMax's unreleased sparse topology or any paper's exact attention rule. |
+| **MiniMax H3 Attention Lab** | **OpenVDN**, **FreeSwim**, **HRDiT**, **ResDiT**; MiniMax-H3's public sparse-attention statement | Output-neutral retention diagnostics; OpenVDN-inspired 5-frame chunk-local temporal reference topology with previous/current/next chunks and boundary anchors; native-scale spatial/local-global research | H3 uses one packed multimodal stream. The VDN topology path is an independently written dense-mask correctness oracle, not OpenVDN's trained hybrid model, FlexAttention kernel, weights, or a production acceleration claim. |
 | **MiniMax H3 Reference Budget** | MiniMax-H3 / ComfyUI packed-reference contract; secondary context from **PAB**, **DiffCR/VideoDiffCR** and token-reduction literature | Measurement of direct-reference row growth and a bounded experimental direct-reference cap | PAB and VideoDiffCR are **not** evidence that H3 should use a fixed reference budget. No published token-pruning policy is copied, and already encoded Qwen3-VL context is not modified. |
 | **Runtime Metrics Probe** / **Metrics JSON** | ComfyUI, Spectrum, SA-Solver and the sibling integration APIs | Auditable logical-call, actual/forecast, phase, geometry, timing, and reset provenance | These are instrumentation nodes, not implementations of the cited research algorithms. |
 
@@ -105,6 +105,15 @@ Patrick Esser, Sumith Kulal, Andreas Blattmann, Rahim Entezari, Jonas Müller, H
 The node composes this as a relative factor with H3's native video shift instead of replacing H3's model sampling.
 
 ## High-resolution attention research
+
+### OpenVDN — Video DeltaNet
+
+- Project: https://openvdn.github.io/
+- Code: https://github.com/OpenVDN/OpenVDN
+- Inspected code revision: `b8cb28fbfca0266d1c7742a9f25ab8b58191de97`
+- Direct influence here: complete 5-frame chunk alignment, radius-1 previous/current/next temporal windows, globally visible non-video tokens, and first/last row-and-column boundary-anchor semantics.
+
+Flow independently implements that public topology as an analytic diagnostic and dense additive-mask reference. It does not copy OpenVDN's hybrid linear branch, compiled FlexAttention/BlockMask implementation, cache policy, training code, or checkpoints. OpenVDN's repository code is Apache-2.0, while its separately distributed VDN-H3 weights are derivatives of MiniMax H3 and are governed by the MiniMax H3 Community License Agreement, including territorial restrictions. This project does not download or distribute those weights.
 
 ### FreeSwim — Revisiting Sliding-Window Attention Mechanisms for Training-Free Ultra-High-Resolution Video Generation
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ private/source grid  ------------>  target grid
 
 The handoff is not a blind resize of noisy state. The wrapper performs an exact low-grid probe, transfers the predicted-clean video state, reconstructs the target-grid conditional state, resets sampler/forecast histories that cannot safely cross the geometry change, and continues sampling at the final resolution.
 
-For **Continuum**, use **MiniMax H3 Progressive Handoff (Target Input)**. Continuum stays configured for the final target size while the node privately runs the early stage on a smaller video grid.
+For **Continuum**, use **MiniMax H3 Progressive Handoff (Target Input)**. Continuum stays configured for the final target size while the node privately runs the early stage on a smaller video grid. If Continuum's native mask exactly protects any video prefix (`mask == 0`), Flow automatically preserves that stronger contract by skipping the private resize/handoff and running the original target-grid sampler once.
 
 ### 3. Optional learned handoff
 
@@ -125,7 +125,7 @@ The same trajectory handle must be used by capture and guidance.
 | **MiniMax H3 Refine Target Geometry [Experimental]** | Mirrors the companion learned-refiner's target sizing so schedule experiments can use the same geometry metadata. It does not upscale latents. |
 | **MiniMax H3 Resolution-Aware Sigmas [Experimental]** | Tests a resolution-dependent remap of the downstream learned-refine sigma schedule. Default/recommended mode remains `off`. |
 | **MiniMax H3 Reference Budget [Experimental]** | Reports direct-reference row growth and provides a guarded experimental direct-reference cap. |
-| **MiniMax H3 Attention Lab [Experimental]** | H3 packed-layout diagnostics plus a guarded sparse/local attention experiment. It is not MiniMax's proprietary sparse-attention implementation. |
+| **MiniMax H3 Attention Lab [Experimental]** | Output-neutral H3/VDN retention diagnostics, a dense-mask VDN topology oracle, and the earlier guarded spatial-local experiment. No path is presented as production sparse acceleration. |
 
 ### Diagnostics
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,23 @@
+# Unreleased
+
+## Exact Continuum prefix safety
+
+- Progressive Target Input now bypasses the private low-grid handoff when the prepared video denoise mask contains exact-zero values.
+- The fallback forwards the original target-grid noise, latent, mask, schedule, sampler, callback, and mutable shape metadata through one sampler lifetime, preserving ComfyUI's exact mask contract and stateful sampler behavior.
+- Audio-only protection and fractional video blends retain the existing progressive path.
+- Metrics distinguish the fallback from both ordinary and split-progressive sampling.
+
+## Attention Lab
+
+- Output-neutral diagnostics now measure native dense-attention mass retained by the public OpenVDN temporal topology, plus outside mass, boundary-frame mass, exact analytic pair density, and an optional authoritative Continuum seam.
+- Adds `vdn_reference_dense`, an all-head query-chunked dense-mask correctness oracle using complete 5-frame chunks, radius 1, global non-video tokens, and first/last row-and-column anchors.
+- The seam anchor requires `protected_video_prefix_latent_slots`; frame-count metadata is never guessed into latent indices.
+- No sparse-kernel or speed claim is made. OpenVDN's trained hybrid branch, compiled kernel, and separately licensed weights are not included.
+
+Decoded H3 media validation remains required before release or recommendation.
+
+---
+
 # MiniMax H3 Flow-Aligned Regenerate v0.2.1
 
 v0.2.1 adds CI-gated Comfy Registry publication. Runtime and sampling behavior are unchanged from v0.2.0.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -429,7 +429,10 @@ fresh-lifetime boundaries instead of reporting an unverified solver-reset boolea
   committed run is immediately invalidated and becomes ineligible for future trajectory selection.
   Guidance state clears in `finally`.
 - **Denoise masks:** current ComfyUI prepares each user mask to full latent-channel AV geometry before
-  OUTER_SAMPLE wrappers run. Progressive mode resizes only the prepared video portion, preserves the
+  OUTER_SAMPLE wrappers run. An exact-zero target-input video mask bypasses progressive splitting and
+  forwards the untouched target-grid sampler inputs once, because restoring the returned prefix cannot
+  undo the different context that generated rows would have seen during a resized low-grid pass. For
+  masks without exact-zero video values, progressive mode resizes only the prepared video portion, preserves the
   audio portion, spatially transfers the external latent image, converts it through H3's normal latent-in
   transform, and solves `noise = (x_sigma - (1-sigma) * latent_image) / (sigma * noise_scale)` so
   the next sampler invocation starts from the exact carried state. In target-input mode, mask-protected
@@ -449,11 +452,19 @@ latent would make the packed reference contract inconsistent.
 
 ## Attention lab
 
-Diagnostics sample selected heads/queries and report entropy and modality mass without retaining full
-matrices. Experimental sparse layers keep text/reference/audio global. Video queries retain non-video
-keys and all temporal positions inside a spatial patch window; configured heads remain fully global.
-Query-local restrictions are passed to ComfyUI attention backends as numeric QxK additive masks,
-because Core's boolean-mask path is a batch/key mask and cannot represent per-query sparsity.
-Unsupported mask backends fall back to native attention. Query chunking avoids a sequence-square mask.
-RoPE is untouched and block replacements are chained. If another optimized attention override exists,
-the experiment records a fallback and delegates to it.
+Diagnostics sample video queries on selected heads and report entropy, modality mass, OpenVDN-topology
+retained/outside mass, first/last anchor mass, optional Continuum seam mass, and exact analytic pair
+density without changing backend output. The VDN dense reference keeps every pair involving
+text/reference/audio global and restricts video/video pairs to complete 5-frame chunks in the previous,
+current, and next chunk. First/last boundary anchors are symmetric row-and-column anchors. A Continuum
+seam becomes a matching symmetric anchor only when `h3_continuum.protected_video_prefix_latent_slots`
+provides an authoritative latent index; frame-count metadata is never heuristically converted.
+
+The VDN reference and earlier spatial-local experiment both pass numeric QxK additive masks to ordinary
+ComfyUI attention backends in query chunks. They avoid retaining a sequence-square mask, but still use
+dense keys and repeated dense backend calls. They are correctness/topology experiments, not sparse
+execution or speed claims. Unsupported mask backends fall back to native attention. RoPE is untouched
+and block replacements are chained. If another optimized attention override exists, the experiment
+records a fallback and delegates to it. OpenVDN's compiled FlexAttention/BlockMask path was audited but
+is not transplanted: its static inference specialization and mask-cache lifecycle need bounded,
+real-H3 validation inside long-lived dynamic ComfyUI processes first.

--- a/docs/RESEARCH.md
+++ b/docs/RESEARCH.md
@@ -14,6 +14,7 @@ This design uses public work as evidence and inspiration while keeping H3 assump
 | [RALU](https://arxiv.org/abs/2507.08422) | Naively resizing noisy state causes distribution/timestep mismatch; spatial transitions need explicit noise semantics. | H3 uses a conditional rectified-flow state, exact transition probe, and fresh sampler lifetime instead of copying RALU's noise construction. |
 | [CineScale](https://arxiv.org/abs/2508.15774) | Self-cascade video regeneration and high-resolution degradation are relevant hypotheses. | Wan-specific positional changes are not transferred to H3 MM-RoPE. |
 | [FreeSwim](https://arxiv.org/abs/2511.14712) | Separate global and local-detail paths motivate selective spatial locality. | H3 is one multimodal stream; non-video and temporal paths remain global. |
+| [OpenVDN](https://openvdn.github.io/) | Complete 5-frame temporal chunks, previous/current/next chunk reach, global non-video tokens, and symmetric boundary anchors define a concrete H3 attention topology to measure. | Flow implements an independent output-neutral diagnostic and dense-mask oracle only. It does not include the trained linear branch, FlexAttention kernel, or separately licensed VDN-H3 weights. |
 | [HRDiT](https://arxiv.org/abs/2608.07003) | Positional-capacity analysis and per-head/layer scope diagnostics are worth investigating. | No sparse-head policy is recommended without H3 measurements. |
 | [ResDiT](https://arxiv.org/abs/2512.01426) | Separating global-layout positional behavior from local-detail receptive-field behavior supports the Attention Lab's local/global diagnostic framing. | No ResDiT PE scaling, Gaussian patch splicing, or spectral fusion is implemented. |
 | [Just-in-Time](https://arxiv.org/abs/2603.10744) | Fine spatial compute can be deferred while global structure forms. | JiT SAG-ODE/DMF token activation is not treated as a license for arbitrary latent resizing. |
@@ -156,6 +157,7 @@ CI checks executable contracts at:
 - ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`
 - Spectrum `beb32dd210ef9e95520453107f158241d4f2ecf3`
 - Continuum `bf25353d8bec44afea22c89717c4301ce13c2036`
+- OpenVDN code `b8cb28fbfca0266d1c7742a9f25ab8b58191de97` (Apache-2.0 code inspected; weights not downloaded or used)
 - DiffAid `ba9d9efbcf7e64c755e068cb76547d8cc85481eb`
 - RefDelta `034e4c4c14c56bf76813cee4765e7164b0c7e0db`
 - Untwisting RoPE `299d4c56a3f057a97b3140d2136189bcd1e7d6bb`

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -49,6 +49,8 @@ Do **not** add a separate Trajectory Capture node on this path. The progressive 
 
 Continuum remains configured for the final target width/height. The wrapper creates a private smaller video state for the early stage, performs the handoff, rebuilds target-grid conditioning, and continues at the final grid.
 
+If the prepared video denoise mask contains any exact-zero values, the exact native-masked contract takes precedence over progressive resizing. Flow forwards the original target noise, latent, mask, schedule, sampler, callback, and shape metadata through one ordinary target-grid sampler lifetime. No private noise, spatial transfer, exact probe, history boundary, or progressive guidance is used. A `progressive_target_fallback` metrics event records this path. Audio-only zero masks do not trigger it, and fractional video masks remain intentional blends rather than exact protection.
+
 ### What happens at the handoff
 
 At the selected handoff point the wrapper:
@@ -379,10 +381,13 @@ The node cannot retroactively change Qwen3-VL tokens that have already been enco
 Modes:
 
 - `native` — no attention change;
-- `diagnostic` — inspect the selected H3 blocks/layout path;
-- `experimental_sparse` — guarded research experiment with selected layers, local window size, global heads, and sequence cap.
+- `diagnostic` — output-neutral measurement of native dense attention: entropy, modality mass, VDN-retained/outside mass, first/last boundary mass, exact mask density, and Continuum seam mass when authoritative seam metadata exists;
+- `vdn_reference_dense` — query-chunked dense additive-mask correctness oracle for OpenVDN's chunk-local temporal topology; this changes attention output but is explicitly not a sparse-compute or acceleration path;
+- `experimental_sparse` — the earlier guarded spatial-local/all-time dense-mask experiment with selected layers, local window size, global heads, and sequence cap.
 
-This is not an implementation of MiniMax's unreleased H3 sparse-attention topology and should not be treated as a production acceleration path.
+The VDN reference defaults are 5-frame chunks, radius 1 (previous/current/next complete chunks), globally visible non-video tokens, and `both` first/last anchors: every video query sees both boundary frames and both boundary-frame query rows see all video frames. When `continuum_seam_anchor` is enabled, the same symmetric anchor is added at the last protected latent frame only if Continuum supplies `protected_video_prefix_latent_slots`. Flow deliberately does not infer a latent seam from `context_frames`.
+
+The reference path still feeds ordinary attention backends dense Q×K masks in query chunks and can be slower than native attention. It is not OpenVDN's FlexAttention kernel, does not include OpenVDN's trained linear branch or weights, is not an implementation of MiniMax's unreleased H3 sparse-attention topology, and should not be treated as a production acceleration path.
 
 ## Evidence documents
 

--- a/h3_flow_regenerate/attention.py
+++ b/h3_flow_regenerate/attention.py
@@ -19,9 +19,13 @@ class AttentionConfig:
     global_heads: int = 8
     query_chunk: int = 64
     max_sequence: int = 8192
+    vdn_chunk_size: int = 5
+    vdn_chunk_radius: int = 1
+    vdn_anchor_mode: str = "both"
+    continuum_seam_anchor: bool = True
 
     def __post_init__(self) -> None:
-        if self.mode not in {"native", "diagnostic", "experimental_sparse"}:
+        if self.mode not in {"native", "diagnostic", "vdn_reference_dense", "experimental_sparse"}:
             raise ValueError(f"unsupported H3 attention mode {self.mode!r}")
         if any(layer < 0 for layer in self.layers):
             raise ValueError("H3 diagnostic/sparse layers must be non-negative")
@@ -31,6 +35,10 @@ class AttentionConfig:
             raise ValueError("sparse attention controls must be positive")
         if self.max_sequence < 1:
             raise ValueError("max_sequence must be positive")
+        if self.vdn_chunk_size < 1 or self.vdn_chunk_radius < 0:
+            raise ValueError("VDN chunk size must be positive and radius must be non-negative")
+        if self.vdn_anchor_mode not in {"none", "columns", "rows", "both"}:
+            raise ValueError(f"unsupported VDN anchor mode {self.vdn_anchor_mode!r}")
 
 
 def layout_summary(layout: Any) -> dict[str, Any]:
@@ -92,6 +100,155 @@ def video_local_mask(
     return mask
 
 
+def vdn_chunk_bounds(num_frames: int, *, chunk_size: int = 5, radius: int = 1) -> tuple[tuple[int, int], ...]:
+    """Return clamped chunk-aligned temporal bounds for each latent frame.
+
+    This independently implements the public OpenVDN c1 topology: a query sees
+    complete neighbouring chunks rather than a frame-centred partial window.
+    """
+    if num_frames < 1 or chunk_size < 1 or radius < 0:
+        raise ValueError("VDN frame count/chunk size must be positive and radius non-negative")
+    last = num_frames - 1
+    return tuple(
+        (
+            max(0, (frame // chunk_size - radius) * chunk_size),
+            min(last, (frame // chunk_size + radius + 1) * chunk_size - 1),
+        )
+        for frame in range(num_frames)
+    )
+
+
+def _video_layout(layout: Any) -> tuple[int, int, int, int]:
+    va, vb, _ = next(segment for segment in layout.segments if segment[2] == "video")
+    _, latent_t, latent_h, latent_w, _ = map(int, layout.signature)
+    tokens_per_frame = (latent_h // 2) * (latent_w // 2)
+    if latent_t < 1 or tokens_per_frame < 1 or vb - va != latent_t * tokens_per_frame:
+        raise ValueError("H3 video segment does not match the layout signature")
+    return int(va), int(vb), latent_t, tokens_per_frame
+
+
+def _vdn_allowed_frames(
+    frame: int,
+    *,
+    num_frames: int,
+    bounds: tuple[tuple[int, int], ...],
+    anchor_mode: str,
+    seam_frame: int | None,
+) -> set[int]:
+    lo, hi = bounds[frame]
+    allowed = set(range(lo, hi + 1))
+    if anchor_mode in {"columns", "both"}:
+        allowed.update((0, num_frames - 1))
+    if anchor_mode in {"rows", "both"} and frame in {0, num_frames - 1}:
+        allowed.update(range(num_frames))
+    if seam_frame is not None:
+        # The Continuum seam uses the same symmetric anchor rule as the first
+        # and last boundary anchors: all video queries see the seam frame, and
+        # seam-frame queries retain global video reach.
+        allowed.add(seam_frame)
+        if frame == seam_frame:
+            allowed.update(range(num_frames))
+    return allowed
+
+
+def vdn_reference_mask(
+    layout: Any,
+    query_indices: torch.Tensor,
+    *,
+    chunk_size: int = 5,
+    radius: int = 1,
+    anchor_mode: str = "both",
+    seam_frame: int | None = None,
+    device: torch.device,
+) -> torch.Tensor:
+    """Build the exact dense-mask reference for VDN's temporal topology.
+
+    Every pair involving a non-video token remains global. Video/video pairs
+    use complete chunk-aligned temporal windows across all spatial positions,
+    with optional first/last boundary anchors and a symmetric Continuum seam
+    anchor. This is a correctness oracle, not a sparse-compute implementation.
+    """
+    if anchor_mode not in {"none", "columns", "rows", "both"}:
+        raise ValueError(f"unsupported VDN anchor mode {anchor_mode!r}")
+    seq_len = int(layout.seq_len)
+    query_indices = query_indices.to(device=device, dtype=torch.long)
+    if bool((query_indices < 0).any()) or bool((query_indices >= seq_len).any()):
+        raise IndexError("attention query index is outside the packed sequence")
+    va, vb, num_frames, tokens_per_frame = _video_layout(layout)
+    if seam_frame is not None and not 0 <= seam_frame < num_frames:
+        raise ValueError("Continuum seam frame is outside the H3 video segment")
+    bounds = vdn_chunk_bounds(num_frames, chunk_size=chunk_size, radius=radius)
+    mask = torch.ones((query_indices.numel(), seq_len), dtype=torch.bool, device=device)
+    video_queries = (query_indices >= va) & (query_indices < vb)
+    video_rows = torch.nonzero(video_queries, as_tuple=False).flatten()
+    if video_rows.numel():
+        query_frames = torch.div(
+            query_indices[video_rows] - va,
+            tokens_per_frame,
+            rounding_mode="floor",
+        )
+        key_frames = torch.arange(num_frames, device=device).repeat_interleave(tokens_per_frame)
+        bound_tensor = torch.tensor(bounds, device=device, dtype=torch.long)
+        lo = bound_tensor[query_frames, 0]
+        hi = bound_tensor[query_frames, 1]
+        allowed = (key_frames[None, :] >= lo[:, None]) & (key_frames[None, :] <= hi[:, None])
+        if anchor_mode in {"columns", "both"}:
+            allowed |= (key_frames == 0) | (key_frames == num_frames - 1)
+        if anchor_mode in {"rows", "both"}:
+            boundary_queries = (query_frames == 0) | (query_frames == num_frames - 1)
+            allowed |= boundary_queries[:, None]
+        if seam_frame is not None:
+            allowed |= key_frames == seam_frame
+            allowed |= (query_frames == seam_frame)[:, None]
+        mask[video_rows, va:vb] = allowed
+    return mask
+
+
+def vdn_attention_density(
+    layout: Any,
+    *,
+    chunk_size: int = 5,
+    radius: int = 1,
+    anchor_mode: str = "both",
+    seam_frame: int | None = None,
+) -> dict[str, int | float]:
+    """Return exact allowed pair counts without materialising a square mask."""
+    va, vb, num_frames, tokens_per_frame = _video_layout(layout)
+    sequence = int(layout.seq_len)
+    video_rows = vb - va
+    global_rows = sequence - video_rows
+    bounds = vdn_chunk_bounds(num_frames, chunk_size=chunk_size, radius=radius)
+    allowed_pairs = global_rows * sequence
+    for frame in range(num_frames):
+        allowed_frames = _vdn_allowed_frames(
+            frame,
+            num_frames=num_frames,
+            bounds=bounds,
+            anchor_mode=anchor_mode,
+            seam_frame=seam_frame,
+        )
+        allowed_keys = global_rows + len(allowed_frames) * tokens_per_frame
+        allowed_pairs += tokens_per_frame * allowed_keys
+    total_pairs = sequence * sequence
+    return {
+        "allowed_pairs": allowed_pairs,
+        "total_pairs": total_pairs,
+        "density": allowed_pairs / total_pairs,
+    }
+
+
+def _continuum_seam_frame(transformer: dict[str, Any], num_frames: int) -> tuple[int | None, str]:
+    request = transformer.get("h3_continuum")
+    if not isinstance(request, dict) or request.get("active") is not True:
+        return None, "continuum_inactive"
+    slots = request.get("protected_video_prefix_latent_slots")
+    if isinstance(slots, bool) or not isinstance(slots, int):
+        return None, "exact_prefix_slots_unavailable"
+    if not 1 <= slots <= num_frames:
+        return None, "exact_prefix_slots_invalid"
+    return slots - 1, "exact_contract"
+
+
 def _call_backend(backend, q, k, v, heads: int, kwargs: dict[str, Any], *, mask=None):
     call_kwargs = dict(kwargs)
     call_kwargs["_inside_attn_wrapper"] = True
@@ -137,6 +294,36 @@ def _sparse_attention(backend, q, k, v, heads, layout, config, kwargs):
     return torch.cat(pieces, dim=2).reshape(q.shape[0], sequence, heads * q.shape[-1])
 
 
+def _vdn_reference_attention(backend, q, k, v, heads, layout, config, kwargs, *, seam_frame):
+    sequence = int(q.shape[-2])
+    chunks: list[torch.Tensor] = []
+    for start in range(0, sequence, config.query_chunk):
+        stop = min(sequence, start + config.query_chunk)
+        indices = torch.arange(start, stop, device=q.device)
+        allowed = vdn_reference_mask(
+            layout,
+            indices,
+            chunk_size=config.vdn_chunk_size,
+            radius=config.vdn_chunk_radius,
+            anchor_mode=config.vdn_anchor_mode,
+            seam_frame=seam_frame,
+            device=q.device,
+        )
+        additive_mask = torch.zeros(allowed.shape, dtype=q.dtype, device=q.device)
+        additive_mask.masked_fill_(~allowed, -torch.finfo(q.dtype).max)
+        out = _call_backend(
+            backend,
+            q[:, :, start:stop],
+            k,
+            v,
+            heads,
+            kwargs,
+            mask=additive_mask,
+        )
+        chunks.append(out.reshape(q.shape[0], stop - start, heads, q.shape[-1]))
+    return torch.cat(chunks, dim=1).reshape(q.shape[0], sequence, heads * q.shape[-1])
+
+
 def make_attention_override(
     config: AttentionConfig,
     metrics: H3FlowMetrics,
@@ -157,10 +344,63 @@ def make_attention_override(
                 return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
             return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
         if config.mode == "diagnostic":
-            _record_attention_diagnostic(q, k, layout, layer, config, metrics)
+            _record_attention_diagnostic(q, k, layout, layer, config, metrics, transformer)
             if previous_override is not None:
                 return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
             return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+        if config.mode == "vdn_reference_dense":
+            if previous_override is not None:
+                metrics.event("attention_fallback", layer=layer, reason="existing_attention_override")
+                return previous_override(backend, q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+            sequence = int(q.shape[-2])
+            if sequence > config.max_sequence:
+                metrics.event("attention_fallback", layer=layer, reason="sequence_guard")
+                return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
+            _, _, num_frames, _ = _video_layout(layout)
+            seam_frame, seam_status = (None, "disabled")
+            if config.continuum_seam_anchor:
+                seam_frame, seam_status = _continuum_seam_frame(transformer, num_frames)
+            try:
+                result = _vdn_reference_attention(
+                    backend,
+                    q,
+                    k,
+                    v,
+                    heads,
+                    layout,
+                    config,
+                    kwargs,
+                    seam_frame=seam_frame,
+                )
+            except (RuntimeError, TypeError, ValueError) as exc:
+                metrics.event(
+                    "attention_fallback",
+                    layer=layer,
+                    reason="backend_rejected_vdn_reference_mask",
+                    error=type(exc).__name__,
+                )
+                return backend(q, k, v, heads, mask=None, skip_reshape=True, **kwargs)
+            density = vdn_attention_density(
+                layout,
+                chunk_size=config.vdn_chunk_size,
+                radius=config.vdn_chunk_radius,
+                anchor_mode=config.vdn_anchor_mode,
+                seam_frame=seam_frame,
+            )
+            metrics.event(
+                "attention_vdn_reference",
+                layer=layer,
+                sequence=sequence,
+                chunk_size=config.vdn_chunk_size,
+                chunk_radius=config.vdn_chunk_radius,
+                anchor_mode=config.vdn_anchor_mode,
+                seam_frame=seam_frame,
+                seam_status=seam_status,
+                implementation="dense_additive_mask",
+                acceleration_claim=False,
+                **density,
+            )
+            return result
         if config.mode != "experimental_sparse":
             return backend(q, k, v, heads, mask=mask, skip_reshape=True, **kwargs)
         if previous_override is not None:
@@ -198,24 +438,66 @@ def make_attention_override(
     return override
 
 
-def _record_attention_diagnostic(q, k, layout, layer, config, metrics) -> None:
+def _record_attention_diagnostic(q, k, layout, layer, config, metrics, transformer) -> None:
     head = min(config.diagnostic_head, q.shape[1] - 1)
-    sequence = q.shape[-2]
-    count = min(config.diagnostic_queries, sequence)
-    indices = torch.linspace(0, sequence - 1, count, device=q.device).round().long()
+    va, vb, num_frames, tokens_per_frame = _video_layout(layout)
+    count = min(config.diagnostic_queries, vb - va)
+    indices = torch.linspace(va, vb - 1, count, device=q.device).round().long()
     logits = torch.matmul(q[0, head, indices].float(), k[0, head].float().transpose(0, 1)) / math.sqrt(q.shape[-1])
     probabilities = logits.softmax(dim=-1)
+    seam_frame, seam_status = (None, "disabled")
+    if config.continuum_seam_anchor:
+        seam_frame, seam_status = _continuum_seam_frame(transformer, num_frames)
+    allowed = vdn_reference_mask(
+        layout,
+        indices,
+        chunk_size=config.vdn_chunk_size,
+        radius=config.vdn_chunk_radius,
+        anchor_mode=config.vdn_anchor_mode,
+        seam_frame=seam_frame,
+        device=q.device,
+    )
+    retained_mass = (probabilities * allowed).sum(dim=-1)
+    outside_mass = (probabilities * ~allowed).sum(dim=-1)
     entropy = -(probabilities.clamp_min(1e-12).log() * probabilities).sum(dim=-1).mean()
     masses: dict[str, float] = {}
     for a, b, kind in layout.segments:
         masses[kind] = masses.get(kind, 0.0) + float(probabilities[:, a:b].sum(dim=-1).mean().item())
+    density = vdn_attention_density(
+        layout,
+        chunk_size=config.vdn_chunk_size,
+        radius=config.vdn_chunk_radius,
+        anchor_mode=config.vdn_anchor_mode,
+        seam_frame=seam_frame,
+    )
+    boundary_mass = {
+        "first": float(probabilities[:, va : va + tokens_per_frame].sum(dim=-1).mean().item()),
+        "last": float(probabilities[:, vb - tokens_per_frame : vb].sum(dim=-1).mean().item()),
+    }
+    seam_mass = None
+    if seam_frame is not None:
+        seam_start = va + seam_frame * tokens_per_frame
+        seam_mass = float(probabilities[:, seam_start : seam_start + tokens_per_frame].sum(dim=-1).mean().item())
     metrics.event(
         "attention_diagnostic",
         layer=layer,
         head=head,
         queries=count,
+        query_scope="video",
         entropy=float(entropy.item()),
         modality_mass=masses,
+        vdn_retained_mass_mean=float(retained_mass.mean().item()),
+        vdn_retained_mass_min=float(retained_mass.min().item()),
+        vdn_outside_mass_mean=float(outside_mass.mean().item()),
+        vdn_chunk_size=config.vdn_chunk_size,
+        vdn_chunk_radius=config.vdn_chunk_radius,
+        vdn_anchor_mode=config.vdn_anchor_mode,
+        boundary_mass=boundary_mass,
+        continuum_seam_frame=seam_frame,
+        continuum_seam_status=seam_status,
+        continuum_seam_mass=seam_mass,
+        output_neutral=True,
+        **density,
     )
 
 

--- a/h3_flow_regenerate/nodes.py
+++ b/h3_flow_regenerate/nodes.py
@@ -677,13 +677,22 @@ class H3AttentionExperiment:
         return {
             "required": {
                 "model": ("MODEL",),
-                "mode": (["native", "diagnostic", "experimental_sparse"], {"default": "native"}),
+                "mode": (
+                    ["native", "diagnostic", "vdn_reference_dense", "experimental_sparse"],
+                    {"default": "native"},
+                ),
                 "layers": ("STRING", {"default": "8,16,24,32,40"}),
                 "sparse_window": ("INT", {"default": 4, "min": 1, "max": 32}),
                 "global_heads": ("INT", {"default": 8, "min": 0, "max": 56}),
                 "max_sequence": ("INT", {"default": 8192, "min": 256, "max": 65536}),
             },
-            "optional": {"metrics": ("H3_FLOW_METRICS",)},
+            "optional": {
+                "metrics": ("H3_FLOW_METRICS",),
+                "vdn_chunk_size": ("INT", {"default": 5, "min": 1, "max": 32}),
+                "vdn_chunk_radius": ("INT", {"default": 1, "min": 0, "max": 8}),
+                "vdn_anchor_mode": (["both", "columns", "rows", "none"], {"default": "both"}),
+                "continuum_seam_anchor": ("BOOLEAN", {"default": True}),
+            },
         }
 
     RETURN_TYPES = ("MODEL", "H3_FLOW_METRICS")
@@ -691,7 +700,20 @@ class H3AttentionExperiment:
     FUNCTION = "patch"
     CATEGORY = "MiniMax H3/flow regenerate/experimental"
 
-    def patch(self, model, mode, layers, sparse_window, global_heads, max_sequence, metrics=None):
+    def patch(
+        self,
+        model,
+        mode,
+        layers,
+        sparse_window,
+        global_heads,
+        max_sequence,
+        metrics=None,
+        vdn_chunk_size=5,
+        vdn_chunk_radius=1,
+        vdn_anchor_mode="both",
+        continuum_seam_anchor=True,
+    ):
         try:
             selected = tuple(sorted({int(value.strip()) for value in layers.split(",") if value.strip()}))
         except ValueError as exc:
@@ -704,6 +726,10 @@ class H3AttentionExperiment:
             sparse_window=sparse_window,
             global_heads=global_heads,
             max_sequence=max_sequence,
+            vdn_chunk_size=vdn_chunk_size,
+            vdn_chunk_radius=vdn_chunk_radius,
+            vdn_anchor_mode=vdn_anchor_mode,
+            continuum_seam_anchor=continuum_seam_anchor,
         )
         metrics = metrics or H3FlowMetrics()
         if mode == "native":

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -717,6 +717,28 @@ def _resize_packed_mask(
     return packed
 
 
+def _has_exact_video_protection(
+    mask: torch.Tensor | None,
+    shapes: list[tuple[int, ...]],
+) -> bool:
+    """Return whether a prepared packed H3 mask exactly protects video values.
+
+    ComfyUI's inpaint contract uses mask value zero for exact preservation and
+    supports fractional values as intentional blends.  Progressive target-input
+    sampling may therefore resize fractional masks, but it must not resize any
+    video value whose downstream sampler contract is exact.
+    """
+    if mask is None:
+        return False
+    if len(shapes) != 2:
+        raise ValueError("H3 exact-protection detection requires video and audio shapes")
+    expected = (shapes[0][0], 1, sum(math.prod(shape[1:]) for shape in shapes))
+    if tuple(mask.shape) != expected:
+        raise ValueError("prepared H3 denoise mask does not match packed AV geometry")
+    video_mask, _audio_mask = unpack_streams(mask, shapes)
+    return bool(torch.any(video_mask == 0).item())
+
+
 def _merge_preserved_noise(
     generated_noise: torch.Tensor,
     preserved_noise: torch.Tensor,
@@ -867,6 +889,45 @@ def _run_progressive(
 ):
     if len(latent_shapes) != 2:
         raise ValueError("progressive handoff supports native packed H3 AV latents only")
+    input_shapes = list(latent_shapes)
+    if isinstance(config, ProgressiveTargetInputConfig) and _has_exact_video_protection(denoise_mask, input_shapes):
+        # Native masked continuation promises exact video-prefix preservation.
+        # A private low-grid lifetime would resize those clean prefix latents and
+        # expose the changed values to every generated row through H3's dense
+        # attention.  A later mask/noise merge can restore the returned prefix,
+        # but it cannot undo that altered low-stage context.  Preserve the exact
+        # contract by executing the untouched target-grid sampler once.
+        binding.metrics.increment("progressive_target_fallbacks")
+        binding.metrics.increment("progressive_sampler_invocations")
+        binding.metrics.event(
+            "progressive_target_fallback",
+            reason="exact_video_protection",
+            input_mode="target_grid",
+            target_shape=input_shapes[0],
+            sampler_invocation_count=1,
+            history_boundary_count=0,
+            exact_target_inputs_forwarded=True,
+            progressive_guidance_applied=False,
+        )
+        _begin_capture(binding, guider, sampler, sigmas, input_shapes)
+        error: BaseException | None = None
+        try:
+            return executor(
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes=latent_shapes,
+            )
+        except BaseException as exc:
+            error = exc
+            raise
+        finally:
+            _finish_capture(binding, error=error)
     _validate_progressive_sampler_state(sampler)
     if sigmas.ndim != 1 or sigmas.numel() < 4:
         raise ValueError("progressive handoff requires a full H3 sigma schedule")
@@ -874,7 +935,6 @@ def _run_progressive(
         float(sigmas[-1]), 0.0, rel_tol=0.0, abs_tol=1e-8
     ):
         raise ValueError("progressive handoff requires a full 1-to-0 H3 sigma schedule")
-    input_shapes = list(latent_shapes)
     if input_shapes[0][-2] % 2 or input_shapes[0][-1] % 2:
         raise ValueError("input H3 geometry is not patch-safe")
     model_options = getattr(guider, "model_options", None)

--- a/tests/test_attention_reference_runtime.py
+++ b/tests/test_attention_reference_runtime.py
@@ -4,7 +4,16 @@ from types import ModuleType, SimpleNamespace
 import pytest
 import torch
 
-from h3_flow_regenerate.attention import AttentionConfig, layout_summary, make_attention_override, video_local_mask
+from h3_flow_regenerate.attention import (
+    AttentionConfig,
+    _continuum_seam_frame,
+    layout_summary,
+    make_attention_override,
+    vdn_attention_density,
+    vdn_chunk_bounds,
+    vdn_reference_mask,
+    video_local_mask,
+)
 from h3_flow_regenerate.comfy_compat import patch_flow_model, reconfigure_binding
 from h3_flow_regenerate.contracts import H3FlowTrajectory
 from h3_flow_regenerate.geometry import pack_streams, unpack_streams
@@ -26,6 +35,7 @@ from h3_flow_regenerate.runtime import (
     _begin_capture,
     _conditioning_signature,
     _finish_capture,
+    _has_exact_video_protection,
     _high_stage_contract,
     _make_probe_sampler,
     _merge_preserved_noise,
@@ -49,6 +59,15 @@ def layout():
     )
 
 
+def temporal_layout():
+    # Three global rows followed by 12 one-token video frames.
+    return SimpleNamespace(
+        segments=[(0, 2, "text"), (2, 3, "audio"), (3, 15, "video")],
+        signature=(2, 12, 2, 2, 1),
+        seq_len=15,
+    )
+
+
 def test_sparse_mask_keeps_nonvideo_global_and_video_spatiotemporal_local():
     mask = video_local_mask(layout(), torch.tensor([0, 8]), radius=1, device=torch.device("cpu"))
     assert mask[0].all()
@@ -58,6 +77,116 @@ def test_sparse_mask_keeps_nonvideo_global_and_video_spatiotemporal_local():
     assert mask[1, 14]
     # Far spatial corner is hidden.
     assert not mask[1, 13]
+
+
+def test_vdn_chunk_topology_uses_complete_neighbour_chunks_and_short_tail():
+    assert vdn_chunk_bounds(12, chunk_size=5, radius=1) == (
+        *((0, 9),) * 5,
+        *((0, 11),) * 5,
+        *((5, 11),) * 2,
+    )
+    test_layout = temporal_layout()
+    # global, first-frame boundary row, frame 4, and final short-chunk frame
+    queries = torch.tensor([0, 3, 7, 13])
+    mask = vdn_reference_mask(
+        test_layout,
+        queries,
+        chunk_size=5,
+        radius=1,
+        anchor_mode="both",
+        device=torch.device("cpu"),
+    )
+    assert mask[0].all()
+    assert mask[1].all()
+    assert mask[2, 3:13].all()  # frames 0..9
+    assert not mask[2, 13]  # frame 10 is outside the window
+    assert mask[2, 14]  # last-frame anchor column
+    assert mask[3, 3]  # first-frame anchor column
+    assert not mask[3, 4:8].any()  # frames 1..4 are outside the final chunk's window
+    assert mask[3, 8:15].all()  # frames 5..11
+
+
+def test_vdn_row_column_and_continuum_seam_anchor_semantics():
+    test_layout = temporal_layout()
+    query = torch.tensor([7])  # frame 4: first chunk, but not a boundary frame
+    columns = vdn_reference_mask(
+        test_layout,
+        query,
+        chunk_size=5,
+        radius=0,
+        anchor_mode="columns",
+        device=torch.device("cpu"),
+    )
+    assert columns[0, 3] and columns[0, 14]
+    assert not columns[0, 13]
+
+    first_row = vdn_reference_mask(
+        test_layout,
+        torch.tensor([3]),
+        chunk_size=5,
+        radius=0,
+        anchor_mode="rows",
+        device=torch.device("cpu"),
+    )
+    assert first_row.all()
+
+    seam = vdn_reference_mask(
+        test_layout,
+        torch.tensor([7, 13]),
+        chunk_size=5,
+        radius=0,
+        anchor_mode="none",
+        seam_frame=4,
+        device=torch.device("cpu"),
+    )
+    assert seam[0].all()  # seam query row is global over video keys
+    assert seam[1, 7]  # every video query sees the seam key column
+    assert not seam[1, 6]
+
+
+def test_vdn_density_matches_materialized_reference_mask_exactly():
+    test_layout = temporal_layout()
+    full = vdn_reference_mask(
+        test_layout,
+        torch.arange(test_layout.seq_len),
+        chunk_size=5,
+        radius=1,
+        anchor_mode="both",
+        seam_frame=4,
+        device=torch.device("cpu"),
+    )
+    density = vdn_attention_density(
+        test_layout,
+        chunk_size=5,
+        radius=1,
+        anchor_mode="both",
+        seam_frame=4,
+    )
+    assert density["allowed_pairs"] == int(full.sum().item())
+    assert density["total_pairs"] == full.numel()
+    assert density["density"] == pytest.approx(float(full.float().mean().item()))
+
+
+def test_continuum_seam_requires_authoritative_latent_slot_metadata():
+    frame, status = _continuum_seam_frame(
+        {"h3_continuum": {"active": True, "context_frames": 5}},
+        12,
+    )
+    assert frame is None
+    assert status == "exact_prefix_slots_unavailable"
+
+    frame, status = _continuum_seam_frame(
+        {
+            "h3_continuum": {
+                "active": True,
+                "context_frames": 5,
+                "protected_video_prefix_latent_slots": 2,
+            }
+        },
+        12,
+    )
+    assert frame == 1
+    assert status == "exact_contract"
 
 
 def test_layout_summary_counts_packed_modalities():
@@ -166,11 +295,89 @@ def test_attention_diagnostic_preserves_existing_override():
         q,
         2,
         skip_reshape=True,
-        transformer_options={"h3_flow_attention_context": {"layout": layout(), "layer": 0}},
+        transformer_options={
+            "h3_flow_attention_context": {"layout": layout(), "layer": 0},
+            "h3_continuum": {
+                "active": True,
+                "protected_video_prefix_latent_slots": 1,
+            },
+        },
     )
     assert result.shape == (1, 20, 8)
     assert calls == [(None, True)]
-    assert metrics.events[-1].kind == "attention_diagnostic"
+    event = metrics.events[-1]
+    assert event.kind == "attention_diagnostic"
+    assert event.fields["query_scope"] == "video"
+    assert event.fields["output_neutral"] is True
+    assert event.fields["vdn_chunk_size"] == 5
+    assert event.fields["vdn_chunk_radius"] == 1
+    assert event.fields["vdn_anchor_mode"] == "both"
+    assert event.fields["continuum_seam_frame"] == 0
+    assert event.fields["continuum_seam_status"] == "exact_contract"
+    assert event.fields["continuum_seam_mass"] is not None
+    assert event.fields["vdn_retained_mass_mean"] == pytest.approx(1.0)
+    assert event.fields["vdn_outside_mass_mean"] == pytest.approx(0.0)
+
+
+def test_vdn_reference_dense_uses_all_head_query_chunk_masks_without_claiming_acceleration():
+    test_layout = temporal_layout()
+    q = torch.randn(1, 2, 15, 4)
+    observed = []
+
+    def backend(q, _k, _v, heads, mask=None, skip_reshape=False, **_kwargs):
+        assert heads == 2
+        assert skip_reshape
+        if mask is not None:
+            observed.append(mask.detach().clone())
+        return torch.zeros(q.shape[0], q.shape[2], heads * q.shape[-1], dtype=q.dtype)
+
+    metrics = H3FlowMetrics()
+    override = make_attention_override(
+        AttentionConfig(
+            mode="vdn_reference_dense",
+            layers=(0,),
+            query_chunk=6,
+            max_sequence=32,
+            vdn_chunk_size=5,
+            vdn_chunk_radius=1,
+            vdn_anchor_mode="both",
+        ),
+        metrics,
+    )
+    result = override(
+        backend,
+        q,
+        q,
+        q,
+        2,
+        skip_reshape=True,
+        transformer_options={
+            "h3_flow_attention_context": {"layout": test_layout, "layer": 0},
+            "h3_continuum": {
+                "active": True,
+                "protected_video_prefix_latent_slots": 5,
+            },
+        },
+    )
+    assert result.shape == (1, 15, 8)
+    assert [mask.shape for mask in observed] == [(6, 15), (6, 15), (3, 15)]
+    expected = vdn_reference_mask(
+        test_layout,
+        torch.arange(15),
+        chunk_size=5,
+        radius=1,
+        anchor_mode="both",
+        seam_frame=4,
+        device=torch.device("cpu"),
+    )
+    actual = torch.cat([mask.eq(0) for mask in observed], dim=0)
+    assert torch.equal(actual, expected)
+    event = metrics.events[-1]
+    assert event.kind == "attention_vdn_reference"
+    assert event.fields["implementation"] == "dense_additive_mask"
+    assert event.fields["acceleration_claim"] is False
+    assert event.fields["seam_frame"] == 4
+    assert event.fields["allowed_pairs"] == int(expected.sum().item())
 
 
 def test_sparse_backend_error_falls_back_to_full_attention():
@@ -1150,6 +1357,24 @@ def test_progressive_mask_resize_uses_prepared_full_channel_av_geometry():
     assert torch.equal(out_audio, audio_mask)
 
 
+def test_exact_video_protection_detection_ignores_audio_and_fractional_video_masks():
+    shapes = [(1, 24, 2, 4, 4), (1, 32, 2, 5)]
+    video_mask = torch.ones(shapes[0])
+    audio_mask = torch.ones(shapes[1])
+
+    audio_mask[..., 0] = 0
+    audio_only, _ = pack_streams((video_mask, audio_mask))
+    assert not _has_exact_video_protection(audio_only, shapes)
+
+    video_mask[..., 0, :, :] = 0.25
+    fractional_video, _ = pack_streams((video_mask, audio_mask))
+    assert not _has_exact_video_protection(fractional_video, shapes)
+
+    video_mask[..., 0, :, :] = 0
+    exact_video, _ = pack_streams((video_mask, audio_mask))
+    assert _has_exact_video_protection(exact_video, shapes)
+
+
 def test_preserved_noise_merge_keeps_native_noise_only_under_mask():
     generated = torch.full((1, 1, 8), 7.0)
     native = torch.arange(8, dtype=torch.float32).reshape(1, 1, 8)
@@ -1365,7 +1590,7 @@ def test_progressive_rejects_explicit_stateful_noise_sampler():
         _validate_progressive_sampler_state(sampler)
 
 
-def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
+def test_target_input_progressive_keeps_target_geometry_for_fractional_video_masks(monkeypatch):
     class KSampler:
         def __init__(self, function, inpaint_options=None):
             self.sampler_function = function
@@ -1384,7 +1609,7 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
     target_latent, target_shapes = pack_streams((target_video, target_audio))
     target_noise = torch.randn_like(target_latent)
     video_mask = torch.ones(1, 24, 1, 8, 6)
-    video_mask[:, :, :, :2] = 0
+    video_mask[:, :, :, :2] = 0.25
     audio_mask = torch.ones(1, 32, 2, 5)
     packed_mask, _ = pack_streams((video_mask, audio_mask))
     source_video = torch.randn(1, 24, 1, 4, 4)
@@ -1560,6 +1785,124 @@ def test_target_input_progressive_keeps_continuum_target_geometry(monkeypatch):
     assert binding.metrics.counters["progressive_sampler_invocations"] == 6
     assert binding.metrics.counters["progressive_history_boundaries"] == 4
     assert len(learned_provider.calls) == 1
+
+
+def test_target_input_exact_video_protection_forwards_one_untouched_target_sampler_call():
+    target_video = torch.randn(1, 24, 2, 8, 6)
+    target_audio = torch.randn(1, 32, 2, 5)
+    target_latent, target_shapes = pack_streams((target_video, target_audio))
+    target_noise = torch.randn_like(target_latent)
+    video_mask = torch.ones_like(target_video)
+    video_mask[:, :, :1] = 0
+    audio_mask = torch.ones_like(target_audio)
+    packed_mask, _ = pack_streams((video_mask, audio_mask))
+    sigmas = torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_stateful"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={"noise_sampler": object()})
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+    callback = object()
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(
+            self,
+            noise,
+            latent,
+            call_sampler,
+            call_sigmas,
+            mask,
+            call_callback,
+            disable_pbar,
+            seed,
+            *,
+            latent_shapes,
+        ):
+            calls.append(
+                (
+                    noise,
+                    latent,
+                    call_sampler,
+                    call_sigmas,
+                    mask,
+                    call_callback,
+                    disable_pbar,
+                    seed,
+                    latent_shapes,
+                )
+            )
+            return latent
+
+    class UnusedProvider:
+        api_version = 1
+        kind = "minimax_h3_learned_latent_upscaler"
+        model_name = "unused.safetensors"
+        device = "cpu"
+        precision = "fp32"
+        offload_after_upscale = False
+
+        def upscale_clean_video(self, *_args, **_kwargs):
+            raise AssertionError("exact-prefix fallback must not invoke the transfer provider")
+
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(
+        trajectory=trajectory,
+        guidance=GuidanceConfig(mode="direction"),
+        capture_enabled=True,
+    )
+    mutable_shapes = list(target_shapes)
+    result = _run_progressive(
+        Executor(),
+        guider,
+        binding,
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            handoff_coordinate=0.3,
+            transfer_mode="learned_3d",
+            learned_upscaler=UnusedProvider(),
+        ),
+        target_noise,
+        target_latent,
+        sampler,
+        sigmas,
+        packed_mask,
+        callback,
+        True,
+        7,
+        mutable_shapes,
+    )
+
+    assert result is target_latent
+    assert len(calls) == 1
+    call = calls[0]
+    assert call[0] is target_noise
+    assert call[1] is target_latent
+    assert call[2] is sampler
+    assert call[3] is sigmas
+    assert call[4] is packed_mask
+    assert call[5] is callback
+    assert call[6:] == (True, 7, mutable_shapes)
+    assert mutable_shapes == target_shapes
+    event = [event for event in binding.metrics.events if event.kind == "progressive_target_fallback"][-1]
+    assert event.fields["reason"] == "exact_video_protection"
+    assert event.fields["sampler_invocation_count"] == 1
+    assert event.fields["history_boundary_count"] == 0
+    assert event.fields["exact_target_inputs_forwarded"] is True
+    assert event.fields["progressive_guidance_applied"] is False
+    assert binding.metrics.counters["progressive_target_fallbacks"] == 1
+    assert binding.metrics.counters["progressive_sampler_invocations"] == 1
+    assert trajectory.latest.complete
+    assert trajectory.latest.geometry.latent_h == 8
+    assert trajectory.latest.geometry.latent_w == 6
 
 
 def test_progressive_high_failure_invalidates_committed_low_trajectory(monkeypatch):


### PR DESCRIPTION
## Summary

- preserve ComfyUI/Continuum's exact video-prefix contract in Progressive Target Input
- add output-neutral OpenVDN-topology retention diagnostics
- add an all-head, query-chunked dense-mask VDN correctness oracle
- add exact chunk/anchor/density tests and clarify source/license boundaries

## Root cause and fix

Continuum copies its accepted latent tail into the next chunk and marks that video prefix with an exact-zero denoise mask. Flow previously resized the entire target latent into the private low grid. Even though the later target-noise merge restored protected values at the high-grid boundary, it could not undo the different protected context that generated rows had already seen during low-stage dense self-attention.

When a prepared target-input video mask contains any exact zero, Flow now forwards the original noise, latent, mask, schedule, sampler, callback, and mutable shape metadata through one ordinary target-grid sampler lifetime. It does not create private noise, resize state/conditioning, call a learned transfer provider, split sampler/Spectrum history, run a handoff probe, or apply same-invocation progressive guidance. Audio-only protection and fractional video blends retain existing progressive behavior.

The path emits `progressive_target_fallback` and preserves target-geometry trajectory capture.

## Attention Lab

`diagnostic` remains output-neutral and now reports:

- VDN retained/outside native dense-attention mass
- modality and first/last boundary mass
- exact analytic allowed-pair density
- Continuum seam mass/status when authoritative metadata exists

`vdn_reference_dense` independently implements the public OpenVDN reference topology:

- complete 5-latent-frame chunks
- radius 1: previous/current/next chunks
- all non-video token pairs global
- first/last symmetric row-and-column anchors
- optional symmetric Continuum seam anchor

This reference still uses ordinary dense attention backends with Q×K additive masks in query chunks. It is a correctness oracle, not sparse compute or a performance claim. It does not include OpenVDN's trained linear branch, FlexAttention kernel, cache design, or separately licensed VDN-H3 weights.

The seam is fail-closed: Flow requires `h3_continuum.protected_video_prefix_latent_slots`. Current Continuum only emits `context_frames`, which Flow deliberately does not guess into a latent index. Companion exact latent-slot metadata remains a follow-up and does not affect the default-path prefix fallback in this PR.

## Validation

### Static / CI

- Ruff check: pass
- Ruff format check: pass
- pytest: **150 passed**
- compileall: pass
- sdist/wheel build: pass
- built-wheel import: pass
- pinned ComfyUI/H3 sibling source contracts: pass
- current ComfyUI audit through `5c23fb7b6cb5912b1488d1b20162987eefb07a99`: mask/attention contracts unchanged from the existing pin
- OpenVDN source audited at `b8cb28fbfca0266d1c7742a9f25ab8b58191de97`
- GitHub CI: green on `0d5ddf54670955322e9a0bb29172b3528263a0ec`

### Real H3 Continuum runtime

Matched two-chunk Native Masked runs were repeated with the ordinary `sa_solver_pece` sampler, same workflow stack/seed/reference settings, once without Progressive Target Input and once with this PR's progressive path enabled.

**Control — Progressive Target Input off**

- chunk 1: target-grid SA-PECE, 11 logical calls = 8 actual + 3 Spectrum forecasts, Spectrum wall `176.991 s`
- chunk 2: Continuum `actual_prefix=2`, target-grid SA-PECE, 11 logical calls = 8 actual + 3 forecasts, Spectrum wall `219.901 s`
- full workflow: `440.32 s`
- decoded result: no full-frame jitter/flashing

**Progressive Target Input on**

- chunk 1 low stage: 7 logical calls = 6 actual + 1 forecast, `59.134 s`
- exact handoff probe: 1 exact NFE at sigma `0.8575096726`, `10.522 s`
- chunk 1 high stage: 3 actual calls, `66.304 s`
- chunk 2: exact protected-video prefix detected; `progressive_target_fallback` forwards the untouched target-grid inputs through one ordinary sampler lifetime
- chunk 2 fallback: 11 logical calls = 8 actual + 3 forecasts, Spectrum wall `215.644 s`
- metrics: `progressive_target_fallbacks=1`, `handoff_exact_probe_nfe=1`, `progressive_history_boundaries=2`, `progressive_sampler_invocations=4`, total transformer `18 actual / 4 forecast`
- full workflow: `398.64 s` (~9.5% below the matched non-progressive workflow; only chunk 1 is progressively accelerated because chunk 2 correctly falls back)
- decoded result: no full-frame jitter/flashing; no new Continuum seam regression was reported, and the earlier tested seed/reference setup retained the material seam/cut improvement that motivated the fallback

The earlier merge-blocking flashing report was a false attribution. It reproduced with the external **MiniMax H3 RefDelta Stability Sampler** and disappeared when that sampler was replaced with ordinary SA-PECE, including the matched non-progressive control where both chunks use target-grid sampling. The flashing is therefore not evidence of a Flow fallback regression and is tracked separately from this PR.

## Merge status

Default-path runtime gates for the Continuum exact-prefix fix are passed:

- [x] real multi-chunk native-masked H3 Continuum decode
- [x] exact-prefix fallback event observed
- [x] one sampler invocation for the protected continuation chunk
- [x] original target-grid noise/latent/mask path used by the fallback
- [x] valid decoded video/audio workflow completion
- [x] no new flashing/jitter with ordinary SA-PECE
- [x] matched progressive-off control completed
- [x] CI green

The Attention Lab modes are opt-in research/correctness tools and do not alter the default model path. Further decoded-media exploration of `vdn_reference_dense` and companion Continuum seam-slot metadata remain follow-up research rather than blockers for the exact-prefix fix.

No release/version bump is included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the `vdn_reference_dense` attention mode with configurable temporal chunk size, radius, boundary anchors, and Continuum seam anchors.
  - Expanded Attention Lab diagnostics with video attention mass, topology, boundary, seam, and density metrics.
  - Added exact video-mask protection handling that preserves the original target-grid sampling path.

- **Documentation**
  - Updated usage, architecture, research, README, credits, and release notes with the new attention diagnostics and mask behavior.
  - Added OpenVDN attribution and clarified the reference implementation’s validation scope.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->