### PR TITLE
Release v0.3.0 mixed-grid Continuum handoff, seam bridge, and decode context

### DIFF
--- a/.comfyignore
+++ b/.comfyignore
@@ -1,0 +1,3 @@
+# Development-only files must not be shipped in Comfy Registry archives.
+.github/
+tests/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,13 +81,28 @@ jobs:
           git -C .contracts/Untwist checkout 299d4c56a3f057a97b3140d2136189bcd1e7d6bb
           git clone --filter=blob:none https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler.git .contracts/Upscaler
           git -C .contracts/Upscaler checkout bdc670e5926bcefbe4022e17fe8b171fbfcf15de
+          git clone --filter=blob:none https://github.com/xmarre/ComfyUI-VDN-H3.git .contracts/VDN
+          git -C .contracts/VDN checkout 1fc9d0d979683e3410587fac17358d3dd583e551
       - name: Validate native and sibling contracts
-        run: >-
-          python tools/check_source_contracts.py
-          --comfy .contracts/ComfyUI
-          --spectrum .contracts/Spectrum
-          --continuum .contracts/Continuum
-          --diffaid .contracts/DiffAid
-          --refdelta .contracts/RefDelta
-          --untwist .contracts/Untwist
-          --upscaler .contracts/Upscaler
+        run: |
+          python tools/check_source_contracts.py \
+            --comfy .contracts/ComfyUI \
+            --spectrum .contracts/Spectrum \
+            --continuum .contracts/Continuum \
+            --diffaid .contracts/DiffAid \
+            --refdelta .contracts/RefDelta \
+            --untwist .contracts/Untwist \
+            --upscaler .contracts/Upscaler
+          python tools/check_target_sparse_contracts.py \
+            --comfy .contracts/ComfyUI \
+            --spectrum .contracts/Spectrum \
+            --continuum .contracts/Continuum \
+            --diffaid .contracts/DiffAid \
+            --vdn .contracts/VDN
+      - name: Execute mixed-grid and temporal VAE native source oracles
+        env:
+          COMFYUI_ROOT: ${{ github.workspace }}/.contracts/ComfyUI
+        run: |
+          python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
+          python -m pip install pytest numpy scipy einops psutil safetensors tqdm pillow comfy-kitchen comfy-aimdo
+          python -m pytest tests/test_mixed_grid.py tests/test_decode_context.py -q

--- a/CREDITS.md
+++ b/CREDITS.md
@@ -14,6 +14,7 @@ These references are attribution, not relicensing. The research repositories lis
 | **MiniMax H3 Flow-Aligned Regenerate** / **Flow-Aligned Refine State** | **HiFlow**; **FrescoDiffusion** | Time-matched low-resolution trajectory guidance; low-frequency direction alignment; experimental adjacent-velocity acceleration; use of a low-resolution video trajectory as a global prior | HiFlow is an image method and FrescoDiffusion uses tiled prior-regularized fusion. This project adapts the ideas to H3 predicted-clean AV sampling rather than copying either pipeline. |
 | `direction+temporal` guidance | **TokenFlow**, **FRESCO**, **MoVideo**, **Upscale-A-Video**, **LatentWarp** | Inter-frame correspondence, latent/feature propagation, confidence/visibility gating, and the need to avoid transporting content through ambiguous or occluded regions | No external optical-flow model is loaded. H3 clean-state latents are locally matched with strict similarity, uniqueness, and reverse-cycle gates. |
 | **MiniMax H3 Progressive Handoff** | **RALU**, **Self-Cascade Diffusion**, **CineScale**, **Just-in-Time** | Coarse-to-fine sampling, explicit spatial transition semantics, re-noising after scale change, and deferring expensive high-resolution computation | The H3 handoff uses an exact probe plus a rectified-flow conditional state and fresh sampler/Spectrum lifetimes. It is not RALU NT-Matching, JiT DMF, or MiniMax H3-Regenerate-2K. |
+| **MiniMax H3 Progressive Target-Sparse Continuum [Experimental]** | **Just-in-Time**; **RALU**; MiniMax-H3 / ComfyUI native mask and packed-layout contracts | Deferring dense target-grid work with target-grid anchor tokens and a hidden-space lifter while retaining every exact protected video row and every non-video row | Independently written H3 adaptation. It does not implement JiT SAG-ODE/DMF/deterministic micro-flow, RALU NT-Matching, OpenVDN's trained hybrid path, or MiniMax's private sparse attention. Structural validity does not establish decoded-media quality or speedup. |
 | **Progressive Handoff (Target Input)** `learned_3d` | Companion **Comfyui_Minimax_h3_latent_Upscaler**; inherited **LBH-123-AI**, **ComfyUi_NNLatentUpscale**, and **LTX spatial-upscaler** lineage | A single learned clean-video spatial transform at the exact handoff boundary | Flow only consumes the companion provider API. The learned model/architecture lineage and checkpoints remain owned and credited by their upstream projects; audio, target noise, sigma law, masks, and H3 NFEs are unchanged. |
 | **MiniMax H3 Refine Target Geometry** | Companion **Comfyui_Minimax_h3_latent_Upscaler** | Mirrors the companion node's scale-by-multiplier geometry contract for schedule metadata | No latent upscale or sampling occurs in this helper. |
 | **MiniMax H3 Resolution-Aware Sigmas** | **simple diffusion**; **Scaling Rectified Flow Transformers for High-Resolution Image Synthesis** | Resolution/SNR motivation and the fractional-linear resolution-dependent flow-time map | The SD3 constant-observation derivation is only used as an experimental relative correction composed with H3's native shift; it is not claimed to be an optimal H3 schedule. |
@@ -22,6 +23,15 @@ These references are attribution, not relicensing. The research repositories lis
 | **Runtime Metrics Probe** / **Metrics JSON** | ComfyUI, Spectrum, SA-Solver and the sibling integration APIs | Auditable logical-call, actual/forecast, phase, geometry, timing, and reset provenance | These are instrumentation nodes, not implementations of the cited research algorithms. |
 
 ## Primary flow-guidance and high-resolution research
+
+The **Progressive Mixed-Grid Continuum** path independently combines ComfyUI's
+native H3 patch projection, packed positions, per-row timestep modulation, and
+output projection with Continuum's original protected prefix and the companion
+learned upscaler. It reuses the existing progressive handoff mathematics.
+Mixed-grid packing is this repository's H3-specific implementation; it does
+not claim a new implementation of RALU, HRDiT, or another paper's algorithm.
+VDN's explicit mixed-sequence mode retains its learned dense softmax gate while
+omitting the geometry-dependent branch during that stage.
 
 ### HiFlow — Training-free High-Resolution Image Generation with Flow-Aligned Guidance
 
@@ -53,7 +63,7 @@ Wongi Jeong, Kyungryeol Lee, Hoigi Seo, Se Young Chun.
 - Code: https://github.com/ignoww/RALU
 - Direct influence here: the warning that a noisy latent cannot simply be resized mid-trajectory; resolution transitions must account for changed noise/timestep statistics.
 
-The progressive H3 handoff does not copy RALU's mixed-resolution mask or NT-Matching formula. It uses H3's own rectified-flow conditional state and a fresh solver lifetime.
+The progressive H3 handoff does not copy RALU's mixed-resolution mask or NT-Matching formula. It uses H3's own rectified-flow conditional state and a fresh solver lifetime. The experimental target-sparse path likewise does not implement NT-Matching; its retained target-grid row set and hidden-space lifter are separate from RALU's mixed-resolution transition method.
 
 ### Make a Cheap Scaling: A Self-Cascade Diffusion Model for Higher-Resolution Adaptation
 
@@ -83,9 +93,9 @@ Wenhao Sun, Ji Li, Zhaoqiang Liu.
 
 - Paper: https://arxiv.org/abs/2603.10744
 - Code: https://github.com/Wenhao-Sun77/Just-in-Time
-- Direct influence here: the compute-allocation principle that early global-structure stages should not necessarily pay the full final-resolution spatial cost.
+- Direct influence here: the compute-allocation principle that early global-structure stages should not necessarily pay the full final-resolution spatial cost; for the experimental target-sparse Continuum path, the more specific public anchor-token/lifter idea also motivates retaining a target-grid anchor lattice and restoring a full hidden field before the native output layer.
 
-JiT's SAG-ODE, anchor-token lifter, and deterministic micro-flow are not implemented by the H3 progressive handoff.
+The normal H3 progressive handoff does not implement JiT's SAG-ODE, DMF, anchor-token lifter, or deterministic micro-flow. The experimental target-sparse Continuum path independently implements only the high-level anchor/lifter compute-allocation idea: it selects native target-grid H3 rows and applies a bilinear hidden-space lifter while retaining every exact protected row. It does not reproduce JiT's SAG-ODE, deterministic micro-flow, source code, or model-specific mechanics.
 
 ### simple diffusion: End-to-end diffusion for high resolution images
 
@@ -266,6 +276,14 @@ The supplied source ZIPs do **not** contain Git metadata, so no commit SHA is in
 Absence of a top-level license in an inspected research snapshot must **not** be interpreted as permission to reuse its code. The citations above document research provenance; they do not grant rights beyond the upstream authors' actual licenses.
 
 ## Attribution policy for future changes
+
+**Continuum Decode Context** is derived from the native temporal-window contract
+in ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`
+(`comfy/ldm/minimax/vae.py`) and Continuum
+`bf25353d8bec44afea22c89717c4301ce13c2036` (`temporal.py`, `v3/assembly.py`,
+`hardening.py`). The node independently supplies real right context to the
+existing VAE; it does not vendor the decoder or introduce a new blending law.
+Tests execute temporal methods from the external pinned ComfyUI checkout.
 
 When a new paper or repository materially influences an algorithm, heuristic, node, or default in this project:
 

--- a/README.md
+++ b/README.md
@@ -1,186 +1,206 @@
 # MiniMax H3 Flow-Aligned Regenerate
 
-Training-free ComfyUI nodes for reusing low-resolution MiniMax H3 generation structure while moving toward a higher-resolution result.
+Training-free ComfyUI nodes for reusing lower-resolution MiniMax H3 structure while producing a higher-resolution result, with dedicated Continuum paths for exact-prefix continuation.
 
-The project has two main goals:
+The project has two main approaches:
 
-- **guide a high-resolution/refine pass with the actual low-resolution H3 denoising trajectory**, instead of treating the low-resolution result as only a final latent;
-- **move from a smaller video grid to the final grid inside one sampling schedule**, so more H3 work can happen at the cheaper resolution before the expensive high-resolution stage begins.
+1. **Flow-aligned two-pass guidance** — capture the low-resolution H3 denoising trajectory and use it to guide a later learned-upscale/refine pass.
+2. **Progressive handoff** — spend early H3 work on a smaller video grid, then switch to the target grid inside one sampling schedule.
 
-Native H3 generation directly on the final high-resolution grid can be more expensive and, depending on the workflow, less robust than generating smaller and refining after a learned latent upscale. The ordinary upscale/refine approach solves that by starting a second H3 sampling pass. These nodes explore two alternatives: make that second pass reuse the first pass's trajectory, or avoid a complete second pass by carrying one trajectory across a controlled spatial-resolution handoff.
+For Continuum exact-prefix continuation, the recommended accelerated path is now **Progressive Mixed-Grid Continuum**: it keeps the authoritative target-grid prefix for H3 conditioning, generates the continuation suffix on a real lower-resolution grid, performs the learned 3D latent upscale, then starts a fresh full-grid refinement stage.
 
-> [!IMPORTANT]
-> This is an independent research implementation informed by public work. It does **not** reproduce MiniMax's closed H3-Regenerate-2K implementation or its unreleased sparse-attention topology.
+> This is an independent research implementation informed by public work. It does not reproduce MiniMax's closed H3-Regenerate-2K implementation or an unreleased sparse-attention model.
 
-Full node-by-node research and implementation attribution is in [CREDITS.md](CREDITS.md).
-
-## What the nodes do
-
-### 1. Flow-aligned second-pass guidance
-
-The low-resolution H3 pass is captured as a time-indexed trajectory. A later high-resolution or learned-refine pass can then be guided toward the matching low-resolution predicted-clean state at the same flow coordinate.
-
-```text
-low-resolution H3
-      |
-      +-> Trajectory Capture -> H3_FLOW_TRAJECTORY
-                                  |
-learned upscale / refine input ---+
-                                  |
-                         Flow-Aligned Regenerate
-                                  |
-                         high-resolution H3
-```
-
-This keeps the existing two-pass workflow, but lets the second H3 pass reuse information from the full first-pass trajectory rather than only the upscaled endpoint.
-
-For H3 Continuum refinement, **Flow-Aligned Refine State** applies the same guidance directly to each Continuum `refine_state`.
-
-### 2. Progressive resolution handoff
-
-The progressive nodes keep early denoising on a smaller video grid and switch to the target grid later in the same schedule.
-
-```text
-early schedule                     late schedule
-
-private/source grid  ------------>  target grid
-        H3            handoff           H3
-```
-
-The handoff is not a blind resize of noisy state. The wrapper performs an exact low-grid probe, transfers the predicted-clean video state, reconstructs the target-grid conditional state, resets sampler/forecast histories that cannot safely cross the geometry change, and continues sampling at the final resolution.
-
-For **Continuum**, use **MiniMax H3 Progressive Handoff (Target Input)**. Continuum stays configured for the final target size while the node privately runs the early stage on a smaller video grid. If Continuum's native mask exactly protects any video prefix (`mask == 0`), Flow automatically preserves that stronger contract by skipping the private resize/handoff and running the original target-grid sampler once.
-
-### 3. Optional learned handoff
-
-**Progressive Handoff (Target Input)** supports:
-
-- `bicubic` — built-in compatibility path;
-- `learned_3d` — one learned clean-video spatial transfer using the companion [MiniMax H3 Latent Upscaler](https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler).
-
-The learned provider replaces only the clean-video spatial transfer at the handoff. It does not add a second H3 sampling pass, does not spatially transform audio, and adds no H3 transformer NFE by itself.
+See [CREDITS.md](CREDITS.md) for research and implementation attribution.
 
 ## Install
 
-From `ComfyUI/custom_nodes`:
-
 ```bash
+cd ComfyUI/custom_nodes
 git clone https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate.git
 ```
 
 Restart ComfyUI.
 
-The core package has no runtime dependency on the sibling H3 custom nodes. The optional `learned_3d` transfer requires the companion latent-upscaler package above.
+The core package has no mandatory sibling-node dependency. The learned transfer paths require the companion [MiniMax H3 Latent Upscaler](https://github.com/xmarre/Comfyui_Minimax_h3_latent_Upscaler).
 
 ## Recommended Continuum path
 
-When the surrounding H3 patches used by the validated workflow are present, keep this model-patch order:
+### Progressive Mixed-Grid Continuum
+
+Use **MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]** for exact-prefix continuation when you want progressive speedup without giving up the learned latent upscale.
+
+The execution contract is:
+
+```text
+authoritative target-grid prefix
+            +
+real low-grid generated suffix
+            |
+       mixed H3 sequence
+            |
+       exact handoff probe
+            |
+      learned 3D upscale
+            |
+  restore exact target prefix
+            |
+ fresh target-grid refinement
+```
+
+The protected prefix is never spatially resized for transformer conditioning. The low-grid suffix is real low-resolution H3 sampling, not a sparse subset of target-grid hidden rows.
+
+When VDN is enabled, this path uses VDN external-sequence API 2 (`mixed_grid_low_suffix`) during the mixed low stage and returns to normal VDN execution for the fresh target-grid stage.
+
+### Suffix DC bridge
+
+**Mixed-Grid Continuum** exposes `suffix_dc_bridge`, enabled by default.
+
+At the exact-prefix handoff, the learned 3D upscaler produces a complete target-grid clean sequence before its learned prefix is discarded. The bridge measures the per-channel DC difference between that learned prefix boundary and the authoritative exact prefix, then applies the corresponding constant offset to **only the first generated suffix latent token**.
+
+It does not:
+
+- edit the authoritative prefix;
+- alter later suffix tokens at bridge application;
+- perform a video-space crossfade;
+- add an H3 transformer evaluation.
+
+The bridge fixed the brief Continuum boundary flash in matched real-media testing, including multi-boundary continuation. In the validated run, the uncorrected exact-boundary DC RMS was about `0.207763`; the corrected boundary was about `0.093093`, matching the learned-upscaler native boundary at about `0.093093`, while `final_prefix_exact=true` remained intact.
+
+### Continuum Decode Context
+
+**MiniMax H3 Continuum Decode Context** can be placed immediately before the normal Video VAE Decode. It supplies real future latent context to the native H3 temporal decoder at exact chunk joins while leaving accepted sampling latents, continuation state, masks, audio and the assembly plan unchanged.
+
+This solves a separate decoder-window boundary problem. It is not the mechanism that fixed the mixed-grid DC flash above.
+
+See [docs/CONTINUUM_DECODE_CONTEXT.md](docs/CONTINUUM_DECODE_CONTEXT.md).
+
+## Target-Sparse Continuum status
+
+**MiniMax H3 Progressive Target-Sparse Continuum [Experimental]** remains available as a research/control path, but it is **not recommended for production quality**.
+
+It keeps the sampler latent on the target grid and sparsifies only the early H3 hidden-token stream over generated video rows. Because it does **not** perform the learned latent upscale used by the Mixed-Grid path, real decoded-media testing showed cascading quality errors: skin imperfections, odd clothing changes and spurious background additions could appear and propagate through later continuation.
+
+That negative result is the reason the release recommendation is Mixed-Grid rather than Target-Sparse. Target-Sparse remains useful for architectural experiments and controlled comparisons, not as the preferred Continuum acceleration path.
+
+## Generic Progressive Handoff (Target Input)
+
+**MiniMax H3 Progressive Handoff (Target Input)** is the generic target-input progressive node. It is not a Continuum-specific exact-prefix node.
+
+- Unprotected calls can run early H3 work privately at lower resolution before handing off to the target grid.
+- Exact protected video prefixes conservatively fall back to one ordinary target-grid sampler lifetime.
+- It supports `bicubic` and optional `learned_3d` clean-video transfer on the normal handoff path.
+- It does **not** expose or apply the Continuum `suffix_dc_bridge`.
+
+## Flow-aligned two-pass guidance
+
+The two-pass path keeps the established low-resolution generation -> learned upscale/refine workflow but reuses the full low-resolution denoising trajectory instead of only the endpoint.
+
+```text
+low-resolution H3
+      |
+Trajectory Capture
+      |
+H3_FLOW_TRAJECTORY ------------------+
+                                      |
+learned upscale / refine input -------+
+                                      |
+                         Flow-Aligned Regenerate
+                                      |
+                             high-resolution H3
+```
+
+Use:
+
+1. **MiniMax H3 Flow Trajectory**
+2. **MiniMax H3 Trajectory Capture** on the first pass
+3. your learned latent upscale/refine initialization
+4. **MiniMax H3 Flow-Aligned Regenerate** on the second pass
+
+For Continuum `refine_state`, use **MiniMax H3 Flow-Aligned Refine State**.
+
+`direction` remains the conservative guidance recommendation. `direction+acceleration`, `direction+temporal`, `downsample_consistency`, resolution-aware sigma remapping and the Attention Lab remain research controls.
+
+## Nodes
+
+### Main nodes
+
+| Node | Purpose |
+|---|---|
+| **MiniMax H3 Flow Trajectory** | Shared trajectory handle for capture, guidance and progressive execution. |
+| **MiniMax H3 Trajectory Capture** | Records first-pass H3 predicted-clean trajectory states. |
+| **MiniMax H3 Flow-Aligned Regenerate** | Guides a later H3 pass from the matching captured trajectory state. |
+| **MiniMax H3 Flow-Aligned Refine State** | Continuum `refine_state` version of flow-aligned guidance. |
+| **MiniMax H3 Progressive Handoff** | Generic source-sized progressive resolution handoff. |
+| **MiniMax H3 Progressive Handoff (Target Input)** | Generic target-input progressive handoff; exact protected prefixes fall back to the target grid. |
+| **MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]** | Recommended accelerated exact-prefix Continuum path: real low-grid suffix, target-grid prefix conditioning, learned 3D transfer, DC bridge and fresh target-grid refine. |
+| **MiniMax H3 Continuum Decode Context** | Supplies right context to the native temporal VAE at exact Continuum joins. |
+
+### Research/control nodes
+
+| Node | Purpose |
+|---|---|
+| **MiniMax H3 Progressive Target-Sparse Continuum [Experimental]** | Target-grid hidden-row sparsification experiment. Real media showed cascading quality artifacts; not recommended for final output. |
+| **MiniMax H3 Refine Target Geometry [Experimental]** | Mirrors learned-refiner target sizing metadata. |
+| **MiniMax H3 Resolution-Aware Sigmas [Experimental]** | Resolution-dependent refine-sigma experiments; default remains off. |
+| **MiniMax H3 Reference Budget [Experimental]** | Reference-row diagnostics and guarded direct-reference cap. |
+| **MiniMax H3 Attention Lab [Experimental]** | Attention/retention diagnostics and topology oracles. |
+
+### Diagnostics
+
+| Node | Purpose |
+|---|---|
+| **MiniMax H3 Runtime Metrics Probe** | Passive sampler/model-call instrumentation. |
+| **MiniMax H3 Metrics JSON** | Writes structured H3/Spectrum/sampler/geometry metrics. |
+
+## Patch order and interoperability
+
+For the tested Continuum stack, keep model patches in this order when present:
 
 ```text
 DiffAid
   -> Untwisting RoPE
   -> Spectrum
-  -> Progressive Handoff (Target Input)
+  -> Progressive node
   -> Continuum
 ```
 
-DiffAid, Untwisting RoPE, and Spectrum are optional external integrations, not requirements of this package. Omit any that are not part of your workflow; when Spectrum is used, keep Progressive Handoff downstream of it.
+DiffAid, Untwisting RoPE, Spectrum and VDN are optional integrations.
 
-Create one **MiniMax H3 Flow Trajectory** and connect it to **Progressive Handoff (Target Input)**. A separate **Trajectory Capture** node is not required on this path because the progressive wrapper captures its private low-grid trajectory internally.
+Important contracts:
 
-Continuum remains on the target geometry. Only the video grid changes internally; audio remains in the native joint H3 path.
+- **Spectrum:** actual/forecast provenance and sampler-history boundaries are preserved. Fresh target-grid stages start with an actual H3 evaluation where required.
+- **VDN-H3:** Mixed-Grid uses API 2 only during the external mixed sequence and resumes ordinary VDN behavior at full target resolution.
+- **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** sampler objects are preserved; separate sampler lifetimes are used where geometry/history boundaries require them.
+- **Audio:** progressive spatial transfer affects video only. Audio is never spatially resized.
+- **Learned upscaler:** Mixed-Grid requires `learned_3d`; the generic Target Input node can use either `bicubic` or `learned_3d`.
 
-Detailed parameter guidance, tested starting points, `source_scale` behavior, handoff selection, learned-provider setup, and sampler requirements are in [docs/USAGE.md](docs/USAGE.md).
+## Practical status
 
-## Two-pass path
+The paths with the strongest real-media support are:
 
-Use the explicit two-pass nodes when you want to keep an existing low-resolution generation + learned upscale/refine workflow:
+- two-pass flow-aligned guidance with the learned upscale/refine workflow;
+- generic Progressive Handoff for unprotected calls;
+- **Mixed-Grid Continuum with learned 3D transfer and the suffix DC bridge** for exact-prefix continuation.
 
-1. Create one **Flow Trajectory**.
-2. Patch the first-pass model with **Trajectory Capture**.
-3. Run the low-resolution generation.
-4. Perform the existing learned latent upscale / refine initialization.
-5. Patch the second-pass model with **Flow-Aligned Regenerate**.
-6. For Continuum-integrated refinement, patch the emitted `refine_state` with **Flow-Aligned Refine State** instead.
+The Mixed-Grid path has been exercised on a real RTX Pro 6000 workflow with VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact handoff probing and multiple Continuum boundaries. The previously observed boundary flashing is fixed by the suffix DC bridge in that tested workflow.
 
-The same trajectory handle must be used by capture and guidance.
+Target-Sparse is deliberately not promoted because its no-latent-upscale design produced cascading decoded-media defects in testing.
 
-## Nodes
-
-### Core generation nodes
-
-| Node | What it is for |
-|---|---|
-| **MiniMax H3 Flow Trajectory** | Shared mutable trajectory handle used by capture, guidance, and progressive sampling. Storage can live in system RAM or VRAM. |
-| **MiniMax H3 Trajectory Capture** | Patches an H3 model so first-pass predicted-clean trajectory states and provenance are recorded. |
-| **MiniMax H3 Flow-Aligned Regenerate** | Guides a later H3 pass from the matching captured low-resolution trajectory. |
-| **MiniMax H3 Flow-Aligned Refine State** | Continuum version of Flow-Aligned Regenerate; patches each `H3_CONTINUUM_REFINE_STATE`. |
-| **MiniMax H3 Progressive Handoff** | Starts from a source-sized workflow input and grows the video grid to a target resolution during sampling. |
-| **MiniMax H3 Progressive Handoff (Target Input)** | Target-sized/Continuum-safe variant: the public workflow stays at final geometry while the early H3 stage runs privately on a smaller grid. Supports optional `learned_3d` transfer. |
-
-### Experimental research nodes
-
-| Node | What it is for |
-|---|---|
-| **MiniMax H3 Refine Target Geometry [Experimental]** | Mirrors the companion learned-refiner's target sizing so schedule experiments can use the same geometry metadata. It does not upscale latents. |
-| **MiniMax H3 Resolution-Aware Sigmas [Experimental]** | Tests a resolution-dependent remap of the downstream learned-refine sigma schedule. Default/recommended mode remains `off`. |
-| **MiniMax H3 Reference Budget [Experimental]** | Reports direct-reference row growth and provides a guarded experimental direct-reference cap. |
-| **MiniMax H3 Attention Lab [Experimental]** | Output-neutral H3/VDN retention diagnostics, a dense-mask VDN topology oracle, and the earlier guarded spatial-local experiment. No path is presented as production sparse acceleration. |
-
-### Diagnostics
-
-| Node | What it is for |
-|---|---|
-| **MiniMax H3 Runtime Metrics Probe** | Passive sampler/model-call instrumentation without enabling trajectory guidance or progressive handoff. |
-| **MiniMax H3 Metrics JSON** | Saves structured H3/Spectrum/sampler/geometry metrics to a JSON artifact. |
-
-## Guidance modes
-
-| Mode | Purpose | Current posture |
-|---|---|---|
-| `direction` | Low-frequency alignment toward the matched captured predicted-clean state | **Preferred/default guidance path** |
-| `direction+acceleration` | Adds adjacent denoising-time velocity-change alignment inspired by HiFlow | Experimental; structurally valid, no consistent media advantage established |
-| `direction+temporal` | Adds conservative adjacent-frame latent correspondence | Experimental; functioning, currently neutral in matched decoded-media testing |
-| `downsample_consistency` | Compares the target clean estimate against the captured low-grid state after downsampling | Experimental; measurable but not currently preferred |
-| `off` | Disable trajectory correction while retaining the surrounding wrapper/metrics path | Control/debug use |
-
-Exact settings and evidence are intentionally kept out of the main README. See [docs/USAGE.md](docs/USAGE.md) for practical configuration and [docs/BENCHMARKS.md](docs/BENCHMARKS.md) for the decoded-media evidence ledger.
-
-## Current practical status
-
-The core paths are usable and have been exercised with real decoded H3 media:
-
-- **two-pass flow-aligned guidance** is functional with the learned upscale/refine workflow;
-- **Progressive Handoff (Target Input)** is the main single-schedule coarse-to-fine path for Continuum;
-- **direction-only guidance** remains the conservative recommendation;
-- **learned `learned_3d` handoff** has shown a clear benefit over bicubic for aggressive transitions in the tested ~1 MP workflow;
-- the resolution-aware sigma, temporal, acceleration, reference-budget, and attention experiments remain research features rather than promoted defaults.
-
-The current observed performance comparison for the learned progressive path is documented separately in [docs/PERFORMANCE.md](docs/PERFORMANCE.md). It is workflow-specific and not a universal speed or quality claim.
-
-## Compatibility
-
-The implementation is designed around native MiniMax H3 joint audio/video sampling rather than treating video as an isolated tensor path.
-
-- **Continuum:** use **Progressive Handoff (Target Input)** for multi-chunk progressive generation. **Flow-Aligned Refine State** is available for explicit two-pass Continuum refinement.
-- **Spectrum:** actual/forecast provenance is preserved. Feature-history state is reset across a progressive geometry boundary, and the first target-grid call is forced actual.
-- **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** sampler objects are preserved; progressive stages use separate sampler lifetimes where required by the geometry change.
-- **DiffAid / Untwisting RoPE:** keep these upstream of the progressive wrapper when used.
-- **Learned H3 latent upscaler:** optional provider for `learned_3d`; not bundled with this repository.
-
-More detailed wiring rules and failure conditions are in [docs/USAGE.md](docs/USAGE.md).
+Quality and speed still depend on prompt, references, geometry, sampler, Spectrum policy, model residency and hardware. Use decoded media rather than structural metrics alone for new workflow variants.
 
 ## Documentation
 
-- **[docs/USAGE.md](docs/USAGE.md)** — practical wiring, settings, handoff behavior, guidance modes, learned transfer, metrics, and compatibility rules.
-- **[CREDITS.md](CREDITS.md)** — node-by-node research and implementation attribution.
-- **[docs/RESEARCH.md](docs/RESEARCH.md)** — research-transfer rationale and empirical conclusions.
-- **[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)** — internal H3 contracts and implementation architecture.
-- **[docs/BENCHMARKS.md](docs/BENCHMARKS.md)** — decoded-media validation ledger and benchmark protocol.
-- **[docs/PERFORMANCE.md](docs/PERFORMANCE.md)** — measured workflow-level timing evidence and limits.
-- **[docs/DEVELOPMENT.md](docs/DEVELOPMENT.md)** — development setup, CI/test scope, source pins, and maintenance rules.
-- **[RELEASE_NOTES.md](RELEASE_NOTES.md)** — release history.
-- **[LICENSE](LICENSE)** — Apache License 2.0 terms for this project.
+- [docs/USAGE.md](docs/USAGE.md) — wiring and parameter details
+- [docs/MIXED_GRID_CONTINUUM.md](docs/MIXED_GRID_CONTINUUM.md) — Mixed-Grid contract and diagnostics
+- [docs/TARGET_SPARSE_CONTINUUM.md](docs/TARGET_SPARSE_CONTINUUM.md) — Target-Sparse research path
+- [docs/CONTINUUM_DECODE_CONTEXT.md](docs/CONTINUUM_DECODE_CONTEXT.md) — decoder right-context helper
+- [docs/BENCHMARKS.md](docs/BENCHMARKS.md) — decoded-media validation ledger
+- [docs/PERFORMANCE.md](docs/PERFORMANCE.md) — workflow-specific timing evidence
+- [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md) — internal contracts
+- [docs/RESEARCH.md](docs/RESEARCH.md) — research-transfer rationale
+- [CREDITS.md](CREDITS.md) — attribution and provenance
+- [RELEASE_NOTES.md](RELEASE_NOTES.md) — release history
 
 ## License
 
@@ -188,13 +208,4 @@ MiniMax H3 Flow-Aligned Regenerate is licensed under the [Apache License 2.0](LI
 
 Copyright 2026 xmarre.
 
-Research references and implementation provenance are documented in [CREDITS.md](CREDITS.md). Those references are attribution, not relicensing: third-party projects retain their own copyrights and licenses, and referenced research repositories are not bundled into this project unless explicitly stated otherwise.
-
-## Scope and limitations
-
-- This is research-grade tooling, not an official MiniMax implementation.
-- Progressive handoff changes only the **video** spatial grid; audio is never spatially resized.
-- Progressive sampling requires a complete H3 sigma schedule whose absolute flow origin is known.
-- Arbitrary external sampler RNG/history closures cannot be safely carried across a geometry reset and may be rejected.
-- Mutable capture/guidance/progressive state currently fails closed for unsupported parallel multi-GPU model-call ordering.
-- Quality and speed depend on prompt, references, geometry, sampler, Spectrum policy, model residency, and hardware. Use decoded media rather than metrics alone as the final quality test.
+Referenced papers and third-party repositories retain their own copyrights and licenses.

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,104 +1,101 @@
-# Unreleased
+# MiniMax H3 Flow-Aligned Regenerate v0.3.0
 
-## Exact Continuum prefix safety
+v0.3.0 makes the real low-grid **Mixed-Grid Continuum** path the recommended exact-prefix progressive workflow, adds the one-token suffix DC seam bridge that fixed the observed Continuum boundary flash, adds native temporal decode context, and ships the VDN API-2 interoperability needed by the mixed sequence.
 
-- Progressive Target Input now bypasses the private low-grid handoff when the prepared video denoise mask contains exact-zero values.
-- The fallback forwards the original target-grid noise, latent, mask, schedule, sampler, callback, and mutable shape metadata through one sampler lifetime, preserving ComfyUI's exact mask contract and stateful sampler behavior.
-- Audio-only protection and fractional video blends retain the existing progressive path.
-- Metrics distinguish the fallback from both ordinary and split-progressive sampling.
+## Mixed-Grid Continuum
 
-## Attention Lab
+- Adds **MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]**.
+- Keeps the authoritative target-grid protected prefix for H3 transformer conditioning while sampling a genuine lower-resolution generated suffix.
+- Runs the exact handoff probe under the same mixed topology.
+- Requires the versioned `learned_3d` provider from `Comfyui_Minimax_h3_latent_Upscaler` for suffix transfer.
+- Restores the authoritative target-grid prefix before a fresh full-grid refinement stage.
+- Requires an actual first target-grid H3 evaluation after the handoff.
+- Preserves audio, mask/noise semantics, sampler boundaries and exact final-prefix protection.
 
-- Output-neutral diagnostics now measure native dense-attention mass retained by the public OpenVDN temporal topology, plus outside mass, boundary-frame mass, exact analytic pair density, and an optional authoritative Continuum seam.
-- Adds `vdn_reference_dense`, an all-head query-chunked dense-mask correctness oracle using complete 5-frame chunks, radius 1, global non-video tokens, and first/last row-and-column anchors.
-- The seam anchor requires `protected_video_prefix_latent_slots`; frame-count metadata is never guessed into latent indices.
-- No sparse-kernel or speed claim is made. OpenVDN's trained hybrid branch, compiled kernel, and separately licensed weights are not included.
+## Continuum suffix DC bridge
 
-Decoded H3 media validation remains required before release or recommendation.
+`Progressive Mixed-Grid Continuum` exposes `suffix_dc_bridge`, enabled by default.
+
+The bridge is intentionally narrow:
+
+- computes a per-batch/per-channel spatial-mean offset from the learned-upscaler prefix boundary to the authoritative exact prefix;
+- applies that offset to exactly the **first generated suffix latent token**;
+- uses fixed weight `1.0`;
+- never edits the protected prefix;
+- leaves every later suffix token unchanged at bridge application;
+- performs no video-space crossfade;
+- adds no H3 transformer NFE.
+
+Matched real-media testing on the production RTX Pro 6000 Continuum workflow removed the brief boundary flash, including multi-boundary continuation. The validated run reported approximately:
+
+- uncorrected exact-boundary DC RMS: `0.207763`;
+- corrected exact-boundary DC RMS: `0.093093`;
+- learned-upscaler native boundary DC RMS: `0.093093`;
+- corrected tokens: `1`;
+- bridge weight: `1.0`;
+- `final_prefix_exact=true`.
+
+The correction fixed the artifact rather than merely moving it to another boundary.
+
+The dedicated **Target-Sparse Continuum** research node also exposes the same one-token control at its full-grid high-stage boundary, but Target-Sparse is not the recommended quality path; see below. The generic **Progressive Handoff (Target Input)** node is not Continuum-specific and does **not** expose or apply this bridge.
+
+## Target-Sparse quality result
+
+Target-Sparse remains in the package as an architectural/control experiment but is not promoted for production output.
+
+Real decoded-media testing showed that its target-grid hidden-row sparsification can produce cascading quality errors because it does not perform the learned latent upscale used by Mixed-Grid. Observed failures included skin imperfections, odd clothing changes and spurious background additions that propagated through later continuation.
+
+This negative media result closes the previous Target-Sparse acceptance question: the preferred Continuum acceleration path is Mixed-Grid, where the low-resolution suffix is followed by learned 3D latent transfer and full-grid refinement.
+
+## Continuum Decode Context
+
+Adds **MiniMax H3 Continuum Decode Context** for native H3 temporal VAE boundaries.
+
+- validates exact physical Continuum joins;
+- supplies real right-context latent tokens to the preceding chunk's decode-only tensor;
+- leaves accepted sampling latents, continuation state, mask, plan and audio unchanged;
+- relies on unchanged Continuum assembly trimming to discard the decode-only tail.
+
+This addresses the native temporal-decoder window boundary and is independent from the latent DC bridge above.
+
+## VDN-H3 interoperability
+
+- Adds external-sequence API 2 / `mixed_grid_low_suffix` integration for `ComfyUI-VDN-H3`.
+- During the mixed sequence VDN retains the learned dense softmax gate while disabling only geometry-dependent local-window/linear-complement processing that cannot be interpreted on mixed spatial lattices.
+- The fresh target-grid stage receives no external mixed-sequence contract and resumes ordinary VDN behavior.
+- API 1 target-sparse compatibility remains available.
+
+The coordinated VDN release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
+
+## Validation
+
+The release is gated by:
+
+- Python 3.10, 3.11, 3.12 and 3.13 CI;
+- Ruff + format checks;
+- full unit/synthetic suite;
+- source-contract/native-oracle lane against pinned ComfyUI, Continuum, Spectrum, DiffAid, RefDelta, Untwisting RoPE, the learned upscaler and the coordinated VDN release;
+- package build, Apache-2.0 metadata validation and isolated wheel import;
+- real multi-boundary Mixed-Grid Continuum media validation on RTX Pro 6000.
+
+## Distribution
+
+The package version is bumped to `0.3.0`. After the exact `main` commit passes CI, the existing release workflow creates the GitHub source ZIP + `SHA256SUMS`, and the registry workflow publishes the same tested version to the Comfy Registry.
 
 ---
 
 # MiniMax H3 Flow-Aligned Regenerate v0.2.1
 
-v0.2.1 adds CI-gated Comfy Registry publication. Runtime and sampling behavior are unchanged from v0.2.0.
-
-## Distribution
-
-- Adds a dedicated **Publish to Comfy registry** workflow using the pinned `Comfy-Org/publish-node-action` v1 revision already used by the companion MiniMax H3 latent-upscaler release path.
-- Registry publication runs only after a successful `CI` push run on `main` and only when the tested commit changes the package version relative to its first parent.
-- Manual `workflow_dispatch` remains available for explicit operator-controlled publication/retry.
-- The workflow checks out the exact CI-tested commit, uses read-only repository permissions and non-persistent checkout credentials, and consumes `REGISTRY_ACCESS_TOKEN` only in the publish step.
-- Publication is serialized per tested commit so overlapping workflow-run/manual attempts are not cancelled mid-publish.
-
-## Versioning
-
-The package version is bumped to `0.2.1` rather than republishing `0.2.0` from a different source commit. This keeps the GitHub release/tag and Comfy Registry package version aligned to the same source revision.
-
-## Compatibility
-
-No Python runtime, sampler, handoff, guidance, Continuum, Spectrum, metrics, or learned-upscaler integration code changes are included in v0.2.1.
+v0.2.1 added CI-gated Comfy Registry publication. Runtime and sampling behavior were unchanged from v0.2.0.
 
 ---
 
 # MiniMax H3 Flow-Aligned Regenerate v0.2.0
 
-v0.2.0 adds an optional learned 3D transfer at the Progressive Target Input handoff boundary, backed by the versioned API-v1 provider from `Comfyui_Minimax_h3_latent_Upscaler`.
-
-## Learned progressive handoff
-
-- Adds `handoff_transfer=learned_3d` to **MiniMax H3 Progressive Handoff (Target Input)**.
-- Keeps `handoff_transfer=bicubic` as the compatibility default for existing workflows.
-- Consumes the API-v1 `H3_LATENT_UPSCALER` clean-video provider rather than importing sibling-node internals.
-- Replaces only the exact-probe clean-video spatial transfer. Deterministic target noise, conditional re-noising, caller audio, masks, target conditioning, sampler/Spectrum history boundaries, and the mandatory first high-grid actual H3 call remain unchanged.
-- Learned CNN work is tracked separately and does not increase H3 model-call/NFE counters.
-
-The coordinated provider is released in `Comfyui_Minimax_h3_latent_Upscaler` v0.2.0. The exact provider revision validated by this release is `bdc670e5926bcefbe4022e17fe8b171fbfcf15de`.
-
-## Decoded-media validation
-
-The learned-transfer path was validated on aggressive progressive transitions around 1 MP rather than only on synthetic shape/contract tests.
-
-- Around a `1152×864` (~0.995 MP) target, an aggressive bicubic handoff from roughly a ~0.55 MP private source showed substantial body/spatial handoff artifacts in the tested difficult prompt.
-- Replacing only that boundary with `learned_3d` fixed the majority of the observed artifacts.
-- `source_scale=0.70` resolved to `800×608 → 1152×864` and was judged excellent.
-- `source_scale=0.65` resolved to `736×576 → 1152×864` and began losing reference likeness / tonal stability, so it is not promoted.
-- The final higher-resolution gate used `source_scale=0.70` at `832×640 → 1184×896` (~1.061 MP). The generated action differed, but decoded quality was again judged very good.
-- That final run preserved `38 logical / 28 actual H3 NFE / 10 Spectrum forecast` calls across two physical chunks, with 2 exact probes, 6 progressive sampler invocations, 4 history boundaries, copied audio, rebuilt high-grid conditioning, and an actual first high-grid H3 call in both chunks.
-- BF16 CUDA learned inference took about 0.60 s and 0.77 s for the two chunks and added zero H3 NFEs.
-
-For this prompt around 1 MP, `source_scale=0.70` is the current tested quality/compute point and `0.65` is below the observed fidelity floor. These values are not claimed as universal optima.
-
-## Guidance interpretation
-
-The latest learned-transfer media sweep used `direction+acceleration`. It does not establish an acceleration advantage over direction-only. The earlier matched evidence still supports `direction` as the conservative preferred guidance mode; acceleration, temporal correspondence, downsample consistency, auto handoff, and resolution-aware refine sigmas remain experimental controls unless future matched media shows a clear benefit.
-
-## Compatibility and validation
-
-- Existing bicubic Progressive Target Input workflows retain their prior behavior.
-- Full 1-to-0 H3 sigma schedules remain required for progressive handoff.
-- CI validates Python 3.10–3.13, Ruff and formatting, 142 unit/synthetic tests, `compileall`, package build, isolated wheel import, and pinned native/sibling source contracts.
-- The source-contract gate pins the merged learned-provider revision and checks its API/kind constants, helper, provider classes, callable surface, and ComfyUI type.
+v0.2.0 added the optional `learned_3d` handoff provider for Progressive Target Input. Around ~1 MP, the learned transfer clearly outperformed aggressive bicubic handoff in difficult decoded-media testing; `source_scale=0.70` was the strongest tested quality/compute point in that sweep.
 
 ---
 
 # MiniMax H3 Flow-Aligned Regenerate v0.1.0
 
-Initial public release of MiniMax H3 Flow-Aligned Regenerate.
-
-## Highlights
-
-- H3-native low-resolution trajectory capture and time-aligned high-resolution guidance.
-- Progressive Target Input handoff for Continuum: early H3 sampling can run on a private lower-resolution grid before switching to the final grid without a separate learned-refine replay.
-- Integrated Continuum refine-state guidance for the existing MiniMax H3 Latent Upscaler + Refine path.
-- Experimental resolution-aware refine sigmas, temporal correspondence, acceleration, downsample consistency, reference-budget diagnostics, and attention diagnostics.
-- Runtime metrics distinguish logical sampler calls, actual H3 NFEs, Spectrum forecasts, handoff probes, guidance events, and resolution-map events.
-
-## Tested operating point
-
-The strongest matched difficult-motion result tested during v0.1.0 development used 14 SA-Solver-PECE outer steps, a 736×736 private source to 896×896 target, `source_scale=0.83`, fixed handoff 0.35, direction guidance 0.25, and 54 logical / 36 actual H3 NFE / 18 Spectrum forecast calls across two chunks.
-
-D12 was judged better than D10, and D14 slightly better again. These are tested quality/speed tradeoffs, not universal optima.
-
-## Scope
-
-This project is an independent, training-free research implementation informed by public work. It does not reproduce MiniMax's closed H3-Regenerate-2K model or unreleased sparse-attention topology. Decoded media remains the quality gate.
+Initial public release: H3 trajectory capture, flow-aligned second-pass guidance, progressive target-input handoff, Continuum refine-state guidance, runtime metrics and the initial experimental research controls.

--- a/__init__.py
+++ b/__init__.py
@@ -1,6 +1,37 @@
 try:
+    from .h3_flow_regenerate.decode_context import (
+        NODE_CLASS_MAPPINGS as DECODE_NODE_CLASS_MAPPINGS,
+    )
+    from .h3_flow_regenerate.decode_context import (
+        NODE_DISPLAY_NAME_MAPPINGS as DECODE_NODE_DISPLAY_NAME_MAPPINGS,
+    )
     from .h3_flow_regenerate.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+    from .h3_flow_regenerate.target_sparse_node import (
+        NODE_CLASS_MAPPINGS as TARGET_SPARSE_NODE_CLASS_MAPPINGS,
+    )
+    from .h3_flow_regenerate.target_sparse_node import (
+        NODE_DISPLAY_NAME_MAPPINGS as TARGET_SPARSE_NODE_DISPLAY_NAME_MAPPINGS,
+    )
 except ImportError:  # Direct-file import used by packaging and test smoke checks.
+    from h3_flow_regenerate.decode_context import (
+        NODE_CLASS_MAPPINGS as DECODE_NODE_CLASS_MAPPINGS,
+    )
+    from h3_flow_regenerate.decode_context import (
+        NODE_DISPLAY_NAME_MAPPINGS as DECODE_NODE_DISPLAY_NAME_MAPPINGS,
+    )
     from h3_flow_regenerate.nodes import NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS
+    from h3_flow_regenerate.target_sparse_node import (
+        NODE_CLASS_MAPPINGS as TARGET_SPARSE_NODE_CLASS_MAPPINGS,
+    )
+    from h3_flow_regenerate.target_sparse_node import (
+        NODE_DISPLAY_NAME_MAPPINGS as TARGET_SPARSE_NODE_DISPLAY_NAME_MAPPINGS,
+    )
+
+NODE_CLASS_MAPPINGS = {**NODE_CLASS_MAPPINGS, **TARGET_SPARSE_NODE_CLASS_MAPPINGS, **DECODE_NODE_CLASS_MAPPINGS}
+NODE_DISPLAY_NAME_MAPPINGS = {
+    **NODE_DISPLAY_NAME_MAPPINGS,
+    **TARGET_SPARSE_NODE_DISPLAY_NAME_MAPPINGS,
+    **DECODE_NODE_DISPLAY_NAME_MAPPINGS,
+}
 
 __all__ = ["NODE_CLASS_MAPPINGS", "NODE_DISPLAY_NAME_MAPPINGS"]

--- a/docs/CONTINUUM_DECODE_CONTEXT.md
+++ b/docs/CONTINUUM_DECODE_CONTEXT.md
@@ -1,0 +1,79 @@
+# Continuum video decode context
+
+Use **MiniMax H3 Continuum Decode Context** immediately before the video VAE
+decoder, after the final sampling, refinement, or latent-upscale operation:
+
+1. Final `video_latents` list → Decode Context `video_latents`.
+2. Corresponding Continuum `assembly_plan` → Decode Context `assembly_plan`.
+3. Decode Context `video_latents` → existing **Video VAE Decode**.
+4. Decoded images → existing **Continuum Assemble**.
+
+Keep the original assembly plan connected to Assemble. Keep the audio path
+unchanged. The context node's output is **decode-only**: do not feed it back into
+sampling, latent refinement/upscaling, Run Storage, or continuation state.
+
+This works independently of the progressive node: conservative Target Input,
+target-sparse, and mixed-grid can all produce exact-prefix continuation chunks.
+No H3 transformer evaluation is added. The selected VAE remains external.
+
+## Boundary defect
+
+ComfyUI's native `MiniMaxH3VideoVAE.decode_temporal` decodes seven latent tokens
+per window with a five-token stride. It retains 17 frames from each window's
+first part and blends five frames with the preceding window's terminal part.
+When a sequence ends, its last five frames are emitted without a following
+window. Independently decoding the next Continuum chunk and trimming its
+protected prefix does not retroactively supply that missing window.
+
+Consequently, bit-identical protected latents do not make independent chunk
+decoding equivalent to continuous decoding. The difference occupies the five
+frames immediately before the assembly join. This mechanism is shared by
+progressive paths and exists without any mixed-grid attention or learned-prefix
+replacement. It is separate from a discontinuity already present in generated
+latents, which this node does not repair.
+
+## Correction
+
+For each adjacent physical decode group, verify that the next prefix matches
+the previous latent tail exactly and that their geometry, dtype, and device
+agree. The overlap must have the native 5/22/39/... frame phase. Append the next
+five **generated** latent tokens to a newly allocated temporary copy of the
+preceding chunk. The VAE can now evaluate the formerly missing window. Assemble
+already trims each decoded result to its original `total_frames`, so the 17
+extra output frames are discarded and the timeline length stays unchanged.
+
+The final chunk is unchanged. Accepted latents, masks, original dictionaries,
+the plan, and audio remain unchanged. Existing physical `decode_groups` take
+precedence over logical chunk entries, including terminal-merged plans.
+
+Non-exact overlaps (for example, independently upscaled/refined duplicate
+prefixes or Guide-mode regeneration) remain unchanged and are identified in
+the report. No approximate equality, implicit resizing, color matching, or
+replacement of generated suffix latents is used. Such boundaries require a
+different correction; a `0/N` report means this fix did not activate.
+
+## Evidence and limits
+
+The regression oracle executes the pinned native VAE's actual temporal window,
+padding, blending, and write methods with a context-sensitive stand-in for its
+learned pixel decoder. Four-chunk tests with 5-, 22-, and 39-frame overlaps:
+
+- reproduce the previous five-frame boundary discrepancy;
+- produce bit-identical results to a single continuous latent decode with
+  right context;
+- preserve accepted latent values, plan contents, and output duration.
+
+Source: ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`,
+`comfy/ldm/minimax/vae.py`; Continuum
+`bf25353d8bec44afea22c89717c4301ce13c2036`, `v3/assembly.py`, `hardening.py`,
+and `temporal.py`. The native source oracle runs in CI.
+
+The structural decode-context correction is proven by that oracle. Actual
+checkpoint media and speed are not established by a synthetic pixel decoder.
+There is one extra seven-token VAE window and 17 discarded decoded frames per
+corrected boundary, plus temporary extended latent storage. The implementation
+does not combine the entire sequence into a single large decode call. TRT or
+other replacement VAEs must preserve native H3 temporal window semantics for
+the equivalence argument to apply. Inspect decoded media with the actual VAE;
+remaining generation-domain flashing and the learned-prefix splice remain
+separate research questions. Both integration PRs remain draft.

--- a/docs/MIXED_GRID_CONTINUUM.md
+++ b/docs/MIXED_GRID_CONTINUUM.md
@@ -1,0 +1,116 @@
+# Mixed-Grid Continuum continuation
+
+**MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]** is the recommended accelerated exact-prefix Continuum path in v0.3.0.
+
+It requires `handoff_transfer=learned_3d` and the companion `H3_LATENT_UPSCALER` provider. Continuum stays configured for the final target geometry.
+
+## Why Mixed-Grid exists
+
+The conservative Target Input node cannot safely resize an exact protected prefix, so exact-prefix continuation falls back to one target-grid sampler lifetime. The earlier Target-Sparse experiment avoids resizing the prefix but also avoids the learned latent upscale; real decoded-media testing showed cascading quality defects on that path.
+
+Mixed-Grid instead keeps the exact target-grid prefix authoritative while generating the new suffix on a genuine smaller sampler grid, then uses the learned 3D latent transfer before target-grid refinement.
+
+## Execution contract
+
+1. Snapshot the original model-domain target-grid prefix and corresponding target-grid sampler noise.
+2. Run the private early sampler on a normal low-grid carrier.
+3. Immediately before H3 transformer block 0, independently patchify/project the original target-grid protected prefix using native H3 masked-conditioning semantics and replace only the carrier prefix rows.
+4. Keep genuine source-grid suffix patch embeddings. Prefix positions use the native target grid; suffix positions use the native source grid while preserving temporal slot continuity.
+5. Run all transformer blocks on the mixed sequence with matching per-row modulation metadata.
+6. Before native output projection, discard target-prefix transformer outputs and restore the normal low-carrier layout so native projection/unpatchification remains valid.
+7. Run the exact handoff probe through the same mixed topology in a separate sampler lifetime.
+8. Feed the complete clean low-grid sequence plus resized prefix context to the learned 3D upscaler.
+9. Discard the upscaler's prefix output, restore the authoritative target-grid prefix, rebuild the high-stage conditional state/noise, and start a fresh full-grid sampler lifetime.
+10. Require the first high-stage call to be an actual H3 evaluation and verify the returned protected prefix remains exact.
+
+The authoritative target-grid prefix is never spatially resized for H3 transformer conditioning.
+
+## Suffix DC bridge
+
+`suffix_dc_bridge` defaults **on** for Mixed-Grid.
+
+The learned 3D transfer produces a complete target-grid clean sequence before its learned prefix is discarded. Let that learned output be `[U_prefix | U_suffix]` and the authoritative protected prefix be `P_exact`.
+
+Flow computes the per-batch/per-channel spatial-mean offset:
+
+```text
+delta = mean(P_exact[-1]) - mean(U_prefix[-1])
+```
+
+and adds `delta` to **only** `U_suffix[0]`.
+
+This preserves the learned upscaler's native boundary relation while keeping the exact prefix authoritative.
+
+The bridge:
+
+- corrects exactly one generated suffix latent token;
+- uses fixed weight `1.0`;
+- never edits the authoritative prefix;
+- leaves later suffix tokens unchanged at bridge application;
+- performs no video-space crossfade;
+- adds no H3 transformer NFE.
+
+For the conditional flow state, the clean-space delta is mapped through the same affine construction:
+
+```text
+x_sigma = (1 - sigma) * x0 + sigma * noise
+```
+
+The deterministic noise is unchanged.
+
+## Real-media result
+
+The matched production test on RTX Pro 6000 removed the brief exact-prefix boundary flash. Multi-boundary continuation was also clean.
+
+The validated metrics were approximately:
+
+- uncorrected exact-boundary DC RMS: `0.207763`;
+- corrected exact-boundary DC RMS: `0.093093`;
+- native learned-upscaler boundary DC RMS: `0.093093`;
+- corrected suffix tokens: `1`;
+- weight: `1.0`;
+- `final_prefix_exact=true`.
+
+This is the basis for making the bridge default on for Mixed-Grid in v0.3.0.
+
+## VDN-H3 contract
+
+With VDN enabled, Mixed-Grid requires external-sequence capability API 2 using:
+
+```text
+key      = vdn_h3_external_sequence_v1
+api      = 2
+mode     = dense_gate_no_linear
+topology = mixed_grid_low_suffix
+```
+
+VDN validates both target-prefix and source-suffix row identities, full sequence length, temporal partition and explicit RoPE.
+
+During the mixed sequence, VDN retains the learned dense softmax gate and disables only geometry-dependent local-window/linear-complement processing. The fresh target-grid high stage receives no external contract and resumes ordinary VDN behavior.
+
+The coordinated release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
+
+## Continuum Decode Context
+
+**MiniMax H3 Continuum Decode Context** addresses a separate native temporal-VAE issue: independently decoding chunks can miss real right context that a continuous decode would have seen.
+
+Place it immediately before the normal Video VAE Decode when using the native H3 temporal decoder. It changes only the decode-only tensor; accepted sampling latents, continuation state, masks, audio and the assembly plan remain unchanged.
+
+The suffix DC bridge, not Decode Context, is what fixed the mixed-grid latent tone flash in the validated workflow.
+
+## Diagnostics
+
+Mixed-Grid records four seam states:
+
+- **A** — native learned-upscaler boundary `[U_prefix | U_suffix]`;
+- **B** — authoritative prefix restored without the bridge `[P_exact | U_suffix]`;
+- **C** — authoritative prefix plus corrected first suffix token;
+- **D** — final boundary after target-grid refinement.
+
+Diagnostics include raw RMS, spatial low-pass RMS, per-channel spatial-mean/DC RMS, bridge magnitude/count/weight and final/B/final/C ratios.
+
+## Current status
+
+The mixed-grid path is still labeled Experimental because it is an independent research topology, but its previously open production acceptance gate is closed for the tested stack: real GPU/media validation, multiple Continuum boundaries, VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact probe, fresh target-grid refinement and the suffix DC bridge have all been exercised together successfully.
+
+Quality/speed remain workflow dependent; the documented result is evidence for this implementation and tested stack, not a universal model guarantee.

--- a/docs/TARGET_SPARSE_CONTINUUM.md
+++ b/docs/TARGET_SPARSE_CONTINUUM.md
@@ -1,0 +1,56 @@
+# Target-Sparse Continuum continuation
+
+**MiniMax H3 Progressive Target-Sparse Continuum [Experimental]** is retained as a research/control path. It is **not the recommended quality path** in v0.3.0.
+
+## What it does
+
+Target-Sparse keeps the caller's sampler latent, mask and protected prefix on the final target grid. During the early stage it reduces only the generated-video hidden-token stream while retaining:
+
+- every protected video row;
+- all text/reference/audio rows;
+- native target-grid RoPE coordinates for retained rows;
+- target-grid sampler state and mask semantics.
+
+The reduced hidden field is lifted back to the full target grid before H3's native final layer and before Spectrum's final-block observation. A fresh full-grid high-stage sampler lifetime follows.
+
+This is a hidden-stream approximation, not a real lower-resolution sampler suffix.
+
+## Why it is not promoted
+
+Real decoded-media testing showed poor quality on this path. Because Target-Sparse does **not** perform the learned latent upscale used by the Mixed-Grid path, early approximation errors can survive the high stage and cascade into later continuation.
+
+Observed failures included:
+
+- skin imperfections;
+- odd or unstable clothing details;
+- spurious background additions;
+- defects that propagated across continuation rather than remaining isolated to one frame.
+
+That negative result is sufficient to keep Target-Sparse as an architectural experiment/control rather than requiring another acceptance sweep. For exact-prefix Continuum acceleration where output quality matters, use **Progressive Mixed-Grid Continuum**, which performs real low-grid suffix sampling followed by the learned 3D latent upscale and fresh target-grid refinement.
+
+## Suffix DC bridge
+
+Target-Sparse exposes the same narrow `suffix_dc_bridge` control on its dedicated Continuum node.
+
+Unlike Mixed-Grid, it has no learned-upscaler prefix from which to derive the correction. The bridge therefore calibrates from the first **actual** H3 predicted-clean output of the fresh full-grid high stage before native mask restoration.
+
+The contract remains:
+
+- canonical whole-frame exact prefix only;
+- one generated suffix latent token corrected;
+- per-channel spatial-mean/DC offset;
+- fixed weight `1.0`;
+- protected prefix unchanged;
+- later suffix tokens unchanged at bridge application;
+- forecasts are not used for calibration;
+- no extra H3 NFE.
+
+This bridge placement is structurally tested, but it does not change the broader Target-Sparse quality conclusion above.
+
+## VDN-H3
+
+Target-Sparse retains the existing API-1-compatible external reduced-sequence contract. This is separate from the API-2 `mixed_grid_low_suffix` contract used by the recommended Mixed-Grid path.
+
+## Status
+
+Keep this node for controlled sparse-row experiments, profiling and comparison. Do not treat structural test success as evidence that it matches the decoded quality of the learned-upscale Mixed-Grid path.

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -51,6 +51,19 @@ Continuum remains configured for the final target width/height. The wrapper crea
 
 If the prepared video denoise mask contains any exact-zero values, the exact native-masked contract takes precedence over progressive resizing. Flow forwards the original target noise, latent, mask, schedule, sampler, callback, and shape metadata through one ordinary target-grid sampler lifetime. No private noise, spatial transfer, exact probe, history boundary, or progressive guidance is used. A `progressive_target_fallback` metrics event records this path. Audio-only zero masks do not trigger it, and fractional video masks remain intentional blends rather than exact protection.
 
+### Exact-prefix suffix DC bridge
+
+Only the dedicated **Progressive Target-Sparse Continuum** and **Progressive Mixed-Grid Continuum** nodes expose `suffix_dc_bridge`. It defaults to **on** and is only defined for a canonical whole-frame exact prefix followed by a whole-frame generated suffix. The generic **Progressive Handoff (Target Input)** node does not expose or apply this Continuum-specific seam correction. Partial/fractional/noncontiguous masks are skipped rather than guessed.
+
+The correction is intentionally one latent token wide. Flow computes a per-batch/per-channel spatial-mean offset and applies it only to the first generated suffix token. The authoritative prefix and every later suffix token remain unchanged at bridge application. There is no video-space crossfade and no additional H3 transformer evaluation.
+
+The calibration source depends on the Continuum topology:
+
+- **Mixed-Grid:** use the discarded learned-upscaler prefix to preserve the learned transfer's native DC boundary relation when the exact target-grid prefix is restored.
+- **Target-Sparse high stage:** use the first **actual** full-grid H3 predicted-clean output at the exact boundary before native inpaint masking restores the protected prefix. Spectrum forecasts are not used as calibration; the bridge waits for the first actual model output. Target-Sparse already requires its first high-stage call to be actual.
+
+The Mixed-Grid placement passed the matched decoded-media seam test that motivated enabling the control by default. The Target-Sparse placement is structurally covered by CI but still needs its own matched decoded-media validation.
+
 ### What happens at the handoff
 
 At the selected handoff point the wrapper:

--- a/h3_flow_regenerate/attention.py
+++ b/h3_flow_regenerate/attention.py
@@ -46,7 +46,9 @@ def layout_summary(layout: Any) -> dict[str, Any]:
     counts: dict[str, int] = {}
     for start, stop, kind in segments:
         counts[kind] = counts.get(kind, 0) + (stop - start)
-    signature = tuple(int(v) for v in layout.signature)
+    signature = tuple(layout.signature)
+    if not signature or signature[0] != "h3_flow_mixed_grid_v1":
+        signature = tuple(int(v) for v in signature)
     return {
         "signature": signature,
         "segments": segments,

--- a/h3_flow_regenerate/comfy_compat.py
+++ b/h3_flow_regenerate/comfy_compat.py
@@ -9,6 +9,7 @@ from .contracts import H3FlowTrajectory
 from .guidance import GuidanceConfig
 from .handoff import ProgressiveHandoffConfig, ProgressiveTargetInputConfig
 from .metrics import H3FlowMetrics
+from .mixed_grid import MIXED_WRAPPER_KEY, mixed_diffusion_wrapper
 from .runtime import (
     CLONE_CALLBACK_KEY,
     FLOW_BINDING_KEY,
@@ -20,6 +21,7 @@ from .runtime import (
     flow_outer_wrapper,
     flow_predict_wrapper,
 )
+from .target_sparse import VDN_EXTERNAL_SEQUENCE_API_VERSION, make_target_sparse_block_wrapper
 
 
 def validate_h3_model(model: Any) -> Any:
@@ -151,6 +153,19 @@ def patch_flow_model(
     _install_layout_metrics(patched, binding.metrics)
     if attention is not None and attention.mode != "native":
         _install_attention(patched, attention, binding.metrics)
+    if (
+        isinstance(progressive, ProgressiveTargetInputConfig)
+        and progressive.exact_prefix_mode == "target_sparse_lifter"
+    ):
+        _install_target_sparse(patched, binding.metrics)
+    if (
+        isinstance(progressive, ProgressiveTargetInputConfig)
+        and progressive.exact_prefix_mode == "mixed_grid_low_suffix"
+    ):
+        _validate_vdn_target_sparse_compat(patched, len(validate_h3_model(patched).blocks), minimum_api=2)
+        _put_wrapper_first(
+            patched, comfy.patcher_extension.WrappersMP.DIFFUSION_MODEL, MIXED_WRAPPER_KEY, mixed_diffusion_wrapper
+        )
     return patched, binding
 
 
@@ -191,6 +206,62 @@ def _install_attention(model: Any, config: AttentionConfig, metrics: H3FlowMetri
         )
         model.set_model_patch_replace(
             wrapper,
+            "dit",
+            "double_block",
+            layer,
+        )
+
+
+def _contains_target_sparse_wrapper(wrapper: Any) -> bool:
+    """Walk Flow-owned wrapper links without depending on third-party internals."""
+    seen: set[int] = set()
+    current = wrapper
+    while current is not None and id(current) not in seen:
+        seen.add(id(current))
+        if getattr(current, "_h3_flow_target_sparse_wrapper", False):
+            return True
+        if getattr(current, "_h3_flow_layout_wrapper", False):
+            current = getattr(current, "_h3_flow_previous", None)
+            continue
+        current = None
+    return False
+
+
+def _validate_vdn_target_sparse_compat(
+    model: Any, num_layers: int, minimum_api=VDN_EXTERNAL_SEQUENCE_API_VERSION
+) -> None:
+    object_patches = getattr(model, "object_patches", None)
+    if not isinstance(object_patches, dict):
+        return
+    for layer in range(num_layers):
+        key = f"diffusion_model.blocks.{layer}.attn.forward"
+        owner = object_patches.get(key)
+        if owner is None or not getattr(owner, "_vdn_forward", False):
+            continue
+        api = int(getattr(owner, "_vdn_external_sequence_api", 0))
+        if api < minimum_api:
+            raise RuntimeError(
+                "target-sparse Continuum detected VDN-H3 attention without the required "
+                f"external sequence API v{minimum_api}; "
+                "update ComfyUI-VDN-H3 or disable VDN for this experimental path"
+            )
+
+
+def _install_target_sparse(model: Any, metrics: H3FlowMetrics) -> None:
+    diffusion = validate_h3_model(model)
+    blocks = getattr(diffusion, "blocks", None)
+    if blocks is None:
+        raise TypeError("native MiniMax H3 diffusion model does not expose transformer blocks")
+    num_layers = len(blocks)
+    _validate_vdn_target_sparse_compat(model, num_layers)
+    transformer = model.model_options["transformer_options"]
+    existing = ((transformer.get("patches_replace") or {}).get("dit") or {}).copy()
+    for layer in range(num_layers):
+        previous = existing.get(("double_block", layer))
+        if _contains_target_sparse_wrapper(previous):
+            continue
+        model.set_model_patch_replace(
+            make_target_sparse_block_wrapper(layer, num_layers, metrics, previous=previous),
             "dit",
             "double_block",
             layer,

--- a/h3_flow_regenerate/decode_context.py
+++ b/h3_flow_regenerate/decode_context.py
@@ -1,0 +1,117 @@
+"""Supply real right context to H3's existing overlapping temporal VAE decoder.
+
+These LATENTs are decode-only views of accepted chunks. The original assembly
+plan deliberately retains its original frame counts and trims the added future
+frames. No sampler input, saved chunk, or audio tensor is changed.
+"""
+
+from __future__ import annotations
+
+import torch
+
+_CYCLE = 5
+_CYCLE_FRAMES = 17
+_PREFIX_REMAINDER = 2
+
+
+def _frames(tokens: int) -> int:
+    if tokens < 2 or tokens % _CYCLE != _PREFIX_REMAINDER:
+        raise ValueError("Continuum decode context requires H3 video lengths of 5k+2 latents")
+    return ((tokens - 2) // _CYCLE) * _CYCLE_FRAMES + 5
+
+
+def prepare_decode_context(latents: list[dict], plan: dict) -> tuple[list[dict], str]:
+    """Append one real decoder window stride at each bit-identical overlap.
+
+    H3 decodes seven latents every five tokens, blending five pixel frames. A
+    terminal chunk lacks the next window even when its protected overlap is exact.
+    Appending five generated tokens makes that window available. Since independent
+    chunk origins differ by complete five-token cycles, retained frames then use
+    the same decoder windows as a continuously decoded latent timeline.
+
+    Non-exact overlaps remain separate; inventing shared context for independently
+    refined or Guide-mode chunks would change their decoder conditioning.
+    """
+    if not isinstance(plan, dict) or plan.get("magic") != "H3_CONTINUUM_ASSEMBLY_PLAN":
+        raise ValueError("expected an H3 Continuum assembly plan")
+    if plan.get("schema_version") != 1 or plan.get("fps") != 24:
+        raise ValueError("unsupported H3 Continuum assembly plan schema or frame rate")
+    groups = plan.get("decode_groups", plan.get("chunks"))
+    if not isinstance(groups, list) or not groups or len(groups) != len(latents):
+        raise ValueError("decode-context latent count must match physical assembly groups")
+
+    videos = []
+    for index, (latent, group) in enumerate(zip(latents, groups, strict=True)):
+        video = latent.get("samples") if isinstance(latent, dict) else None
+        if not torch.is_tensor(video) or video.ndim != 5 or tuple(video.shape[:2]) != (1, 24):
+            raise ValueError(f"decode group {index + 1} requires native [1,24,T,H,W] video")
+        if not video.is_floating_point():
+            raise ValueError("H3 decode-context latents must be floating point")
+        total = _frames(int(video.shape[2]))
+        trim = int(group["trim_frames"])
+        if total != int(group["total_frames"]) or total - trim != int(group["net_frames"]):
+            raise ValueError(f"decode group {index + 1} latent duration differs from the assembly plan")
+        if int(group["expected_video_latent_t"]) != video.shape[2] or trim < 0:
+            raise ValueError(f"decode group {index + 1} has stale assembly metadata")
+        videos.append(video)
+
+    output = list(latents)
+    reports = []
+    joined = 0
+    for index in range(len(videos) - 1):
+        left, right = videos[index : index + 2]
+        trim = int(groups[index + 1]["trim_frames"])
+        if trim < 5 or (trim - 5) % _CYCLE_FRAMES:
+            reports.append(f"boundary {index + 1}: unchanged (no native whole-cycle overlap)")
+            continue
+        prefix = ((trim - 5) // _CYCLE_FRAMES) * _CYCLE + 2
+        if prefix > left.shape[2] or right.shape[2] - prefix < _CYCLE:
+            reports.append(f"boundary {index + 1}: unchanged (insufficient overlap or generated context)")
+            continue
+        if left.shape[:2] != right.shape[:2] or left.shape[-2:] != right.shape[-2:]:
+            reports.append(f"boundary {index + 1}: unchanged (spatial geometry differs)")
+            continue
+        if left.dtype != right.dtype or left.device != right.device:
+            reports.append(f"boundary {index + 1}: unchanged (latent dtype/device differs)")
+            continue
+        if not torch.equal(left[:, :, -prefix:], right[:, :, :prefix]):
+            reports.append(f"boundary {index + 1}: unchanged (protected overlap is not exact)")
+            continue
+        # New allocation: accepted CPU chunks remain immutable. Do not forward
+        # stale noise masks or sampling metadata on an extended decode-only tensor.
+        output[index] = {"samples": torch.cat((left, right[:, :, prefix : prefix + _CYCLE]), dim=2)}
+        joined += 1
+        reports.append(f"boundary {index + 1}: supplied 5 real future latents (17 decode-only frames)")
+    report = (
+        f"H3 Continuum decode context: {joined}/{max(0, len(videos) - 1)} exact boundaries. "
+        "Use the original assembly plan; added frames are trimmed by Assemble.\n" + "\n".join(reports)
+    )
+    return output, report
+
+
+class H3ContinuumDecodeContext:
+    CATEGORY = "MiniMax H3/flow regenerate"
+    DESCRIPTION = (
+        "Place immediately before Video VAE Decode, after all sampling/refinement/upscaling. "
+        "Supplies the next chunk's real decoder context at exact Continuum overlaps. "
+        "Connect the unchanged assembly plan to Assemble; it trims the extra decode-only frames. "
+        "Works with any progressive sampler. Output is for decoding only, not sampling or storage."
+    )
+    INPUT_IS_LIST = True
+    RETURN_TYPES = ("LATENT", "STRING")
+    RETURN_NAMES = ("video_latents", "report")
+    OUTPUT_IS_LIST = (True, False)
+    FUNCTION = "prepare"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"video_latents": ("LATENT",), "assembly_plan": ("H3_CONTINUUM_ASSEMBLY_PLAN",)}}
+
+    def prepare(self, video_latents, assembly_plan):
+        if len(assembly_plan) != 1:
+            raise ValueError("decode context requires one assembly plan for the video latent list")
+        return prepare_decode_context(video_latents, assembly_plan[0])
+
+
+NODE_CLASS_MAPPINGS = {"H3ContinuumDecodeContext": H3ContinuumDecodeContext}
+NODE_DISPLAY_NAME_MAPPINGS = {"H3ContinuumDecodeContext": "MiniMax H3 Continuum Decode Context"}

--- a/h3_flow_regenerate/handoff.py
+++ b/h3_flow_regenerate/handoff.py
@@ -126,6 +126,13 @@ class ProgressiveTargetInputConfig:
     contract must remain on the final output grid. The wrapper derives a low-grid
     sampler invocation internally and returns to the original target grid at the
     handoff, so downstream spatial contracts never observe a geometry change.
+
+    Exact Native Masked video protection defaults to the conservative target-grid
+    fallback. ``target_sparse_lifter`` is an experimental continuation path that
+    keeps the sampler state and protected rows on the exact target grid while
+    reducing only the early H3 transformer token stream. ``mixed_grid_low_suffix``
+    samples a real low-grid suffix while independently supplying the original
+    target-grid prefix to H3, then performs learned suffix transfer.
     """
 
     source_latent_h: int | None = None
@@ -140,6 +147,8 @@ class ProgressiveTargetInputConfig:
     seed_offset: int = 0x4833464C4F57
     source_noise_offset: int = 0x48334C4F574C52
     min_high_steps: int = 2
+    exact_prefix_mode: str = "fallback"
+    suffix_dc_bridge: bool = False
     learned_upscaler: Any | None = field(default=None, repr=False, compare=False)
 
     def __post_init__(self) -> None:
@@ -165,6 +174,14 @@ class ProgressiveTargetInputConfig:
             raise ValueError("target-input handoff transfer must be bicubic or learned_3d")
         if self.transfer_mode == "learned_3d":
             validate_learned_upscaler_provider(self.learned_upscaler)
+        if self.exact_prefix_mode not in {"fallback", "target_sparse_lifter", "mixed_grid_low_suffix"}:
+            raise ValueError("unsupported exact_prefix_mode")
+        if self.exact_prefix_mode == "mixed_grid_low_suffix" and self.transfer_mode != "learned_3d":
+            raise ValueError("mixed-grid continuation requires learned_3d transfer")
+        if not isinstance(self.suffix_dc_bridge, bool):
+            raise TypeError("suffix_dc_bridge must be boolean")
+        if self.suffix_dc_bridge and self.exact_prefix_mode not in {"target_sparse_lifter", "mixed_grid_low_suffix"}:
+            raise ValueError("suffix_dc_bridge is only supported by Continuum-specific exact-prefix modes")
         if self.min_high_steps < 1:
             raise ValueError("min_high_steps must be positive")
 

--- a/h3_flow_regenerate/mixed_grid.py
+++ b/h3_flow_regenerate/mixed_grid.py
@@ -1,0 +1,254 @@
+"""Mixed target-prefix/source-suffix transformer boundary.
+
+The sampler and native output projection use a regular low-grid carrier. Only
+the transformer sees the larger exact prefix. No generated hidden rows are
+interpolated: suffix rows enter and leave unchanged in native source order.
+"""
+
+from __future__ import annotations
+
+import copy
+from dataclasses import dataclass
+
+import torch
+
+from .geometry import unpack_streams
+
+MIXED_GRID_KEY = "h3_flow_mixed_grid_v1"
+MIXED_WRAPPER_KEY = "h3_flow_regenerate.mixed_grid.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class MixedGridPlan:
+    prefix: torch.Tensor
+    temporal: int
+    source_h: int
+    source_w: int
+    prefix_noise: torch.Tensor | None = None
+
+    @property
+    def prefix_t(self):
+        return int(self.prefix.shape[2])
+
+    @property
+    def target_hw(self):
+        return tuple(map(int, self.prefix.shape[-2:]))
+
+    @property
+    def source_rows(self):
+        return self.source_h * self.source_w // 4
+
+    @property
+    def target_rows(self):
+        return self.target_hw[0] * self.target_hw[1] // 4
+
+    @property
+    def prefix_rows(self):
+        return self.prefix_t * self.target_rows
+
+    @property
+    def mixed_rows(self):
+        return self.prefix_rows + (self.temporal - self.prefix_t) * self.source_rows
+
+
+def build_mixed_grid_plan(mask, shapes, internal_latent, sampler_noise, *, source_h, source_w):
+    video_mask, _ = unpack_streams(mask, shapes)
+    video, _ = unpack_streams(internal_latent, shapes)
+    video_noise, _ = unpack_streams(sampler_noise, shapes)
+    if video.ndim != 5 or video.shape[:2] != (1, 24):
+        raise ValueError("mixed-grid continuation requires batch-one native H3 video")
+    if tuple(video_noise.shape) != tuple(video.shape):
+        raise ValueError("mixed-grid sampler noise does not match target video geometry")
+    if not torch.isfinite(video_mask).all():
+        raise ValueError("mixed-grid video mask must be finite")
+    if not torch.isfinite(video_noise).all():
+        raise ValueError("mixed-grid sampler noise must be finite")
+    frames = video_mask.permute(2, 0, 1, 3, 4).reshape(video.shape[2], -1)
+    protected = (frames == 0).all(1)
+    generated = (frames == 1).all(1)
+    prefix_t = int(protected.sum().item())
+    if not 0 < prefix_t < video.shape[2]:
+        raise ValueError("mixed-grid continuation requires a nonempty protected prefix and generated suffix")
+    if not bool(protected[:prefix_t].all() and generated[prefix_t:].all()):
+        raise ValueError("mixed-grid continuation requires contiguous whole-frame zero-prefix/one-suffix protection")
+    target_h, target_w = map(int, video.shape[-2:])
+    if any(n < 2 or n % 2 for n in (source_h, source_w, target_h, target_w)):
+        raise ValueError("mixed-grid spatial axes must be positive and patch-safe")
+    if source_h > target_h or source_w > target_w or (source_h, source_w) == (target_h, target_w):
+        raise ValueError("mixed-grid source must reduce at least one axis without increasing another")
+    return MixedGridPlan(
+        video[:, :, :prefix_t].detach().clone(),
+        int(video.shape[2]),
+        source_h,
+        source_w,
+        video_noise[:, :, :prefix_t].detach().clone(),
+    )
+
+
+def carrier_layout(native, plan, text_len, audio_t, payload):
+    """Keep native target conditioning/audio positions; give target video a low grid."""
+    layout = native.PackedLayout(
+        text_len, plan.temporal, *plan.target_hw, audio_t, keyframes=payload.get("keyframes"), refs=payload.get("refs")
+    )
+    va, _, _ = layout.segments[-1]
+    origin = float(layout.position_ids[va, 0])
+    frame, _ = native._frame_grid(plan.source_h, plan.source_w)
+    positions = native._video_grid(plan.temporal, frame, origin)
+    layout.position_ids = torch.cat((layout.position_ids[:va], positions))
+    layout.seq_len = va + len(positions)
+    layout.segments = [*layout.segments[:-1], (va, layout.seq_len, "video")]
+    keep = layout.img_pos < va
+    layout.img_pos = torch.cat((layout.img_pos[keep], torch.arange(va, layout.seq_len)))
+    layout.img_update = torch.cat((layout.img_update[keep], torch.ones(len(positions), dtype=torch.bool)))
+    layout.signature = (text_len, plan.temporal, plan.source_h, plan.source_w, audio_t)
+    return layout
+
+
+def mixed_positions(native, plan, layout):
+    va, _, _ = layout.segments[-1]
+    origin = float(layout.position_ids[va, 0])
+    frame, _ = native._frame_grid(*plan.target_hw)
+    prefix = native._video_grid(plan.temporal, frame, origin)[: plan.prefix_rows]
+    # Slice the globally constructed low timeline; never restart k % 5.
+    suffix = layout.position_ids[va + plan.prefix_t * plan.source_rows :]
+    return torch.cat((layout.position_ids[:va], prefix, suffix))
+
+
+def mixed_mod_segments(segments, plan, va, vb):
+    result = []
+    for start, stop, row in segments:
+        if stop <= va:
+            result.append((start, stop, row))
+        elif (start, stop) == (va, vb):
+            if not torch.is_tensor(row) or row.ndim != 1 or row.numel() != vb - va:
+                raise RuntimeError("mixed-grid prefix requires native per-video-row timestep indices")
+            old_prefix = plan.prefix_t * plan.source_rows
+            if not bool((row[:old_prefix] == row[0]).all()):
+                raise RuntimeError("mixed-grid protected prefix has inconsistent timestep labels")
+            rows = torch.cat((row[:1].expand(plan.prefix_rows), row[old_prefix:]))
+            result.append((va, va + plan.mixed_rows, rows))
+        else:
+            raise RuntimeError("mixed-grid requires target video to be the final native segment")
+    return result
+
+
+def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=None, minimax_payload=None, **kwargs):
+    options = transformer_options or {}
+    contract = options.get(MIXED_GRID_KEY)
+    if contract is None:
+        return executor(x, timestep, context, options, minimax_payload=minimax_payload, **kwargs)
+    import comfy.ldm.minimax.model as native
+
+    plan = contract["plan"]
+    metrics = contract["metrics"]
+    inner = executor.class_obj
+    if not isinstance(plan, MixedGridPlan) or len(inner.blocks) == 0:
+        raise RuntimeError("mixed-grid requires a valid plan and native transformer blocks")
+    attention_override = options.get("optimized_attention_override")
+    if getattr(attention_override, "_h3_flow_attention_override", False):
+        raise RuntimeError("mixed-grid continuation does not support uniform-grid Flow Attention Lab overrides")
+    if tuple(x[0].shape) != (1, 24, plan.temporal, plan.source_h, plan.source_w):
+        raise RuntimeError("stale mixed-grid plan does not match sampler geometry")
+    if plan.prefix_noise is None or tuple(plan.prefix_noise.shape) != tuple(plan.prefix.shape):
+        raise RuntimeError("mixed-grid plan is missing the native protected-prefix sampler noise")
+    payload = dict(minimax_payload or {})
+    layout = carrier_layout(native, plan, context.shape[1], x[1].shape[-1], payload)
+    payload["layout"] = layout
+    va, vb, _ = layout.segments[-1]
+    old_prefix = plan.prefix_t * plan.source_rows
+    positions = mixed_positions(native, plan, layout)
+    mixed_layout = copy.copy(layout)
+    mixed_layout.position_ids = positions
+    mixed_layout.seq_len = va + plan.mixed_rows
+    mixed_layout.segments = [*layout.segments[:-1], (va, mixed_layout.seq_len, "video")]
+    # Other providers must not interpret this as uniform target video geometry.
+    mixed_layout.signature = ("h3_flow_mixed_grid_v1", *layout.signature, plan.prefix_t, *plan.target_hw)
+    keep = layout.img_pos < va
+    mixed_layout.img_pos = torch.cat((layout.img_pos[keep], torch.arange(va, mixed_layout.seq_len)))
+    mixed_layout.img_update = torch.cat((layout.img_update[keep], torch.ones(plan.mixed_rows, dtype=torch.bool)))
+    local = dict(options)
+    patches = dict(local.get("patches_replace") or {})
+    blocks = dict(patches.get("dit") or {})
+    patches["dit"] = blocks
+    local["patches_replace"] = patches
+    cached = {}
+
+    def wrap(layer, previous):
+        def call(args, extra):
+            img = args["img"]
+            if layer == 0:
+                # Match native MiniMaxH3.scale_latent_inpaint exactly for the
+                # protected target-grid context: the authoritative clean prefix
+                # stays at target geometry, but the model sees H3's 0.999
+                # visual-conditioning augmentation with the caller's original
+                # target-grid sampler noise. The low carrier prefix never becomes
+                # conditioning.
+                aug = float(native.VISUAL_COND_TIMESTEP)
+                prefix = plan.prefix.to(device=img.device, dtype=torch.float32)
+                prefix_noise = plan.prefix_noise.to(device=img.device, dtype=torch.float32)
+                prefix_rows = native.patchify_video(aug * prefix + (1.0 - aug) * prefix_noise)
+                prefix_embed = inner.video_patch_proj(prefix_rows).to(img)
+                img = torch.cat((img[:va], prefix_embed, img[va + old_prefix :]))
+                metrics.increment("mixed_grid_actual_calls")
+                metrics.event(
+                    "mixed_grid_transformer",
+                    mixed_video_rows=plan.mixed_rows,
+                    prefix_video_rows=plan.prefix_rows,
+                    suffix_video_rows=(plan.temporal - plan.prefix_t) * plan.source_rows,
+                    native_sequence_rows=layout.seq_len,
+                    mixed_sequence_rows=mixed_layout.seq_len,
+                    vdn_external_sequence_mode="dense_gate_no_linear",
+                    vdn_external_sequence_api=2,
+                    prefix_exact_latent_resized=False,
+                    prefix_native_inpaint_augmentation=True,
+                    prefix_visual_cond_timestep=aug,
+                    low_suffix_real_latent=True,
+                )
+            if len(img) != mixed_layout.seq_len:
+                raise RuntimeError("mixed-grid transformer row count mismatch")
+            if "rope" not in cached:
+                cached["rope"] = native.rope_rotation_table(inner.rope_freqs(positions, img.device), img.dtype)
+            forwarded = dict(args)
+            forwarded.update(
+                img=img,
+                layout=mixed_layout,
+                rope_freqs=cached["rope"],
+                mod_segments=mixed_mod_segments(args["mod_segments"], plan, va, vb),
+            )
+            block_options = dict(args["transformer_options"])
+            if "vdn_h3_external_sequence_v1" in block_options:
+                raise RuntimeError("mixed-grid found an already-owned VDN external sequence")
+            block_options["vdn_h3_external_sequence_v1"] = {
+                "api": 2,
+                "mode": "dense_gate_no_linear",
+                "topology": "mixed_grid_low_suffix",
+                "native_sequence_rows": layout.seq_len,
+                "sequence_rows": mixed_layout.seq_len,
+                "video_start": va,
+                "temporal": plan.temporal,
+                "prefix_t": plan.prefix_t,
+                "source_rows_per_frame": plan.source_rows,
+                "prefix_rows_per_frame": plan.target_rows,
+            }
+            forwarded["transformer_options"] = block_options
+            output = previous(forwarded, extra) if previous else extra["original_block"](forwarded)
+            result = output["img"]
+            if result.shape != img.shape:
+                raise RuntimeError("mixed-grid transformer returned incompatible hidden state")
+            if layer == len(inner.blocks) - 1:
+                # Discard exact-prefix transformer output. The low carrier is
+                # masked; only genuine suffix hidden rows reach native unpatchify.
+                result = torch.cat(
+                    (result[:va], result.new_zeros((old_prefix, result.shape[1])), result[va + plan.prefix_rows :])
+                )
+                output = {**output, "img": result}
+            return output
+
+        return call
+
+    for layer in range(len(inner.blocks)):
+        blocks[("double_block", layer)] = wrap(layer, blocks.get(("double_block", layer)))
+    output = executor(x, timestep, context, local, minimax_payload=payload, **kwargs)
+    video = output[0].clone()
+    video[:, :, : plan.prefix_t] = 0
+    return [video, output[1]]

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -23,7 +23,19 @@ from .handoff import (
     select_handoff_index,
 )
 from .metrics import H3FlowMetrics
+from .mixed_grid import MIXED_GRID_KEY, build_mixed_grid_plan
+from .seam_diagnostics import (
+    measure_exact_prefix_splice,
+    measure_video_boundary,
+    recover_conditional_clean_for_diagnostics,
+)
 from .sigma import H3_AUDIO_SHIFT, H3_VIDEO_SHIFT, audio_sigma, normalized_coordinate
+from .target_sparse import TARGET_SPARSE_CONTRACT_KEY, build_target_sparse_plan, target_sparse_contract
+from .tone_bridge import (
+    apply_suffix_dc_bridge,
+    disabled_suffix_dc_bridge_metrics,
+    map_clean_bridge_to_conditional_state,
+)
 
 LOG = logging.getLogger(__name__)
 
@@ -35,6 +47,7 @@ CLONE_CALLBACK_KEY = "h3_flow_regenerate.clone.v1"
 PROBE_MARKER = "_h3_flow_exact_probe"
 PROBE_CONTEXT_KEY = "h3_flow_exact_probe_context"
 FLOW_STAGE_KEY = "h3_flow_stage"
+EXACT_PREFIX_BRIDGE_KEY = "h3_flow_exact_prefix_bridge_v1"
 SPECTRUM_BINDING_KEY = "spectrum_h3_binding"
 SPECTRUM_ACTUAL_KEY = "spectrum_h3_actual"
 SPECTRUM_PHASE_KEY = "spectrum_h3_solver_phase"
@@ -454,6 +467,32 @@ def flow_predict_wrapper(executor, x, timestep, model_options=None, seed=None):
             )
         active.call_index += 1
 
+    exact_bridge = transformer.get(EXACT_PREFIX_BRIDGE_KEY)
+    if isinstance(exact_bridge, dict) and not bool(exact_bridge.get("applied")) and actual:
+        exact_prefix = exact_bridge.get("exact_prefix")
+        base_model = getattr(guider, "inner_model", None)
+        bridge_shapes = getattr(base_model, "latent_shapes", None)
+        if not isinstance(bridge_shapes, list) or len(bridge_shapes) != 2:
+            raise RuntimeError("exact-prefix suffix bridge could not resolve H3 AV latent shapes")
+        video_x0, audio_x0 = unpack_streams(result, bridge_shapes)
+        bridged_video, bridge_metrics = apply_suffix_dc_bridge(
+            video_x0,
+            exact_prefix,
+            weights=(1.0,),
+        )
+        result, _ = pack_streams((bridged_video, audio_x0))
+        exact_bridge["applied"] = True
+        binding.metrics.event(
+            "exact_prefix_suffix_dc_bridge",
+            source=str(exact_bridge.get("source", "unknown")),
+            stage=stage,
+            sigma=sigma,
+            coordinate=coordinate,
+            actual=True,
+            suffix_dc_bridge_state_mapping="first_actual_model_x0",
+            **bridge_metrics,
+        )
+
     if binding.guidance is not None and binding.guidance.mode != "off":
         run = binding.active_guidance_run
         if run is None:
@@ -840,6 +879,92 @@ def _flow_stage_contract(guider: Any, stage: str):
 
 
 @contextlib.contextmanager
+def _target_sparse_stage_contract(guider: Any, contract: dict[str, Any]):
+    options = getattr(guider, "model_options", None)
+    if not isinstance(options, dict):
+        raise RuntimeError("target-sparse progressive handoff requires mutable model options")
+    transformer = options.setdefault("transformer_options", {})
+    if not isinstance(transformer, dict):
+        raise RuntimeError("target-sparse progressive handoff requires mutable transformer options")
+    previous = transformer.get(TARGET_SPARSE_CONTRACT_KEY)
+    transformer[TARGET_SPARSE_CONTRACT_KEY] = contract
+    try:
+        yield
+    finally:
+        if previous is None:
+            transformer.pop(TARGET_SPARSE_CONTRACT_KEY, None)
+        else:
+            transformer[TARGET_SPARSE_CONTRACT_KEY] = previous
+
+
+@contextlib.contextmanager
+def _mixed_grid_stage_contract(guider, plan, metrics):
+    if plan is None:
+        yield
+        return
+    transformer = guider.model_options.setdefault("transformer_options", {})
+    if MIXED_GRID_KEY in transformer:
+        raise RuntimeError("nested mixed-grid stage is unsupported")
+    transformer[MIXED_GRID_KEY] = {"plan": plan, "metrics": metrics}
+    try:
+        yield
+    finally:
+        transformer.pop(MIXED_GRID_KEY, None)
+
+
+def _contiguous_exact_video_prefix(base_model, latent_image, denoise_mask, shapes):
+    """Return a canonical whole-frame Continuum prefix in model-domain latents.
+
+    Arbitrary masks keep their existing behavior; the bridge is only defined for
+    a contiguous all-zero video prefix followed by an all-one generated suffix.
+    """
+    if denoise_mask is None:
+        return None
+    if len(shapes) != 2:
+        raise ValueError("exact-prefix suffix bridge requires native video/audio shapes")
+    expected = (shapes[0][0], 1, sum(math.prod(shape[1:]) for shape in shapes))
+    if tuple(denoise_mask.shape) != expected:
+        raise ValueError("prepared H3 denoise mask does not match packed AV geometry")
+    video_mask, _audio_mask = unpack_streams(denoise_mask, shapes)
+    if not bool(torch.isfinite(video_mask).all().item()):
+        raise ValueError("exact-prefix suffix bridge requires a finite video mask")
+    temporal = int(shapes[0][2])
+    frames = video_mask.permute(2, 0, 1, 3, 4).reshape(temporal, -1)
+    protected = (frames == 0).all(1)
+    generated = (frames == 1).all(1)
+    prefix_t = int(protected.sum().item())
+    if not 0 < prefix_t < temporal:
+        return None
+    if not bool(protected[:prefix_t].all().item() and generated[prefix_t:].all().item()):
+        return None
+    internal = _process_latent_in(base_model, latent_image, shapes)
+    video, _audio = unpack_streams(internal, shapes)
+    return video[:, :, :prefix_t].detach().clone()
+
+
+@contextlib.contextmanager
+def _exact_prefix_suffix_bridge_contract(guider, exact_prefix, *, source):
+    options = getattr(guider, "model_options", None)
+    if not isinstance(options, dict):
+        raise RuntimeError("exact-prefix suffix bridge requires mutable model options")
+    transformer = options.setdefault("transformer_options", {})
+    if not isinstance(transformer, dict):
+        raise RuntimeError("exact-prefix suffix bridge requires mutable transformer options")
+    if EXACT_PREFIX_BRIDGE_KEY in transformer:
+        raise RuntimeError("nested exact-prefix suffix bridge contract is unsupported")
+    contract = {
+        "exact_prefix": exact_prefix,
+        "source": str(source),
+        "applied": False,
+    }
+    transformer[EXACT_PREFIX_BRIDGE_KEY] = contract
+    try:
+        yield contract
+    finally:
+        transformer.pop(EXACT_PREFIX_BRIDGE_KEY, None)
+
+
+@contextlib.contextmanager
 def _high_stage_contract(guider: Any):
     options = getattr(guider, "model_options", None)
     if not isinstance(options, dict):
@@ -872,6 +997,242 @@ def _high_stage_contract(guider: Any):
             transformer["h3_refinement"] = previous
 
 
+def _run_target_sparse_exact_prefix(
+    executor,
+    guider,
+    binding: FlowBinding,
+    config: ProgressiveTargetInputConfig,
+    noise,
+    latent_image,
+    sampler,
+    sigmas,
+    denoise_mask,
+    callback,
+    disable_pbar,
+    seed,
+    latent_shapes,
+):
+    """Progressively reduce H3 transformer tokens without resizing exact context.
+
+    This path is intentionally different from the normal low-grid handoff. The
+    sampler state, latent image, denoise mask, conditioning layout and RoPE all
+    remain on the caller's target grid. During the early sampler lifetime only,
+    H3 block wrappers keep every non-video row, every exact-protected target-video
+    row and a regular coarse lattice of generated video rows. The last block
+    lifts the coarse hidden field to the full target grid. A fresh full-transformer
+    sampler lifetime begins at the configured handoff coordinate.
+    """
+
+    if denoise_mask is None:
+        raise ValueError("target-sparse exact-prefix mode requires a prepared H3 denoise mask")
+    _validate_progressive_sampler_state(sampler)
+    if sigmas.ndim != 1 or sigmas.numel() < 4:
+        raise ValueError("progressive handoff requires a full H3 sigma schedule")
+    if not math.isclose(float(sigmas[0]), 1.0, rel_tol=0.0, abs_tol=1e-6) or not math.isclose(
+        float(sigmas[-1]), 0.0, rel_tol=0.0, abs_tol=1e-8
+    ):
+        raise ValueError("progressive handoff requires a full 1-to-0 H3 sigma schedule")
+
+    target_shapes = list(latent_shapes)
+    target_h, target_w = map(int, target_shapes[0][-2:])
+    if target_h % 2 or target_w % 2:
+        raise ValueError("target-sparse input H3 geometry is not patch-safe")
+    source_h, source_w = config.resolve_source(target_h, target_w)
+
+    model_options = getattr(guider, "model_options", None)
+    if not isinstance(model_options, dict):
+        raise RuntimeError("target-sparse progressive handoff requires mutable model options")
+    transformer = model_options.setdefault("transformer_options", {})
+    if not isinstance(transformer, dict):
+        raise RuntimeError("target-sparse progressive handoff requires mutable transformer options")
+    current_conds = getattr(guider, "conds", None)
+    if not isinstance(current_conds, dict):
+        raise RuntimeError("target-sparse progressive handoff requires ComfyUI guider conditioning state")
+    conditioning_template = {
+        key: [entry.copy() if isinstance(entry, dict) else copy.copy(entry) for entry in entries]
+        for key, entries in current_conds.items()
+    }
+    video_shift = float(transformer.get("minimax_h3_sigma_shift_video", H3_VIDEO_SHIFT))
+    selected_coordinate = config.resolve_coordinate(source_h, source_w, target_h, target_w)
+    index = select_handoff_index(
+        sigmas,
+        selected_coordinate,
+        min_high_steps=config.min_high_steps,
+        video_shift=video_shift,
+    )
+    sigma = float(sigmas[index].item())
+    low_sigmas = sigmas[: index + 1]
+    high_sigmas = sigmas[index:]
+    plan = build_target_sparse_plan(
+        denoise_mask,
+        target_shapes,
+        source_h=source_h,
+        source_w=source_w,
+    )
+    sparse_contract = target_sparse_contract(plan)
+
+    binding.metrics.increment("progressive_target_sparse_runs")
+    binding.metrics.event(
+        "handoff_plan",
+        index=index,
+        sigma=sigma,
+        coordinate=float(normalized_coordinate(sigma, video_shift=video_shift)),
+        requested_coordinate=config.handoff_coordinate,
+        selected_coordinate=selected_coordinate,
+        selection=config.handoff_selection,
+        transfer_mode="target_sparse_lifter",
+        input_mode="target_grid_sparse",
+        source_shape=(*target_shapes[0][:-2], source_h, source_w),
+        target_hw=(target_h, target_w),
+        protected_video_rows=plan.protected_video_row_count,
+        anchor_video_rows=plan.anchor_video_row_count,
+        selected_video_rows=plan.selected_video_row_count,
+        target_video_rows=plan.target_video_rows,
+        video_row_fraction=plan.video_row_fraction,
+        exact_target_latent_resized=False,
+        exact_target_mask_resized=False,
+    )
+
+    sampler_invocation_count = 0
+    history_boundary_count = 0
+    _begin_capture(binding, guider, sampler, low_sigmas, target_shapes)
+    try:
+        _reset_guider_conds(guider, template=conditioning_template)
+        low_started = time.perf_counter()
+        try:
+            sampler_invocation_count += 1
+            binding.metrics.increment("progressive_sampler_invocations")
+            with _flow_stage_contract(guider, "low"), _target_sparse_stage_contract(guider, sparse_contract):
+                low_result = executor(
+                    noise,
+                    latent_image,
+                    sampler,
+                    low_sigmas,
+                    denoise_mask,
+                    callback,
+                    disable_pbar,
+                    seed,
+                    latent_shapes=target_shapes,
+                )
+        finally:
+            binding.metrics.event(
+                "low_stage_wall",
+                elapsed_ms=(time.perf_counter() - low_started) * 1000.0,
+                target_sparse=True,
+            )
+        base_model = guider.model_patcher.model
+        target_raw = _raw_sampler_state(base_model, low_result, target_shapes, sigma)
+    except BaseException as exc:
+        _finish_capture(binding, error=exc)
+        raise
+
+    committed_low_run = _finish_capture(binding)
+    try:
+        target_latent_internal = _process_latent_in(base_model, latent_image, target_shapes)
+        target_noise = _noise_argument(base_model, target_raw, sigma, target_latent_internal)
+        target_noise = _merge_preserved_noise(target_noise, noise, denoise_mask)
+
+        if binding.guidance is not None and binding.guidance.mode != "off":
+            if committed_low_run is None:
+                raise RuntimeError("target-sparse Flow guidance requires low-stage trajectory capture")
+            if committed_low_run.geometry.latent_t != int(target_shapes[0][2]):
+                raise ValueError("target-sparse low trajectory and target video temporal geometry differ")
+            binding.active_guidance_run = committed_low_run
+
+        def high_callback(step, x0, x, _total):
+            if callback is not None:
+                return callback(index + step, x0, x, len(sigmas) - 1)
+            return None
+
+        bridge_prefix = None
+        if config.suffix_dc_bridge:
+            bridge_prefix = _contiguous_exact_video_prefix(
+                base_model,
+                latent_image,
+                denoise_mask,
+                target_shapes,
+            )
+            if bridge_prefix is None:
+                binding.metrics.event(
+                    "exact_prefix_suffix_dc_bridge_skipped",
+                    source="target_sparse_high",
+                    reason="noncanonical_exact_mask",
+                )
+        bridge_context = (
+            _exact_prefix_suffix_bridge_contract(
+                guider,
+                bridge_prefix,
+                source="target_sparse_high",
+            )
+            if bridge_prefix is not None
+            else contextlib.nullcontext(None)
+        )
+
+        _reset_guider_conds(guider, template=conditioning_template)
+        high_started = time.perf_counter()
+        high_event_start = len(binding.metrics.events)
+        sampler_invocation_count += 1
+        history_boundary_count += 1
+        binding.metrics.increment("progressive_sampler_invocations")
+        binding.metrics.increment("progressive_history_boundaries")
+        with _flow_stage_contract(guider, "high"), _high_stage_contract(guider), bridge_context as bridge_contract:
+            result = executor(
+                target_noise,
+                latent_image,
+                sampler,
+                high_sigmas,
+                denoise_mask,
+                high_callback,
+                disable_pbar,
+                seed,
+                latent_shapes=target_shapes,
+            )
+        if isinstance(bridge_contract, dict) and not bool(bridge_contract.get("applied")):
+            raise RuntimeError(
+                "target-sparse exact-prefix suffix bridge did not observe the required actual high-stage H3 evaluation"
+            )
+        binding.metrics.event(
+            "high_stage_wall",
+            elapsed_ms=(time.perf_counter() - high_started) * 1000.0,
+            target_sparse=False,
+        )
+        high_model_calls = [event for event in binding.metrics.events[high_event_start:] if event.kind == "model_call"]
+        if not high_model_calls:
+            raise RuntimeError("target-sparse progressive high stage produced no H3 model evaluations")
+        first_high_actual = bool(high_model_calls[0].fields.get("actual"))
+        if not first_high_actual:
+            raise RuntimeError("target-sparse progressive high stage did not begin with an exact H3 model evaluation")
+        binding.metrics.event(
+            "handoff_complete",
+            sigma=sigma,
+            target_shape=target_shapes[0],
+            audio_state_copied=False,
+            separate_sampler_invocations=True,
+            sampler_invocation_count=sampler_invocation_count,
+            history_boundary_count=history_boundary_count,
+            exact_probe_performed=False,
+            high_stage_exact_prefix_requested=1,
+            high_stage_first_call_actual=first_high_actual,
+            high_stage_model_calls=len(high_model_calls),
+            conditioning_rebuilt_for_high_grid=False,
+            transfer_mode="target_sparse_lifter",
+            input_mode="target_grid_sparse",
+            exact_target_inputs_forwarded=True,
+            exact_protected_rows_retained=True,
+            source_latent_resize_performed=False,
+            learned_transfer_performed=False,
+        )
+        return result
+    except BaseException as exc:
+        if committed_low_run is not None and binding.trajectory is not None:
+            invalid = binding.trajectory.invalidate(
+                committed_low_run.run_id,
+                f"target-sparse progressive continuation failed: {type(exc).__name__}: {exc}",
+            )
+            binding.metrics.event("trajectory_invalidate", run_id=invalid.run_id, error=type(exc).__name__)
+        raise
+
+
 def _run_progressive(
     executor,
     guider,
@@ -887,10 +1248,43 @@ def _run_progressive(
     seed,
     latent_shapes,
 ):
+    chunk_started = time.perf_counter()
     if len(latent_shapes) != 2:
         raise ValueError("progressive handoff supports native packed H3 AV latents only")
+    if isinstance(config, ProgressiveTargetInputConfig) and config.exact_prefix_mode == "mixed_grid_low_suffix":
+        # Recheck the assembled workflow, including VDN applied after Flow.
+        from .comfy_compat import _validate_vdn_target_sparse_compat
+
+        patcher = guider.model_patcher
+        _validate_vdn_target_sparse_compat(patcher, len(patcher.model.diffusion_model.blocks), minimum_api=2)
     input_shapes = list(latent_shapes)
-    if isinstance(config, ProgressiveTargetInputConfig) and _has_exact_video_protection(denoise_mask, input_shapes):
+    mixed = (
+        isinstance(config, ProgressiveTargetInputConfig)
+        and config.exact_prefix_mode == "mixed_grid_low_suffix"
+        and _has_exact_video_protection(denoise_mask, input_shapes)
+    )
+    mixed_plan = None
+    if (
+        not mixed
+        and isinstance(config, ProgressiveTargetInputConfig)
+        and _has_exact_video_protection(denoise_mask, input_shapes)
+    ):
+        if config.exact_prefix_mode == "target_sparse_lifter":
+            return _run_target_sparse_exact_prefix(
+                executor,
+                guider,
+                binding,
+                config,
+                noise,
+                latent_image,
+                sampler,
+                sigmas,
+                denoise_mask,
+                callback,
+                disable_pbar,
+                seed,
+                latent_shapes,
+            )
         # Native masked continuation promises exact video-prefix preservation.
         # A private low-grid lifetime would resize those clean prefix latents and
         # expose the changed values to every generated row through H3's dense
@@ -957,6 +1351,34 @@ def _run_progressive(
         target_shapes = input_shapes
         target_h, target_w = target_shapes[0][-2:]
         source_h, source_w = config.resolve_source(target_h, target_w)
+        if mixed:
+            mixed_plan = build_mixed_grid_plan(
+                denoise_mask,
+                input_shapes,
+                _process_latent_in(guider.model_patcher.model, latent_image, input_shapes),
+                noise,
+                source_h=source_h,
+                source_w=source_w,
+            )
+            binding.metrics.event(
+                "mixed_grid_plan",
+                input_mode="mixed_grid_low_suffix",
+                transfer_mode="learned_3d_suffix",
+                prefix_temporal_length=mixed_plan.prefix_t,
+                suffix_temporal_length=mixed_plan.temporal - mixed_plan.prefix_t,
+                prefix_target_hw=mixed_plan.target_hw,
+                suffix_source_hw=(source_h, source_w),
+                target_hw=mixed_plan.target_hw,
+                full_target_video_rows=mixed_plan.temporal * mixed_plan.target_rows,
+                mixed_video_rows=mixed_plan.mixed_rows,
+                prefix_video_rows=mixed_plan.prefix_rows,
+                suffix_video_rows=(mixed_plan.temporal - mixed_plan.prefix_t) * mixed_plan.source_rows,
+                prefix_exact_latent_resized=False,
+                prefix_target_grid_rope=True,
+                suffix_source_grid_rope=True,
+                continuous_temporal_rope=True,
+                low_suffix_real_latent=True,
+            )
         source_shapes = list(target_shapes)
         source_shapes[0] = (*source_shapes[0][:-2], source_h, source_w)
         target_video_noise, target_audio_noise = unpack_streams(noise, target_shapes)
@@ -1003,7 +1425,7 @@ def _run_progressive(
         selected_coordinate=selected_coordinate,
         selection=config.handoff_selection,
         transfer_mode=config.transfer_mode,
-        input_mode="target_grid" if target_input else "source_grid",
+        input_mode="mixed_grid_low_suffix" if mixed else ("target_grid" if target_input else "source_grid"),
         source_shape=source_shapes[0],
         target_hw=(target_h, target_w),
     )
@@ -1027,13 +1449,13 @@ def _run_progressive(
         _reset_guider_conds(
             guider,
             template=conditioning_template,
-            target_video_hw=(source_h, source_w) if target_input else None,
+            target_video_hw=(source_h, source_w) if target_input and not mixed else None,
         )
         low_started = time.perf_counter()
         try:
             sampler_invocation_count += 1
             binding.metrics.increment("progressive_sampler_invocations")
-            with _flow_stage_contract(guider, "low"):
+            with _flow_stage_contract(guider, "low"), _mixed_grid_stage_contract(guider, mixed_plan, binding.metrics):
                 low_result = executor(
                     low_noise,
                     low_latent_image,
@@ -1061,7 +1483,7 @@ def _run_progressive(
             _reset_guider_conds(
                 guider,
                 template=conditioning_template,
-                target_video_hw=(source_h, source_w) if target_input else None,
+                target_video_hw=(source_h, source_w) if target_input and not mixed else None,
             )
             # The probe is a one-call sampler lifetime, but model-level patches such
             # as DiffAid must still see the full H3 sigma reference. The explicit
@@ -1071,7 +1493,11 @@ def _run_progressive(
             history_boundary_count += 1
             binding.metrics.increment("progressive_sampler_invocations")
             binding.metrics.increment("progressive_history_boundaries")
-            with _flow_stage_contract(guider, "probe"), _high_stage_contract(guider):
+            with (
+                _flow_stage_contract(guider, "probe"),
+                _high_stage_contract(guider),
+                _mixed_grid_stage_contract(guider, mixed_plan, binding.metrics),
+            ):
                 source_x0 = executor(
                     probe_noise,
                     low_latent_image,
@@ -1096,8 +1522,18 @@ def _run_progressive(
     binding.metrics.increment("handoff_exact_probe_nfe")
     try:
         source_x0 = _process_latent_in(base_model, source_x0, source_shapes)
+        if mixed_plan is not None:
+            # Use all prefix frames as transient upscaler context. Its 3D attention
+            # has no proven finite temporal receptive field permitting truncation.
+            clean_video, clean_audio = unpack_streams(source_x0, source_shapes)
+            clean_video = clean_video.clone()
+            clean_video[:, :, : mixed_plan.prefix_t] = resize_spatial_5d(
+                mixed_plan.prefix.to(clean_video), source_h, source_w, mode="bicubic"
+            )
+            source_x0 = pack_streams((clean_video, clean_audio))[0]
         transfer_started = time.perf_counter()
         transfer_metrics: dict[str, Any] = {}
+        splice_diagnostics: dict[str, Any] = {}
         target_raw, target_shapes = build_handoff_state(
             source_packed_state=source_raw,
             source_x0_packed=source_x0,
@@ -1110,6 +1546,66 @@ def _run_progressive(
             learned_upscaler=getattr(config, "learned_upscaler", None),
             transfer_metrics=transfer_metrics,
         )
+        if mixed_plan is not None:
+            target_video, target_audio = unpack_streams(target_raw, target_shapes)
+            diagnostic_started = time.perf_counter()
+            diagnostic_noise = deterministic_video_noise(
+                tuple(target_video.shape),
+                seed=int(seed or 0) + config.seed_offset,
+                device=target_video.device,
+                dtype=target_video.dtype,
+            )
+            learned_clean = recover_conditional_clean_for_diagnostics(
+                target_video,
+                diagnostic_noise,
+                sigma=sigma,
+            )
+            exact_prefix = mixed_plan.prefix.to(device=learned_clean.device, dtype=learned_clean.dtype)
+            bridge_enabled = bool(getattr(config, "suffix_dc_bridge", False))
+            if bridge_enabled:
+                corrected_clean, bridge_metrics = apply_suffix_dc_bridge(
+                    learned_clean,
+                    exact_prefix,
+                    weights=(1.0,),
+                )
+                target_video = map_clean_bridge_to_conditional_state(
+                    target_video,
+                    learned_clean,
+                    corrected_clean,
+                    sigma=sigma,
+                    prefix_t=mixed_plan.prefix_t,
+                    corrected_tokens=int(bridge_metrics["suffix_dc_bridge_corrected_tokens"]),
+                )
+            else:
+                corrected_clean = learned_clean
+                bridge_metrics = disabled_suffix_dc_bridge_metrics(prefix_t=mixed_plan.prefix_t)
+            splice_diagnostics = measure_exact_prefix_splice(
+                learned_clean,
+                exact_prefix,
+                corrected_clean_video=corrected_clean,
+            )
+            splice_diagnostics["splice_diagnostic_elapsed_ms"] = (time.perf_counter() - diagnostic_started) * 1000.0
+            splice_diagnostics["splice_recovery"] = "inverse_conditional_renoise"
+            splice_diagnostics["suffix_dc_bridge_state_mapping"] = (
+                "affine_equivalent_pre_renoise" if bridge_enabled else "disabled"
+            )
+            binding.metrics.increment("mixed_grid_splice_diagnostic_runs")
+            del diagnostic_noise, learned_clean, corrected_clean
+
+            if not bridge_enabled:
+                target_video = target_video.clone()
+            target_video[:, :, : mixed_plan.prefix_t] = mixed_plan.prefix.to(target_video)
+            target_raw = pack_streams((target_video, target_audio))[0]
+            binding.metrics.event(
+                "mixed_grid_transfer",
+                learned_transfer_performed=True,
+                upscaler_prefix_context_used=True,
+                upscaler_prefix_output_discarded=True,
+                final_original_prefix_restored=True,
+                transfer_mode="learned_3d_suffix",
+                **bridge_metrics,
+                **splice_diagnostics,
+            )
         if config.transfer_mode == "learned_3d":
             binding.metrics.event(
                 "handoff_learned_upscale_wall",
@@ -1194,6 +1690,38 @@ def _run_progressive(
         first_high_actual = bool(high_model_calls[0].fields.get("actual"))
         if not first_high_actual:
             raise RuntimeError("progressive high stage did not begin with the required exact H3 model evaluation")
+        if mixed_plan is not None:
+            final_video, _ = unpack_streams(result, target_shapes)
+            original_video, _ = unpack_streams(latent_image, target_shapes)
+            if not torch.equal(
+                final_video[:, :, : mixed_plan.prefix_t], original_video[:, :, : mixed_plan.prefix_t].to(final_video)
+            ):
+                raise RuntimeError("mixed-grid high stage violated exact original-prefix preservation")
+            final_boundary = measure_video_boundary(final_video, mixed_plan.prefix_t)
+            if not splice_diagnostics:
+                raise RuntimeError("mixed-grid splice diagnostics were not recorded before high-stage sampling")
+            binding.metrics.event(
+                "mixed_grid_complete",
+                final_prefix_exact=True,
+                high_stage_first_call_actual=first_high_actual,
+                total_chunk_sampler_elapsed_ms=(time.perf_counter() - chunk_started) * 1000.0,
+                final_seam_lowpass_kernel=final_boundary["lowpass_kernel"],
+                final_seam_rms=final_boundary["seam_rms"],
+                final_seam_lowpass_rms=final_boundary["seam_lowpass_rms"],
+                final_seam_spatial_mean_rms=final_boundary["seam_spatial_mean_rms"],
+                final_over_transfer_exact_seam_rms_ratio=final_boundary["seam_rms"]
+                / max(float(splice_diagnostics["exact_restored_seam_rms"]), 1e-12),
+                final_over_transfer_exact_seam_lowpass_ratio=final_boundary["seam_lowpass_rms"]
+                / max(float(splice_diagnostics["exact_restored_seam_lowpass_rms"]), 1e-12),
+                final_over_transfer_exact_seam_spatial_mean_ratio=final_boundary["seam_spatial_mean_rms"]
+                / max(float(splice_diagnostics["exact_restored_seam_spatial_mean_rms"]), 1e-12),
+                final_over_transfer_corrected_seam_rms_ratio=final_boundary["seam_rms"]
+                / max(float(splice_diagnostics["corrected_exact_seam_rms"]), 1e-12),
+                final_over_transfer_corrected_seam_lowpass_ratio=final_boundary["seam_lowpass_rms"]
+                / max(float(splice_diagnostics["corrected_exact_seam_lowpass_rms"]), 1e-12),
+                final_over_transfer_corrected_seam_spatial_mean_ratio=final_boundary["seam_spatial_mean_rms"]
+                / max(float(splice_diagnostics["corrected_exact_seam_spatial_mean_rms"]), 1e-12),
+            )
         binding.metrics.event(
             "handoff_complete",
             sigma=sigma,
@@ -1208,7 +1736,7 @@ def _run_progressive(
             high_stage_model_calls=len(high_model_calls),
             conditioning_rebuilt_for_high_grid=True,
             transfer_mode=config.transfer_mode,
-            input_mode="target_grid" if target_input else "source_grid",
+            input_mode="mixed_grid_low_suffix" if mixed else ("target_grid" if target_input else "source_grid"),
         )
         return result
 

--- a/h3_flow_regenerate/seam_diagnostics.py
+++ b/h3_flow_regenerate/seam_diagnostics.py
@@ -1,0 +1,214 @@
+"""Non-mutating latent seam diagnostics for progressive exact-prefix handoffs."""
+
+from __future__ import annotations
+
+import math
+
+import torch
+from torch.nn import functional as F
+
+_EPS = 1e-12
+_DEFAULT_LOWPASS_KERNEL = 5
+
+
+def _finite_rms(value: torch.Tensor) -> float:
+    if value.numel() == 0:
+        raise ValueError("seam diagnostic RMS requires a non-empty tensor")
+    result = float(value.float().square().mean().sqrt().detach().to(device="cpu").item())
+    if not math.isfinite(result):
+        raise RuntimeError("seam diagnostic produced a non-finite RMS value")
+    return result
+
+
+def _effective_lowpass_kernel(video: torch.Tensor, requested: int = _DEFAULT_LOWPASS_KERNEL) -> int:
+    if video.ndim != 5:
+        raise ValueError("seam diagnostic low-pass expects BxCxTxHxW")
+    if requested < 1 or requested % 2 == 0:
+        raise ValueError("seam diagnostic low-pass kernel must be a positive odd integer")
+    height, width = map(int, video.shape[-2:])
+    if height < 1 or width < 1:
+        raise ValueError("seam diagnostic spatial axes must be non-empty")
+    radius = min(requested // 2, (height - 1) // 2, (width - 1) // 2)
+    return 2 * max(radius, 0) + 1
+
+
+def _spatial_lowpass(video: torch.Tensor, kernel: int) -> torch.Tensor:
+    if video.ndim != 5:
+        raise ValueError("seam diagnostic low-pass expects BxCxTxHxW")
+    if kernel == 1:
+        return video.float()
+    if kernel < 1 or kernel % 2 == 0:
+        raise ValueError("seam diagnostic low-pass kernel must be a positive odd integer")
+    batch, channels, frames, height, width = video.shape
+    radius = kernel // 2
+    work = video.permute(0, 2, 1, 3, 4).reshape(batch * frames, channels, height, width).float()
+    work = F.pad(work, (radius, radius, radius, radius), mode="replicate")
+    work = F.avg_pool2d(work, kernel_size=kernel, stride=1)
+    return work.reshape(batch, frames, channels, height, width).permute(0, 2, 1, 3, 4)
+
+
+def _delta_metrics(left: torch.Tensor, right: torch.Tensor, *, lowpass_kernel: int) -> dict[str, float]:
+    if left.shape != right.shape or left.ndim != 5:
+        raise ValueError("seam diagnostic comparison tensors must be matching BxCxTxHxW values")
+    raw = _finite_rms(left.float() - right.float())
+    left_low = _spatial_lowpass(left, lowpass_kernel)
+    right_low = _spatial_lowpass(right, lowpass_kernel)
+    lowpass = _finite_rms(left_low - right_low)
+    left_mean = left.float().mean(dim=(-2, -1))
+    right_mean = right.float().mean(dim=(-2, -1))
+    spatial_mean = _finite_rms(left_mean - right_mean)
+    return {
+        "rms": raw,
+        "lowpass_rms": lowpass,
+        "spatial_mean_rms": spatial_mean,
+    }
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float:
+    result = float(numerator) / max(float(denominator), _EPS)
+    if not math.isfinite(result):
+        raise RuntimeError("seam diagnostic produced a non-finite ratio")
+    return result
+
+
+def recover_conditional_clean_for_diagnostics(
+    state: torch.Tensor,
+    noise: torch.Tensor,
+    *,
+    sigma: float,
+) -> torch.Tensor:
+    """Invert ``x_t = (1-sigma) * x0 + sigma * noise`` for diagnostics only.
+
+    The returned float32 tensor is never fed back into sampling. The caller must
+    supply the exact deterministic noise used by the handoff constructor.
+    """
+    if state.shape != noise.shape or state.ndim != 5:
+        raise ValueError("conditional-clean recovery expects matching BxCxTxHxW state/noise tensors")
+    sigma = float(sigma)
+    if not math.isfinite(sigma) or not 0.0 <= sigma < 1.0:
+        raise ValueError("conditional-clean recovery requires finite sigma in [0, 1)")
+    with torch.no_grad():
+        return (state.float() - sigma * noise.float()) / (1.0 - sigma)
+
+
+def measure_exact_prefix_splice(
+    upscaled_clean_video: torch.Tensor,
+    exact_prefix: torch.Tensor,
+    *,
+    corrected_clean_video: torch.Tensor | None = None,
+    requested_lowpass_kernel: int = _DEFAULT_LOWPASS_KERNEL,
+) -> dict[str, float | int]:
+    """Measure the learned-upscaler seam before and after exact-prefix restoration.
+
+    ``upscaled_clean_video`` is the clean target-grid result produced by the
+    learned 3D upscaler before Flow discards its prefix. ``exact_prefix`` is the
+    authoritative target-grid prefix that will replace that learned prefix.
+    Only scalar diagnostics are returned; neither input is mutated.
+    """
+    if upscaled_clean_video.ndim != 5 or exact_prefix.ndim != 5:
+        raise ValueError("exact-prefix splice diagnostics expect BxCxTxHxW tensors")
+    if upscaled_clean_video.shape[:2] != exact_prefix.shape[:2]:
+        raise ValueError("exact-prefix splice batch/channel geometry differs")
+    if upscaled_clean_video.shape[-2:] != exact_prefix.shape[-2:]:
+        raise ValueError("exact-prefix splice spatial geometry differs")
+    if corrected_clean_video is not None:
+        if corrected_clean_video.ndim != 5 or corrected_clean_video.shape != upscaled_clean_video.shape:
+            raise ValueError("corrected exact-prefix splice tensor geometry differs")
+        if not corrected_clean_video.is_floating_point():
+            raise TypeError("corrected exact-prefix splice tensor must be floating-point")
+        if not bool(torch.isfinite(corrected_clean_video).all().item()):
+            raise RuntimeError("corrected exact-prefix splice tensor contains NaN or Inf values")
+    prefix_t = int(exact_prefix.shape[2])
+    temporal = int(upscaled_clean_video.shape[2])
+    if prefix_t < 1 or prefix_t >= temporal:
+        raise ValueError("exact-prefix splice requires a non-empty prefix shorter than the video")
+
+    lowpass_kernel = _effective_lowpass_kernel(upscaled_clean_video, requested_lowpass_kernel)
+    upscaled_prefix = upscaled_clean_video[:, :, :prefix_t]
+    learned_last = upscaled_clean_video[:, :, prefix_t - 1 : prefix_t]
+    suffix_first = upscaled_clean_video[:, :, prefix_t : prefix_t + 1]
+    exact_last = exact_prefix[:, :, -1:]
+
+    with torch.no_grad():
+        fields: dict[str, float | int] = {
+            "splice_diagnostic_version": 1,
+            "splice_prefix_temporal_length": prefix_t,
+            "splice_lowpass_kernel": lowpass_kernel,
+        }
+
+        full_restore = _delta_metrics(exact_prefix, upscaled_prefix, lowpass_kernel=lowpass_kernel)
+        fields.update(
+            prefix_restore_rms_all=full_restore["rms"],
+            prefix_restore_lowpass_rms_all=full_restore["lowpass_rms"],
+            prefix_restore_spatial_mean_rms_all=full_restore["spatial_mean_rms"],
+        )
+        for tail in (1, 2, 4):
+            if prefix_t < tail:
+                continue
+            tail_restore = _delta_metrics(
+                exact_prefix[:, :, -tail:],
+                upscaled_prefix[:, :, -tail:],
+                lowpass_kernel=lowpass_kernel,
+            )
+            fields[f"prefix_restore_rms_tail_{tail}"] = tail_restore["rms"]
+            fields[f"prefix_restore_lowpass_rms_tail_{tail}"] = tail_restore["lowpass_rms"]
+            fields[f"prefix_restore_spatial_mean_rms_tail_{tail}"] = tail_restore["spatial_mean_rms"]
+
+        native = _delta_metrics(suffix_first, learned_last, lowpass_kernel=lowpass_kernel)
+        restored = _delta_metrics(suffix_first, exact_last, lowpass_kernel=lowpass_kernel)
+        corrected_first = (
+            suffix_first if corrected_clean_video is None else corrected_clean_video[:, :, prefix_t : prefix_t + 1]
+        )
+        corrected = _delta_metrics(corrected_first, exact_last, lowpass_kernel=lowpass_kernel)
+        fields.update(
+            upscaler_native_seam_rms=native["rms"],
+            exact_restored_seam_rms=restored["rms"],
+            seam_rms_amplification=_safe_ratio(restored["rms"], native["rms"]),
+            upscaler_native_seam_lowpass_rms=native["lowpass_rms"],
+            exact_restored_seam_lowpass_rms=restored["lowpass_rms"],
+            seam_lowpass_amplification=_safe_ratio(restored["lowpass_rms"], native["lowpass_rms"]),
+            upscaler_native_seam_spatial_mean_rms=native["spatial_mean_rms"],
+            exact_restored_seam_spatial_mean_rms=restored["spatial_mean_rms"],
+            seam_spatial_mean_amplification=_safe_ratio(restored["spatial_mean_rms"], native["spatial_mean_rms"]),
+            corrected_exact_seam_rms=corrected["rms"],
+            corrected_exact_seam_lowpass_rms=corrected["lowpass_rms"],
+            corrected_exact_seam_spatial_mean_rms=corrected["spatial_mean_rms"],
+            corrected_over_native_seam_rms_ratio=_safe_ratio(corrected["rms"], native["rms"]),
+            corrected_over_native_seam_lowpass_ratio=_safe_ratio(corrected["lowpass_rms"], native["lowpass_rms"]),
+            corrected_over_native_seam_spatial_mean_ratio=_safe_ratio(
+                corrected["spatial_mean_rms"], native["spatial_mean_rms"]
+            ),
+            corrected_over_uncorrected_exact_seam_rms_ratio=_safe_ratio(corrected["rms"], restored["rms"]),
+            corrected_over_uncorrected_exact_seam_lowpass_ratio=_safe_ratio(
+                corrected["lowpass_rms"], restored["lowpass_rms"]
+            ),
+            corrected_over_uncorrected_exact_seam_spatial_mean_ratio=_safe_ratio(
+                corrected["spatial_mean_rms"], restored["spatial_mean_rms"]
+            ),
+        )
+    return fields
+
+
+def measure_video_boundary(
+    video: torch.Tensor,
+    prefix_t: int,
+    *,
+    requested_lowpass_kernel: int = _DEFAULT_LOWPASS_KERNEL,
+) -> dict[str, float | int]:
+    """Measure the final latent discontinuity at one protected/generated boundary."""
+    if video.ndim != 5:
+        raise ValueError("video-boundary diagnostics expect BxCxTxHxW")
+    prefix_t = int(prefix_t)
+    if prefix_t < 1 or prefix_t >= int(video.shape[2]):
+        raise ValueError("video-boundary diagnostics require a non-empty prefix shorter than the video")
+    lowpass_kernel = _effective_lowpass_kernel(video, requested_lowpass_kernel)
+    left = video[:, :, prefix_t - 1 : prefix_t]
+    right = video[:, :, prefix_t : prefix_t + 1]
+    with torch.no_grad():
+        values = _delta_metrics(right, left, lowpass_kernel=lowpass_kernel)
+    return {
+        "lowpass_kernel": lowpass_kernel,
+        "seam_rms": values["rms"],
+        "seam_lowpass_rms": values["lowpass_rms"],
+        "seam_spatial_mean_rms": values["spatial_mean_rms"],
+    }

--- a/h3_flow_regenerate/target_sparse.py
+++ b/h3_flow_regenerate/target_sparse.py
@@ -1,0 +1,407 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from .geometry import unpack_streams
+from .metrics import H3FlowMetrics
+
+TARGET_SPARSE_CONTRACT_KEY = "h3_flow_target_sparse_v1"
+TARGET_SPARSE_API_VERSION = 1
+VDN_EXTERNAL_SEQUENCE_KEY = "vdn_h3_external_sequence_v1"
+VDN_EXTERNAL_SEQUENCE_API_VERSION = 1
+VDN_EXTERNAL_SEQUENCE_MODE = "dense_gate_no_linear"
+
+
+@dataclass(frozen=True, slots=True)
+class TargetSparsePlan:
+    """Immutable early-stage token plan for exact-prefix target-grid sampling.
+
+    The sampler latent remains on the full target grid. Only the H3 transformer
+    token stream is reduced: all non-video rows and every exactly protected video
+    patch row are retained, while generated video rows are represented by a
+    regular target-grid anchor lattice. The final block lifts the anchor features
+    back to the full target video grid before H3's native final layer.
+    """
+
+    target_t: int
+    target_h: int
+    target_w: int
+    source_h: int
+    source_w: int
+    selected_video_rows: torch.Tensor
+    anchor_video_rows: torch.Tensor
+    protected_video_rows: torch.Tensor
+
+    @property
+    def target_patch_h(self) -> int:
+        return self.target_h // 2
+
+    @property
+    def target_patch_w(self) -> int:
+        return self.target_w // 2
+
+    @property
+    def source_patch_h(self) -> int:
+        return self.source_h // 2
+
+    @property
+    def source_patch_w(self) -> int:
+        return self.source_w // 2
+
+    @property
+    def target_video_rows(self) -> int:
+        return self.target_t * self.target_patch_h * self.target_patch_w
+
+    @property
+    def selected_video_row_count(self) -> int:
+        return int(self.selected_video_rows.numel())
+
+    @property
+    def anchor_video_row_count(self) -> int:
+        return int(self.anchor_video_rows.numel())
+
+    @property
+    def protected_video_row_count(self) -> int:
+        return int(self.protected_video_rows.numel())
+
+    @property
+    def video_row_fraction(self) -> float:
+        return self.selected_video_row_count / self.target_video_rows
+
+
+def _axis_anchor_indices(target_count: int, source_count: int) -> torch.Tensor:
+    if target_count < 1 or source_count < 1:
+        raise ValueError("target/source patch axes must be non-empty")
+    if source_count > target_count:
+        raise ValueError("target-sparse source patch axis cannot exceed target patch axis")
+    if source_count == target_count:
+        return torch.arange(target_count, dtype=torch.long)
+    if source_count == 1:
+        return torch.tensor([target_count // 2], dtype=torch.long)
+    values = torch.linspace(0, target_count - 1, source_count, dtype=torch.float64).round().to(torch.long)
+    if int(torch.unique(values).numel()) != source_count:
+        raise RuntimeError("target-sparse anchor mapping produced duplicate target positions")
+    return values
+
+
+def _anchor_video_rows(
+    *,
+    target_t: int,
+    target_patch_h: int,
+    target_patch_w: int,
+    source_patch_h: int,
+    source_patch_w: int,
+) -> torch.Tensor:
+    ys = _axis_anchor_indices(target_patch_h, source_patch_h)
+    xs = _axis_anchor_indices(target_patch_w, source_patch_w)
+    spatial = (ys[:, None] * target_patch_w + xs[None, :]).reshape(-1)
+    rows_per_frame = target_patch_h * target_patch_w
+    frames = torch.arange(target_t, dtype=torch.long)[:, None] * rows_per_frame
+    return (frames + spatial[None, :]).reshape(-1)
+
+
+def exact_protected_video_patch_rows(
+    denoise_mask: torch.Tensor,
+    shapes: list[tuple[int, ...]],
+) -> torch.Tensor:
+    """Mirror native H3's 2x2 max-mask row semantics for exact protection."""
+
+    if len(shapes) != 2:
+        raise ValueError("target-sparse protection requires packed video and audio shapes")
+    expected = (shapes[0][0], 1, sum(torch.tensor(shape[1:]).prod().item() for shape in shapes))
+    if tuple(denoise_mask.shape) != tuple(int(value) for value in expected):
+        raise ValueError("prepared H3 denoise mask does not match packed AV geometry")
+    video_mask, _audio_mask = unpack_streams(denoise_mask, shapes)
+    if video_mask.ndim != 5 or video_mask.shape[1] < 1:
+        raise ValueError("prepared H3 video denoise mask has invalid shape")
+    _batch, _channels, target_t, target_h, target_w = map(int, video_mask.shape)
+    if target_h % 2 or target_w % 2:
+        raise ValueError("target-sparse H3 video geometry must be patch-safe")
+
+    # Native MiniMax H3 consumes denoise_mask[0, 0] and takes a 2x2 spatial
+    # maximum for each packed video row. A row is therefore exactly protected
+    # only when every pixel in that 2x2 patch is exactly zero.
+    rows = video_mask[0, 0].to(device="cpu", dtype=torch.float32)
+    row_values = rows.reshape(target_t, target_h // 2, 2, target_w // 2, 2).amax(dim=(2, 4)).reshape(-1)
+    return torch.nonzero(row_values == 0, as_tuple=False).reshape(-1).to(torch.long)
+
+
+def build_target_sparse_plan(
+    denoise_mask: torch.Tensor,
+    shapes: list[tuple[int, ...]],
+    *,
+    source_h: int,
+    source_w: int,
+) -> TargetSparsePlan:
+    if len(shapes) != 2:
+        raise ValueError("target-sparse plan requires native packed H3 AV geometry")
+    target_shape = shapes[0]
+    if len(target_shape) != 5 or int(target_shape[1]) != 24:
+        raise ValueError("target-sparse plan requires Bx24xTxHxW video geometry")
+    target_t, target_h, target_w = map(int, target_shape[-3:])
+    source_h = int(source_h)
+    source_w = int(source_w)
+    if source_h < 2 or source_w < 2 or source_h % 2 or source_w % 2:
+        raise ValueError("target-sparse source latent H/W must be positive and even")
+    if source_h > target_h or source_w > target_w:
+        raise ValueError("target-sparse source latent H/W cannot exceed target geometry")
+    if source_h == target_h and source_w == target_w:
+        raise ValueError("target-sparse source must reduce at least one spatial axis")
+
+    anchor_rows = _anchor_video_rows(
+        target_t=target_t,
+        target_patch_h=target_h // 2,
+        target_patch_w=target_w // 2,
+        source_patch_h=source_h // 2,
+        source_patch_w=source_w // 2,
+    )
+    protected_rows = exact_protected_video_patch_rows(denoise_mask, shapes)
+    if protected_rows.numel() == 0:
+        raise ValueError("target-sparse exact-prefix mode requires at least one exactly protected video row")
+    selected_rows = torch.unique(torch.cat((anchor_rows, protected_rows)), sorted=True)
+    return TargetSparsePlan(
+        target_t=target_t,
+        target_h=target_h,
+        target_w=target_w,
+        source_h=source_h,
+        source_w=source_w,
+        selected_video_rows=selected_rows.contiguous(),
+        anchor_video_rows=anchor_rows.contiguous(),
+        protected_video_rows=protected_rows.contiguous(),
+    )
+
+
+def target_sparse_contract(plan: TargetSparsePlan) -> dict[str, Any]:
+    return {
+        "api": TARGET_SPARSE_API_VERSION,
+        "active": True,
+        "plan": plan,
+        "device_cache": {},
+    }
+
+
+def _video_segment(layout: Any) -> tuple[int, int]:
+    segments = getattr(layout, "segments", None)
+    if not isinstance(segments, (list, tuple)):
+        raise RuntimeError("target-sparse H3 path requires PackedLayout.segments")
+    video = [(int(a), int(b)) for a, b, kind in segments if str(kind) == "video"]
+    if len(video) != 1:
+        raise RuntimeError(f"target-sparse H3 path requires exactly one target video segment, got {len(video)}")
+    return video[0]
+
+
+def _device_indices(contract: dict[str, Any], plan: TargetSparsePlan, device: torch.device) -> dict[str, torch.Tensor]:
+    cache = contract.setdefault("device_cache", {})
+    key = str(device)
+    cached = cache.get(key)
+    if isinstance(cached, dict):
+        return cached
+    selected = plan.selected_video_rows.to(device=device)
+    anchors = plan.anchor_video_rows.to(device=device)
+    anchor_positions = torch.searchsorted(selected, anchors)
+    if not torch.equal(selected.index_select(0, anchor_positions), anchors):
+        raise RuntimeError("target-sparse anchor rows are not a subset of selected rows")
+    cached = {
+        "selected_video": selected,
+        "anchors_video": anchors,
+        "anchor_positions": anchor_positions,
+    }
+    cache[key] = cached
+    return cached
+
+
+def _reduce_mod_segments(
+    mod_segments: Any,
+    *,
+    video_start: int,
+    video_stop: int,
+    selected_video: torch.Tensor,
+) -> list[tuple[int, int, Any]]:
+    if not isinstance(mod_segments, (list, tuple)):
+        raise RuntimeError("target-sparse H3 path requires native mod_segments")
+    reduced: list[tuple[int, int, Any]] = []
+    selected_count = int(selected_video.numel())
+    found_video = False
+    for segment in mod_segments:
+        if not isinstance(segment, (list, tuple)) or len(segment) < 3:
+            raise RuntimeError("target-sparse H3 mod_segments contains an invalid segment")
+        start, stop, row = int(segment[0]), int(segment[1]), segment[2]
+        if stop <= video_start:
+            reduced.append((start, stop, row))
+            continue
+        if start == video_start and stop == video_stop:
+            found_video = True
+            if torch.is_tensor(row) and row.numel() != 1:
+                if row.ndim != 1 or int(row.numel()) != video_stop - video_start:
+                    raise RuntimeError("target-sparse H3 video modulation rows do not match the full video segment")
+                row = row.index_select(0, selected_video.to(device=row.device))
+            reduced.append((video_start, video_start + selected_count, row))
+            continue
+        raise RuntimeError(
+            "target-sparse H3 path encountered packed rows after or overlapping the target video segment"
+        )
+    if not found_video:
+        raise RuntimeError("target-sparse H3 path could not locate target video modulation metadata")
+    return reduced
+
+
+def _lift_video_hidden(
+    compact_video: torch.Tensor,
+    *,
+    plan: TargetSparsePlan,
+    selected_video: torch.Tensor,
+    anchor_positions: torch.Tensor,
+) -> torch.Tensor:
+    if compact_video.ndim != 2 or int(compact_video.shape[0]) != plan.selected_video_row_count:
+        raise RuntimeError("target-sparse compact video hidden shape does not match the selected-row plan")
+    anchors = compact_video.index_select(0, anchor_positions)
+    hidden = int(compact_video.shape[-1])
+    anchors = anchors.reshape(plan.target_t, plan.source_patch_h, plan.source_patch_w, hidden)
+    work = anchors.permute(0, 3, 1, 2).to(torch.float32)
+    align_corners = plan.source_patch_h > 1 or plan.source_patch_w > 1
+    lifted = F.interpolate(
+        work,
+        size=(plan.target_patch_h, plan.target_patch_w),
+        mode="bilinear",
+        align_corners=align_corners,
+    )
+    lifted = lifted.permute(0, 2, 3, 1).reshape(plan.target_video_rows, hidden).to(compact_video)
+    # Retained rows are authoritative transformer outputs. Interpolation is only
+    # a lifter for rows that were intentionally absent from the sparse stream.
+    lifted.index_copy_(0, selected_video, compact_video)
+    return lifted
+
+
+def make_target_sparse_block_wrapper(
+    layer: int,
+    num_layers: int,
+    metrics: H3FlowMetrics,
+    previous=None,
+):
+    """Reduce target-video tokens for an early stage and restore them at the last block."""
+
+    def call_next(args, extra):
+        if previous is not None:
+            return previous(args, extra)
+        return extra["original_block"](args)
+
+    def wrapper(args, extra):
+        transformer = args.get("transformer_options", {}) or {}
+        contract = transformer.get(TARGET_SPARSE_CONTRACT_KEY)
+        if not isinstance(contract, dict) or contract.get("active") is not True:
+            return call_next(args, extra)
+        if int(contract.get("api", -1)) != TARGET_SPARSE_API_VERSION:
+            raise RuntimeError("unsupported H3 target-sparse runtime contract")
+        plan = contract.get("plan")
+        if not isinstance(plan, TargetSparsePlan):
+            raise RuntimeError("H3 target-sparse runtime contract is missing its plan")
+        layout = args.get("layout")
+        video_start, video_stop = _video_segment(layout)
+        if video_stop - video_start != plan.target_video_rows:
+            raise RuntimeError(
+                "target-sparse plan/video layout mismatch: "
+                f"plan={plan.target_video_rows} layout={video_stop - video_start}"
+            )
+        img = args.get("img")
+        rope = args.get("rope_freqs")
+        if not torch.is_tensor(img) or img.ndim != 2:
+            raise RuntimeError("target-sparse H3 block wrapper requires a 2D packed hidden stream")
+        if not torch.is_tensor(rope) or rope.ndim < 2 or int(rope.shape[1]) != video_stop:
+            raise RuntimeError("target-sparse H3 block wrapper requires full target-grid RoPE rows")
+
+        indices = _device_indices(contract, plan, img.device)
+        selected_video = indices["selected_video"]
+        full_prefix = torch.arange(video_start, device=img.device, dtype=torch.long)
+        selected_global = torch.cat((full_prefix, video_start + selected_video))
+        reduced_len = video_start + plan.selected_video_row_count
+        if int(img.shape[0]) == video_stop:
+            reduced_img = img.index_select(0, selected_global)
+        elif int(img.shape[0]) == reduced_len:
+            reduced_img = img
+        else:
+            raise RuntimeError(
+                "target-sparse H3 hidden length "
+                f"{int(img.shape[0])} is neither full {video_stop} nor reduced {reduced_len}"
+            )
+
+        new_transformer = dict(transformer)
+        existing_vdn_contract = new_transformer.get(VDN_EXTERNAL_SEQUENCE_KEY)
+        if existing_vdn_contract is not None:
+            raise RuntimeError("target-sparse H3 path found an existing VDN external-sequence contract")
+        new_transformer[VDN_EXTERNAL_SEQUENCE_KEY] = {
+            "api": VDN_EXTERNAL_SEQUENCE_API_VERSION,
+            "mode": VDN_EXTERNAL_SEQUENCE_MODE,
+            "full_sequence_rows": video_stop,
+            "reduced_sequence_rows": reduced_len,
+        }
+
+        new_args = dict(args)
+        new_args["img"] = reduced_img
+        new_args["rope_freqs"] = rope.index_select(1, selected_global.to(device=rope.device))
+        new_args["mod_segments"] = _reduce_mod_segments(
+            args.get("mod_segments"),
+            video_start=video_start,
+            video_stop=video_stop,
+            selected_video=selected_video,
+        )
+        new_args["transformer_options"] = new_transformer
+        output = call_next(new_args, extra)
+        if not isinstance(output, dict) or "img" not in output or not torch.is_tensor(output["img"]):
+            raise RuntimeError("target-sparse wrapped H3 block must return {'img': tensor}")
+        result = output["img"]
+        if result.ndim != 2 or int(result.shape[0]) != reduced_len:
+            raise RuntimeError("target-sparse wrapped H3 block returned an unexpected hidden shape")
+
+        if layer == 0:
+            metrics.increment("target_sparse_actual_calls")
+            metrics.event(
+                "target_sparse_transformer",
+                layer=layer,
+                full_sequence_rows=video_stop,
+                reduced_sequence_rows=reduced_len,
+                full_video_rows=plan.target_video_rows,
+                selected_video_rows=plan.selected_video_row_count,
+                anchor_video_rows=plan.anchor_video_row_count,
+                protected_video_rows=plan.protected_video_row_count,
+                video_row_fraction=plan.video_row_fraction,
+                source_hw=(plan.source_h, plan.source_w),
+                target_hw=(plan.target_h, plan.target_w),
+                target_t=plan.target_t,
+                exact_protected_rows_retained=True,
+                target_grid_rope_retained=True,
+                vdn_external_sequence_mode=VDN_EXTERNAL_SEQUENCE_MODE,
+            )
+
+        if layer != num_layers - 1:
+            return output
+
+        compact_video = result[video_start:]
+        lifted_video = _lift_video_hidden(
+            compact_video,
+            plan=plan,
+            selected_video=selected_video,
+            anchor_positions=indices["anchor_positions"],
+        )
+        full = torch.cat((result[:video_start], lifted_video), dim=0)
+        if int(full.shape[0]) != video_stop:
+            raise RuntimeError("target-sparse lifter failed to restore the full packed H3 sequence")
+        metrics.event(
+            "target_sparse_lift",
+            layer=layer,
+            restored_sequence_rows=int(full.shape[0]),
+            restored_video_rows=plan.target_video_rows,
+            retained_rows_overwritten_exactly=plan.selected_video_row_count,
+            interpolation="bilinear_hidden",
+        )
+        restored = dict(output)
+        restored["img"] = full
+        return restored
+
+    wrapper._h3_flow_target_sparse_wrapper = True
+    wrapper._h3_flow_target_sparse_previous = previous
+    wrapper._h3_flow_target_sparse_metrics = metrics
+    return wrapper

--- a/h3_flow_regenerate/target_sparse_node.py
+++ b/h3_flow_regenerate/target_sparse_node.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+from .comfy_compat import patch_flow_model
+from .geometry import pixel_to_safe_latent
+from .guidance import GuidanceConfig
+from .handoff import ProgressiveTargetInputConfig
+from .metrics import H3FlowMetrics
+from .nodes import H3ProgressiveTargetInputHandoff
+
+
+class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
+    """Opt-in exact-prefix Continuum research path.
+
+    Chunk 1 retains the normal Progressive Target Input implementation. For a
+    Native Masked continuation chunk with exact video protection, the sampler
+    latent/mask stay on the target grid while only the early H3 hidden-token
+    stream is reduced and lifted back before the native final layer.
+    """
+
+    CATEGORY = "MiniMax H3/flow regenerate/experimental"
+    EXACT_PREFIX_MODE = "target_sparse_lifter"
+    DESCRIPTION = (
+        "Experimental Continuum continuation path. Exact Native Masked video prefixes stay on the "
+        "target grid; early H3 transformer work retains every protected video row plus a coarse "
+        "target-grid anchor lattice for generated rows, then restores the full hidden grid before "
+        "H3's native final layer. source_scale/source_width/source_height control anchor density on "
+        "exact-prefix chunks, not sampler latent geometry. The one-token suffix DC bridge is "
+        "Continuum-specific and enabled by default on canonical exact-prefix boundaries."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        import copy
+
+        inputs = copy.deepcopy(super().INPUT_TYPES())
+        inputs["required"]["suffix_dc_bridge"] = (
+            "BOOLEAN",
+            {
+                "default": True,
+                "tooltip": (
+                    "Continuum-only one-token per-channel DC seam correction. It calibrates from the first "
+                    "actual full-grid H3 predicted-clean boundary, preserves the authoritative prefix, and "
+                    "changes only the first generated suffix latent token."
+                ),
+            },
+        )
+        return inputs
+
+    def patch(
+        self,
+        model,
+        trajectory,
+        source_mode,
+        source_scale,
+        source_width,
+        source_height,
+        handoff_coordinate,
+        handoff_selection,
+        guidance_mode,
+        direction_weight,
+        acceleration_weight,
+        consistency_weight,
+        low_frequency_cutoff,
+        metrics=None,
+        temporal_weight=0.20,
+        handoff_transfer="bicubic",
+        learned_upscaler=None,
+        suffix_dc_bridge=True,
+    ):
+        if source_mode == "scale":
+            progressive = ProgressiveTargetInputConfig(
+                source_scale=source_scale,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+                transfer_mode=handoff_transfer,
+                exact_prefix_mode=self.EXACT_PREFIX_MODE,
+                suffix_dc_bridge=bool(suffix_dc_bridge),
+                learned_upscaler=learned_upscaler,
+            )
+        else:
+            source_h, source_w = pixel_to_safe_latent(source_height, source_width)
+            progressive = ProgressiveTargetInputConfig(
+                source_latent_h=source_h,
+                source_latent_w=source_w,
+                handoff_coordinate=handoff_coordinate,
+                handoff_selection=handoff_selection,
+                transfer_mode=handoff_transfer,
+                exact_prefix_mode=self.EXACT_PREFIX_MODE,
+                suffix_dc_bridge=bool(suffix_dc_bridge),
+                learned_upscaler=learned_upscaler,
+            )
+        guidance = GuidanceConfig(
+            mode=guidance_mode,
+            direction_weight=direction_weight,
+            acceleration_weight=acceleration_weight,
+            temporal_weight=temporal_weight,
+            consistency_weight=consistency_weight,
+            cutoff=low_frequency_cutoff,
+        )
+        metrics = metrics or H3FlowMetrics()
+        patched, _ = patch_flow_model(
+            model,
+            trajectory=trajectory,
+            guidance=guidance,
+            progressive=progressive,
+            capture_enabled=True,
+            capture_forecasts=False,
+            clear_guidance_conditioning_signature=True,
+            clear_guidance_run_id=True,
+            metrics=metrics,
+        )
+        return patched, metrics
+
+
+class H3ProgressiveMixedGridHandoff(H3ProgressiveTargetSparseHandoff):
+    EXACT_PREFIX_MODE = "mixed_grid_low_suffix"
+    DESCRIPTION = (
+        "Real low-resolution Continuum suffix generation with original target-grid protected-prefix "
+        "conditioning, learned 3D handoff, exact prefix restoration, and fresh target-grid refinement. "
+        "Requires an H3 latent-upscaler provider and VDN external-sequence API v2 when VDN is enabled. "
+        "The one-token suffix DC bridge is enabled by default because it removed the validated boundary "
+        "flash while preserving the authoritative prefix bit-exactly."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        import copy
+
+        inputs = copy.deepcopy(super().INPUT_TYPES())
+        # The inherited patch signature is retained for workflow compatibility.
+        for group in ("required", "optional"):
+            if "handoff_transfer" in inputs.get(group, {}):
+                inputs[group]["handoff_transfer"] = (["learned_3d"], {"default": "learned_3d"})
+        inputs["required"]["suffix_dc_bridge"] = (
+            "BOOLEAN",
+            {
+                "default": True,
+                "tooltip": (
+                    "One-token suffix-only per-channel DC bridge. Uses the discarded learned prefix as "
+                    "calibration while keeping the authoritative Continuum prefix bit-exact. Enabled by "
+                    "default after matched multi-boundary decoded-media validation removed the handoff flash."
+                ),
+            },
+        )
+        return inputs
+
+
+NODE_CLASS_MAPPINGS = {
+    "H3ProgressiveTargetSparseHandoff": H3ProgressiveTargetSparseHandoff,
+    "H3ProgressiveMixedGridHandoff": H3ProgressiveMixedGridHandoff,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "H3ProgressiveTargetSparseHandoff": "MiniMax H3 Progressive Target-Sparse Continuum [Experimental]",
+    "H3ProgressiveMixedGridHandoff": "MiniMax H3 Progressive Mixed-Grid Continuum",
+}

--- a/h3_flow_regenerate/tone_bridge.py
+++ b/h3_flow_regenerate/tone_bridge.py
@@ -1,0 +1,163 @@
+"""Experimental suffix-only DC bridge for mixed-grid exact-prefix handoffs."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Sequence
+
+import torch
+
+
+def _validate_video_pair(upscaled_clean_video: torch.Tensor, exact_prefix: torch.Tensor) -> int:
+    if not isinstance(upscaled_clean_video, torch.Tensor) or not isinstance(exact_prefix, torch.Tensor):
+        raise TypeError("suffix DC bridge expects torch.Tensor inputs")
+    if upscaled_clean_video.ndim != 5 or exact_prefix.ndim != 5:
+        raise ValueError("suffix DC bridge expects BxCxTxHxW tensors")
+    if not upscaled_clean_video.is_floating_point() or not exact_prefix.is_floating_point():
+        raise TypeError("suffix DC bridge expects floating-point tensors")
+    if upscaled_clean_video.shape[:2] != exact_prefix.shape[:2]:
+        raise ValueError("suffix DC bridge batch/channel geometry differs")
+    if upscaled_clean_video.shape[-2:] != exact_prefix.shape[-2:]:
+        raise ValueError("suffix DC bridge spatial geometry differs")
+    prefix_t = int(exact_prefix.shape[2])
+    if prefix_t < 1 or prefix_t >= int(upscaled_clean_video.shape[2]):
+        raise ValueError("suffix DC bridge requires a non-empty prefix shorter than the video")
+    if not bool(torch.isfinite(upscaled_clean_video).all().item()):
+        raise RuntimeError("suffix DC bridge learned clean video contains NaN or Inf values")
+    if not bool(torch.isfinite(exact_prefix).all().item()):
+        raise RuntimeError("suffix DC bridge exact prefix contains NaN or Inf values")
+    return prefix_t
+
+
+def disabled_suffix_dc_bridge_metrics(*, prefix_t: int) -> dict[str, float | int | bool]:
+    prefix_t = int(prefix_t)
+    if prefix_t < 1:
+        raise ValueError("suffix DC bridge prefix length must be positive")
+    return {
+        "suffix_dc_bridge_version": 1,
+        "suffix_dc_bridge_enabled": False,
+        "suffix_dc_bridge_prefix_t": prefix_t,
+        "suffix_dc_bridge_corrected_tokens": 0,
+        "suffix_dc_bridge_first_weight": 0.0,
+        "suffix_dc_bridge_last_weight": 0.0,
+        "suffix_dc_bridge_delta_rms": 0.0,
+        "suffix_dc_bridge_delta_abs_mean": 0.0,
+        "suffix_dc_bridge_delta_abs_max": 0.0,
+    }
+
+
+def apply_suffix_dc_bridge(
+    upscaled_clean_video: torch.Tensor,
+    exact_prefix: torch.Tensor,
+    *,
+    weights: Sequence[float] = (1.0,),
+) -> tuple[torch.Tensor, dict[str, float | int | bool]]:
+    """Translate the learned native boundary offset onto an authoritative prefix.
+
+    The authoritative prefix is never modified. For each selected suffix token,
+    only a per-batch/per-channel spatially constant offset is added. With weight
+    1.0 on suffix token 0, its channel-wise spatial-mean offset from the exact
+    prefix equals the learned upscaler's original native boundary offset.
+    """
+
+    prefix_t = _validate_video_pair(upscaled_clean_video, exact_prefix)
+    if not isinstance(weights, Sequence) or isinstance(weights, (str, bytes)) or not weights:
+        raise ValueError("suffix DC bridge weights must be a non-empty sequence")
+    normalized_weights = tuple(float(weight) for weight in weights)
+    if any(not math.isfinite(weight) or weight < 0.0 or weight > 1.0 for weight in normalized_weights):
+        raise ValueError("suffix DC bridge weights must be finite values inside [0, 1]")
+
+    suffix_t = int(upscaled_clean_video.shape[2]) - prefix_t
+    corrected_tokens = min(len(normalized_weights), suffix_t)
+    exact_last = exact_prefix[:, :, -1].to(device=upscaled_clean_video.device, dtype=torch.float32)
+    learned_last = upscaled_clean_video[:, :, prefix_t - 1].float()
+    delta = exact_last.mean(dim=(-2, -1), keepdim=True) - learned_last.mean(dim=(-2, -1), keepdim=True)
+    if not bool(torch.isfinite(delta).all().item()):
+        raise RuntimeError("suffix DC bridge produced a non-finite channel offset")
+
+    corrected = upscaled_clean_video.clone()
+    for offset in range(corrected_tokens):
+        weight = normalized_weights[offset]
+        if weight == 0.0:
+            continue
+        corrected[:, :, prefix_t + offset].add_((delta * weight).to(dtype=corrected.dtype))
+    if not bool(torch.isfinite(corrected).all().item()):
+        raise RuntimeError("suffix DC bridge produced NaN or Inf values")
+
+    summary = (
+        torch.stack(
+            (
+                delta.square().mean().sqrt(),
+                delta.abs().mean(),
+                delta.abs().max(),
+            )
+        )
+        .detach()
+        .to(device="cpu", dtype=torch.float64)
+    )
+    delta_rms, delta_abs_mean, delta_abs_max = map(float, summary.tolist())
+    return corrected, {
+        "suffix_dc_bridge_version": 1,
+        "suffix_dc_bridge_enabled": True,
+        "suffix_dc_bridge_prefix_t": prefix_t,
+        "suffix_dc_bridge_corrected_tokens": corrected_tokens,
+        "suffix_dc_bridge_first_weight": normalized_weights[0] if corrected_tokens else 0.0,
+        "suffix_dc_bridge_last_weight": normalized_weights[corrected_tokens - 1] if corrected_tokens else 0.0,
+        "suffix_dc_bridge_delta_rms": delta_rms,
+        "suffix_dc_bridge_delta_abs_mean": delta_abs_mean,
+        "suffix_dc_bridge_delta_abs_max": delta_abs_max,
+    }
+
+
+def map_clean_bridge_to_conditional_state(
+    state: torch.Tensor,
+    clean_before: torch.Tensor,
+    clean_after: torch.Tensor,
+    *,
+    sigma: float,
+    prefix_t: int,
+    corrected_tokens: int,
+) -> torch.Tensor:
+    """Map a clean-space suffix bridge onto an already re-noised state exactly.
+
+    ``conditional_renoise_target`` is affine:
+    ``x_sigma = (1-sigma) * x0 + sigma * noise``. Therefore adding
+    ``(1-sigma) * (x0_after - x0_before)`` to the same suffix rows is
+    algebraically identical to applying the clean bridge immediately before
+    conditional re-noising, while leaving the deterministic noise untouched.
+    """
+
+    if state.ndim != 5 or clean_before.ndim != 5 or clean_after.ndim != 5:
+        raise ValueError("conditional bridge mapping expects BxCxTxHxW tensors")
+    if state.shape != clean_before.shape or state.shape != clean_after.shape:
+        raise ValueError("conditional bridge mapping tensor geometry differs")
+    if not state.is_floating_point() or not clean_before.is_floating_point() or not clean_after.is_floating_point():
+        raise TypeError("conditional bridge mapping expects floating-point tensors")
+    sigma = float(sigma)
+    if not math.isfinite(sigma) or not 0.0 <= sigma < 1.0:
+        raise ValueError("conditional bridge mapping requires finite sigma in [0, 1)")
+    prefix_t = int(prefix_t)
+    corrected_tokens = int(corrected_tokens)
+    temporal = int(state.shape[2])
+    if prefix_t < 1 or prefix_t >= temporal:
+        raise ValueError("conditional bridge mapping requires a valid prefix boundary")
+    if corrected_tokens < 1 or prefix_t + corrected_tokens > temporal:
+        raise ValueError("conditional bridge mapping corrected-token range is invalid")
+    if not torch.equal(clean_before[:, :, :prefix_t], clean_after[:, :, :prefix_t]):
+        raise RuntimeError("suffix DC bridge attempted to alter the authoritative prefix")
+    if not torch.equal(
+        clean_before[:, :, prefix_t + corrected_tokens :], clean_after[:, :, prefix_t + corrected_tokens :]
+    ):
+        raise RuntimeError("suffix DC bridge attempted to alter later suffix tokens")
+
+    result = state.clone()
+    clean_delta = (
+        clean_after[:, :, prefix_t : prefix_t + corrected_tokens].float()
+        - clean_before[:, :, prefix_t : prefix_t + corrected_tokens].float()
+    )
+    result[:, :, prefix_t : prefix_t + corrected_tokens].add_(
+        ((1.0 - sigma) * clean_delta).to(device=result.device, dtype=result.dtype)
+    )
+    if not bool(torch.isfinite(result).all().item()):
+        raise RuntimeError("conditional bridge mapping produced NaN or Inf values")
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "comfyui-minimax-h3-flow-aligned-regenerate"
-version = "0.2.1"
+version = "0.3.0"
 description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_attention_reference_runtime.py
+++ b/tests/test_attention_reference_runtime.py
@@ -1869,6 +1869,7 @@ def test_target_input_exact_video_protection_forwards_one_untouched_target_sampl
             handoff_coordinate=0.3,
             transfer_mode="learned_3d",
             learned_upscaler=UnusedProvider(),
+            suffix_dc_bridge=False,
         ),
         target_noise,
         target_latent,

--- a/tests/test_continuum_suffix_bridge.py
+++ b/tests/test_continuum_suffix_bridge.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import torch
+
+from h3_flow_regenerate.geometry import pack_streams, unpack_streams
+from h3_flow_regenerate.runtime import (
+    EXACT_PREFIX_BRIDGE_KEY,
+    FLOW_BINDING_KEY,
+    SPECTRUM_ACTUAL_KEY,
+    FlowBinding,
+    _contiguous_exact_video_prefix,
+    flow_predict_wrapper,
+)
+
+
+class _IdentityBase:
+    def process_latent_in(self, value):
+        return value
+
+
+def _packed_mask(video_mask, audio_mask):
+    return torch.cat(
+        (
+            video_mask.reshape(video_mask.shape[0], 1, -1),
+            audio_mask.reshape(audio_mask.shape[0], 1, -1),
+        ),
+        dim=-1,
+    )
+
+
+def test_contiguous_exact_prefix_extraction_uses_model_domain_latent_and_whole_frames():
+    video = torch.arange(1 * 24 * 4 * 2 * 2, dtype=torch.float32).reshape(1, 24, 4, 2, 2)
+    audio = torch.zeros(1, 32, 2, 3)
+    latent, shapes = pack_streams((video, audio))
+    video_mask = torch.ones_like(video)
+    video_mask[:, :, :2] = 0
+    mask = _packed_mask(video_mask, torch.ones_like(audio))
+
+    prefix = _contiguous_exact_video_prefix(_IdentityBase(), latent, mask, shapes)
+
+    assert prefix is not None
+    assert torch.equal(prefix, video[:, :, :2])
+
+
+def test_contiguous_exact_prefix_extraction_skips_noncanonical_partial_mask():
+    video = torch.zeros(1, 24, 4, 2, 2)
+    audio = torch.zeros(1, 32, 2, 3)
+    latent, shapes = pack_streams((video, audio))
+    video_mask = torch.ones_like(video)
+    video_mask[:, :, :2] = 0
+    video_mask[:, :, 2, 0, 0] = 0
+    mask = _packed_mask(video_mask, torch.ones_like(audio))
+
+    assert _contiguous_exact_video_prefix(_IdentityBase(), latent, mask, shapes) is None
+
+
+class _PredictExecutor:
+    def __init__(self, guider, result):
+        self.class_obj = guider
+        self.result = result
+
+    def __call__(self, _x, _timestep, _model_options, _seed):
+        return self.result.clone()
+
+
+def _predict_bridge_fixture(*, actual=True):
+    video = torch.zeros(1, 24, 3, 2, 2)
+    video[:, :, 0] = 1.0
+    video[:, :, 1] = 3.0
+    video[:, :, 2] = 5.0
+    audio = torch.zeros(1, 32, 2, 3)
+    packed, shapes = pack_streams((video, audio))
+    exact_prefix = torch.full((1, 24, 1, 2, 2), 2.0)
+    contract = {"exact_prefix": exact_prefix, "source": "unit", "applied": False}
+    transformer = {
+        EXACT_PREFIX_BRIDGE_KEY: contract,
+        SPECTRUM_ACTUAL_KEY: bool(actual),
+    }
+    binding = FlowBinding()
+    guider = SimpleNamespace(
+        model_options={FLOW_BINDING_KEY: binding, "transformer_options": transformer},
+        inner_model=SimpleNamespace(latent_shapes=list(shapes)),
+    )
+    executor = _PredictExecutor(guider, packed)
+    return video, packed, shapes, contract, binding, guider, executor
+
+
+def test_predict_bridge_applies_once_to_first_suffix_token_and_records_provenance():
+    video, packed, shapes, contract, binding, guider, executor = _predict_bridge_fixture(actual=True)
+
+    first = flow_predict_wrapper(
+        executor,
+        packed,
+        torch.tensor([0.5]),
+        guider.model_options,
+        7,
+    )
+    first_video, _ = unpack_streams(first, shapes)
+    assert torch.equal(first_video[:, :, :1], video[:, :, :1])
+    assert torch.equal(first_video[:, :, 2:], video[:, :, 2:])
+    assert torch.equal(first_video[:, :, 1], video[:, :, 1] + 1.0)
+    assert contract["applied"] is True
+
+    bridge_events = [event for event in binding.metrics.events if event.kind == "exact_prefix_suffix_dc_bridge"]
+    assert len(bridge_events) == 1
+    assert bridge_events[0].fields["source"] == "unit"
+    assert bridge_events[0].fields["actual"] is True
+    assert bridge_events[0].fields["suffix_dc_bridge_corrected_tokens"] == 1
+    assert bridge_events[0].fields["suffix_dc_bridge_state_mapping"] == "first_actual_model_x0"
+
+    second = flow_predict_wrapper(
+        executor,
+        packed,
+        torch.tensor([0.4]),
+        guider.model_options,
+        7,
+    )
+    assert torch.equal(second, packed)
+    assert len([event for event in binding.metrics.events if event.kind == "exact_prefix_suffix_dc_bridge"]) == 1
+
+
+def test_predict_bridge_waits_for_first_actual_call_instead_of_calibrating_from_forecast():
+    _video, packed, shapes, contract, binding, guider, executor = _predict_bridge_fixture(actual=False)
+
+    forecast = flow_predict_wrapper(
+        executor,
+        packed,
+        torch.tensor([0.6]),
+        guider.model_options,
+        7,
+    )
+    assert torch.equal(forecast, packed)
+    assert contract["applied"] is False
+    assert not [event for event in binding.metrics.events if event.kind == "exact_prefix_suffix_dc_bridge"]
+
+    guider.model_options["transformer_options"][SPECTRUM_ACTUAL_KEY] = True
+    actual = flow_predict_wrapper(
+        executor,
+        packed,
+        torch.tensor([0.5]),
+        guider.model_options,
+        7,
+    )
+    actual_video, _ = unpack_streams(actual, shapes)
+    assert torch.equal(actual_video[:, :, 1], torch.full_like(actual_video[:, :, 1], 4.0))
+    assert contract["applied"] is True

--- a/tests/test_decode_context.py
+++ b/tests/test_decode_context.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import ast
+import copy
+import os
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.decode_context import H3ContinuumDecodeContext, prepare_decode_context
+
+
+def frames(t):
+    return (t - 2) // 5 * 17 + 5
+
+
+def sequence(prefix=12, count=4):
+    generator = torch.Generator().manual_seed(82)
+    timeline = torch.randn(1, 24, 22 + 15 * (count - 1), 2, 3, generator=generator)
+    videos = [timeline[:, :, :22].clone()]
+    groups = [{"total_frames": frames(22), "trim_frames": 0, "net_frames": frames(22), "expected_video_latent_t": 22}]
+    for index in range(1, count):
+        stop = 22 + 15 * index
+        video = timeline[:, :, stop - 15 - prefix : stop].clone()
+        videos.append(video)
+        groups.append(
+            {
+                "total_frames": frames(prefix + 15),
+                "trim_frames": frames(prefix),
+                "net_frames": 51,
+                "expected_video_latent_t": prefix + 15,
+            }
+        )
+    return (
+        timeline,
+        [{"samples": v} for v in videos],
+        {
+            "magic": "H3_CONTINUUM_ASSEMBLY_PLAN",
+            "schema_version": 1,
+            "fps": 24,
+            "chunks": groups,
+        },
+    )
+
+
+@pytest.mark.parametrize("prefix", [2, 7, 12])
+def test_exact_context_is_bounded_and_does_not_mutate_accepted_latents(prefix):
+    _, latents, plan = sequence(prefix)
+    before = [x["samples"].clone() for x in latents]
+    old_plan = copy.deepcopy(plan)
+    result, report = H3ContinuumDecodeContext().prepare(latents, [plan])
+    assert "3/3 exact boundaries" in report
+    for index in range(3):
+        assert result[index]["samples"].shape[2] == before[index].shape[2] + 5
+        assert torch.equal(result[index]["samples"][:, :, :-5], before[index])
+        assert torch.equal(result[index]["samples"][:, :, -5:], before[index + 1][:, :, prefix : prefix + 5])
+        assert result[index]["samples"].data_ptr() != latents[index]["samples"].data_ptr()
+    assert result[-1] is latents[-1]
+    assert plan == old_plan
+    assert all(torch.equal(x["samples"], v) for x, v in zip(latents, before, strict=True))
+
+
+def test_nonexact_or_guide_boundary_is_not_silently_replaced():
+    _, latents, plan = sequence()
+    latents[1]["samples"][:, :, 0] += 0.1
+    result, report = prepare_decode_context(latents, plan)
+    assert result[0] is latents[0]
+    assert "protected overlap is not exact" in report
+    assert "2/3 exact boundaries" in report
+
+
+def test_physical_decode_groups_take_precedence_over_logical_chunks():
+    _, latents, plan = sequence(count=2)
+    plan["decode_groups"] = plan["chunks"]
+    plan["chunks"] = [{}] * 3
+    result, report = prepare_decode_context(latents, plan)
+    assert len(result) == 2
+    assert "1/1 exact boundaries" in report
+
+
+def test_single_chunk_is_identity():
+    _, latents, plan = sequence(count=1)
+    result, report = prepare_decode_context(latents, plan)
+    assert result[0] is latents[0]
+    assert "0/0 exact boundaries" in report
+
+
+@pytest.mark.parametrize("corruption", ["count", "duration", "length", "schema"])
+def test_stale_plan_cannot_silently_shift_video(corruption):
+    _, latents, plan = sequence()
+    if corruption == "count":
+        latents.pop()
+    elif corruption == "duration":
+        plan["chunks"][1]["total_frames"] += 1
+    elif corruption == "length":
+        plan["chunks"][1]["expected_video_latent_t"] += 5
+    else:
+        plan["schema_version"] += 1
+    with pytest.raises(ValueError):
+        prepare_decode_context(latents, plan)
+
+
+def native_temporal_decoder():
+    """Execute pinned native temporal decode code with a context-sensitive pixel oracle.
+
+    The learned decoder is replaced; the window selection, padding, blending,
+    frame trimming and writes execute verbatim from ComfyUI. This proves temporal
+    equivalence, not perceptual quality of an actual checkpoint.
+    """
+    root = os.environ.get("COMFYUI_ROOT")
+    if not root:
+        pytest.skip("native VAE temporal oracle runs in source-contract CI with COMFYUI_ROOT")
+    source = Path(root, "comfy/ldm/minimax/vae.py").read_text()
+    tree = ast.parse(source)
+    cls = next(n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == "MiniMaxH3VideoVAE")
+    names = {
+        "blend",
+        "decode_output_shape",
+        "_decode_temporal_pad_frames",
+        "_decode_temporal_frame_plan",
+        "_decode_temporal_chunks",
+        "decode_temporal",
+    }
+    methods = [n for n in cls.body if isinstance(n, ast.FunctionDef) and n.name in names]
+    assert {n.name for n in methods} == names
+    extracted = ast.ClassDef(name="NativeTemporal", bases=[], keywords=[], body=methods, decorator_list=[])
+    namespace = {"torch": torch}
+    exec(
+        compile(ast.fix_missing_locations(ast.Module(body=[extracted], type_ignores=[])), "native_vae", "exec"),
+        namespace,
+    )
+    decoder = namespace["NativeTemporal"]()
+    decoder.tokens_chunk_size = 5
+    decoder.token_overlap = 2
+    decoder.token_drop = 3
+    decoder.vae_ratio_t = 4
+    decoder.frame_pre_padding = 3
+    decoder.frame_overlap = 5
+    decoder.clip_length = 17
+    decoder.vae_ratio = 1
+    decoder.decoder = SimpleNamespace(out_channels=3)
+    decoder._finalize_pixels = lambda x: x
+    # Each output depends on the entire seven-token window, like native ViT3D
+    # attention. This exposes discontinuities invisible to a framewise fake VAE.
+    decoder._adaptive_decode = lambda z: (z[:, :3] + z[:, :3].mean(dim=2, keepdim=True)).repeat_interleave(4, dim=2)
+
+    def decode(z):
+        return decoder.decode_temporal(z, output_buffer=torch.empty(decoder.decode_output_shape(z.shape)))
+
+    return decode
+
+
+@pytest.mark.parametrize("prefix", [2, 7, 12])
+def test_native_window_oracle_matches_continuous_decode_and_reproduces_old_seam(prefix):
+    decode = native_temporal_decoder()
+    timeline, latents, plan = sequence(prefix)
+    extended, _ = prepare_decode_context(latents, plan)
+
+    def assemble(inputs):
+        return torch.cat(
+            [
+                decode(x["samples"])[:, :, p["trim_frames"] : p["total_frames"]]
+                for x, p in zip(inputs, plan["chunks"], strict=True)
+            ],
+            dim=2,
+        )
+
+    expected = decode(timeline)
+    corrected = assemble(extended)
+    old = assemble(latents)
+    assert torch.equal(corrected, expected)
+    assert not torch.equal(old, expected)
+    # Failure is localized to the five-frame decode overlap before each join.
+    cursor = 0
+    bad_frames = torch.zeros(expected.shape[2], dtype=torch.bool)
+    for chunk in plan["chunks"][:-1]:
+        cursor += chunk["net_frames"]
+        bad_frames[cursor - 5 : cursor] = True
+    assert torch.equal(old[:, :, ~bad_frames], expected[:, :, ~bad_frames])

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -160,6 +160,40 @@ def test_learned_handoff_rejects_wrong_provider_geometry(output):
         )
 
 
+def test_suffix_dc_bridge_config_is_restricted_to_continuum_specific_modes_and_boolean():
+    provider = FakeLearnedProvider()
+    fallback = ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=4)
+    assert fallback.suffix_dc_bridge is False
+    with pytest.raises(ValueError, match="Continuum-specific"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            suffix_dc_bridge=True,
+        )
+    sparse = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=4,
+        exact_prefix_mode="target_sparse_lifter",
+        suffix_dc_bridge=True,
+    )
+    assert sparse.suffix_dc_bridge is True
+    mixed = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=4,
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        suffix_dc_bridge=True,
+    )
+    assert mixed.suffix_dc_bridge is True
+    with pytest.raises(TypeError, match="must be boolean"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            suffix_dc_bridge=1,
+        )
+
+
 def test_learned_target_input_config_requires_supported_provider_contract():
     with pytest.raises(ValueError, match="requires a connected"):
         ProgressiveTargetInputConfig(

--- a/tests/test_mixed_grid.py
+++ b/tests/test_mixed_grid.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import ast
+import math
+import os
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+import torch
+
+from h3_flow_regenerate.geometry import pack_streams
+from h3_flow_regenerate.mixed_grid import (
+    MixedGridPlan,
+    build_mixed_grid_plan,
+    carrier_layout,
+    mixed_mod_segments,
+    mixed_positions,
+)
+
+
+def inputs(t=7, prefix=2, h=8, w=12):
+    video = torch.arange(24 * t * h * w, dtype=torch.float32).reshape(1, 24, t, h, w)
+    audio = torch.randn(1, 32, 2, 11)
+    packed, shapes = pack_streams((video, audio))
+    mask = torch.ones_like(video)
+    mask[:, :, :prefix] = 0
+    return packed, shapes, pack_streams((mask, torch.ones_like(audio)))[0]
+
+
+def test_observed_row_count_and_prefix_snapshot():
+    packed, shapes, mask = inputs(t=62, prefix=12, h=48, w=64)
+    noise = torch.randn_like(packed)
+    plan = build_mixed_grid_plan(mask, shapes, packed, noise, source_h=34, source_w=44)
+    assert plan.prefix_rows == 9216
+    assert plan.mixed_rows == 27916
+    before = plan.prefix.clone()
+    before_noise = plan.prefix_noise.clone()
+    packed.zero_()
+    noise.zero_()
+    assert torch.equal(plan.prefix, before)
+    assert torch.equal(plan.prefix_noise, before_noise)
+
+
+@pytest.mark.parametrize("kind", ["partial", "discontiguous", "soft", "nan", "none", "all"])
+def test_reject_unsupported_masks(kind):
+    packed, shapes, mask = inputs()
+    noise = torch.randn_like(packed)
+    if kind == "partial":
+        mask[..., 0] = 1
+    elif kind == "discontiguous":
+        video = mask[..., : math.prod(shapes[0][1:])].reshape(shapes[0])
+        video[:, :, [1, 3]] = video[:, :, [3, 1]]
+    elif kind == "soft":
+        mask[..., 1000] = 0.5
+    elif kind == "nan":
+        mask[..., 0] = float("nan")
+    elif kind == "none":
+        mask.fill_(1)
+    else:
+        mask.zero_()
+    with pytest.raises(ValueError):
+        build_mixed_grid_plan(mask, shapes, packed, noise, source_h=4, source_w=6)
+
+
+def test_reject_invalid_sampler_noise():
+    packed, shapes, mask = inputs()
+    bad = torch.randn_like(packed)
+    bad[..., 0] = float("nan")
+    with pytest.raises(ValueError, match="sampler noise must be finite"):
+        build_mixed_grid_plan(mask, shapes, packed, bad, source_h=4, source_w=6)
+
+
+@pytest.fixture
+def native():
+    root = Path(os.environ.get("COMFYUI_ROOT", Path(__file__).resolve().parents[2] / "comfy"))
+    path = root / "comfy/ldm/minimax/model.py"
+    if not path.is_file():
+        if os.environ.get("COMFYUI_ROOT"):
+            raise FileNotFoundError(path)
+        pytest.skip("native source oracle runs in source-contract CI with COMFYUI_ROOT")
+    tree = ast.parse(path.read_text())
+    names = {
+        "PackedLayout",
+        "patchify_video",
+        "unpatchify_video",
+        "_frame_grid",
+        "_axis_from_sqrt_area",
+        "_video_t_spans",
+        "_video_t_grid",
+        "_video_grid",
+        "_audio_grid",
+        "_ref_t_span",
+    }
+    nodes = [n for n in tree.body if isinstance(n, (ast.FunctionDef, ast.ClassDef)) and n.name in names]
+    module = ModuleType("native_h3_oracle")
+    module.__dict__.update(torch=torch, math=math, FRAME_PER_TOKEN=(1, 4, 4, 4, 4), FRAME_RESCALE=5 / 3)
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(path), "exec"), module.__dict__)
+    return module
+
+
+@pytest.mark.parametrize("prefix_t", [1, 2, 4, 5, 6, 12])
+def test_native_spatial_temporal_and_nonvideo_contract(native, prefix_t):
+    plan = MixedGridPlan(torch.randn(1, 24, prefix_t, 8, 12), 15, 4, 6)
+    payload = {"refs": [{"kind": "image", "latent_h": 4, "latent_w": 8}]}
+    layout = carrier_layout(native, plan, 3, 11, payload)
+    target = native.PackedLayout(3, 15, 8, 12, 11, refs=payload["refs"])
+    low = native.PackedLayout(3, 15, 4, 6, 11, refs=payload["refs"])
+    va = layout.segments[-1][0]
+    positions = mixed_positions(native, plan, layout)
+    assert torch.equal(layout.position_ids[:va], target.position_ids[:va])
+    assert torch.equal(positions[va : va + plan.prefix_rows], target.position_ids[va : va + plan.prefix_rows])
+    assert torch.equal(positions[va + plan.prefix_rows :], low.position_ids[va + prefix_t * plan.source_rows :])
+    assert len(positions) == va + plan.mixed_rows
+    # Actual low-grid rows round-trip, independently of target prefix density.
+    suffix = torch.randn(1, 24, 15 - prefix_t, 4, 6)
+    prefix_rows = native.patchify_video(plan.prefix)
+    mixed = torch.cat((prefix_rows, native.patchify_video(suffix)))
+    assert torch.equal(native.unpatchify_video(mixed[plan.prefix_rows :], 15 - prefix_t, 2, 3), suffix)
+
+
+def test_per_row_timestep_expansion_preserves_suffix_and_nonvideo():
+    plan = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6)
+    row = torch.cat((torch.full((12,), 9), torch.full((30,), 3)))
+    result = mixed_mod_segments([(0, 5, 4), (5, 47, row)], plan, 5, 47)
+    assert result[0] == (0, 5, 4)
+    assert result[1][:2] == (5, 83)
+    assert torch.equal(result[1][2][:48], torch.full((48,), 9))
+    assert torch.equal(result[1][2][48:], row[12:])
+
+
+def test_keyframes_keep_target_geometry(native):
+    plan = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6)
+    payload = {"keyframes": [{"resolved_frame_index": 0, "latent": torch.randn(1, 24, 1, 8, 12)}]}
+    layout = carrier_layout(native, plan, 3, 11, payload)
+    assert next(b - a for a, b, kind in layout.segments if kind == "cond") == 24
+    assert layout.signature == (3, 7, 4, 6, 11)
+
+
+def test_mixed_node_requires_learned_transfer():
+    from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+    from h3_flow_regenerate.target_sparse_node import H3ProgressiveMixedGridHandoff
+
+    with pytest.raises(ValueError, match="requires learned_3d"):
+        ProgressiveTargetInputConfig(source_scale=0.7, exact_prefix_mode="mixed_grid_low_suffix")
+    inputs = H3ProgressiveMixedGridHandoff.INPUT_TYPES()
+    transfer = next(group["handoff_transfer"] for group in inputs.values() if "handoff_transfer" in group)
+    assert transfer[0] == ["learned_3d"]
+
+
+@pytest.mark.parametrize("fail_stage", [None, "low", "probe", "high"])
+def test_stage_lifetimes_learned_context_and_original_prefix(monkeypatch, fail_stage):
+    import sys
+    from types import SimpleNamespace
+
+    from test_handoff import FakeLearnedProvider
+
+    from h3_flow_regenerate.geometry import resize_spatial_5d, unpack_streams
+    from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+    from h3_flow_regenerate.mixed_grid import MIXED_GRID_KEY
+    from h3_flow_regenerate.runtime import FlowBinding, _run_progressive
+
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+    packed, shapes, mask = inputs()
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}}, model_patcher=SimpleNamespace(model=base), conds={"positive": []}
+    )
+    binding = FlowBinding()
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+    )
+    calls = []
+
+    def execute(noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+        stage = guider.model_options["transformer_options"]["h3_flow_stage"]
+        calls.append(stage)
+        contract = guider.model_options["transformer_options"].get(MIXED_GRID_KEY)
+        assert (contract is not None) == (stage != "high")
+        if stage == fail_stage:
+            raise RuntimeError("test stage failure")
+        if stage == "high":
+            assert torch.equal(call_mask, mask)
+            assert latent_shapes == shapes
+            binding.metrics.event("model_call", actual=True)
+            return packed.clone()
+        video_mask, _ = unpack_streams(call_mask, latent_shapes)
+        assert torch.count_nonzero(video_mask[:, :, :2]) == 0
+        if stage == "probe":
+            clean = latent.clone()
+            clean_video, _ = unpack_streams(clean, latent_shapes)
+            clean_video[:, :, :2] = -999  # Must be replaced by original context before learned transfer.
+            return clean
+        return latent / (1 - sigmas[-1])
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    args = (
+        execute,
+        guider,
+        binding,
+        config,
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        list(shapes),
+    )
+    if fail_stage:
+        with pytest.raises(RuntimeError, match="test stage failure"):
+            _run_progressive(*args)
+    else:
+        assert torch.equal(_run_progressive(*args), packed)
+        assert calls == ["low", "probe", "high"]
+        original_video, _ = unpack_streams(packed, shapes)
+        # Provider records its real input; authoritative context replaces the poisoned probe carrier.
+        context = resize_spatial_5d(original_video[:, :, :2], 4, 6, mode="bicubic")
+        assert torch.equal(provider.calls[0][0][:, :, :2], context)
+    assert MIXED_GRID_KEY not in guider.model_options["transformer_options"]
+
+
+def test_native_forward_uses_authoritative_prefix_and_real_suffix(monkeypatch, native):
+
+    from h3_flow_regenerate.metrics import H3FlowMetrics
+    from h3_flow_regenerate.mixed_grid import MIXED_GRID_KEY, mixed_diffusion_wrapper
+
+    root = Path(os.environ.get("COMFYUI_ROOT", Path(__file__).resolve().parents[2] / "comfy"))
+    monkeypatch.syspath_prepend(str(root))
+    # Load the real native forward path with CPU operations, not a copied model.
+    import comfy.cli_args
+
+    comfy.cli_args.args.cpu = True
+    import comfy.ldm.minimax.model as model_module
+    import comfy.ops
+
+    torch.manual_seed(71)
+    model = model_module.MiniMaxH3Model(
+        hidden_size=96,
+        num_layers=2,
+        token_refiner_num_layers=0,
+        num_attention_heads=1,
+        attention_head_dim=96,
+        ffn_hidden_size=96,
+        text_dim=96,
+        timestep_input_dim=8,
+        time_embed_hidden_size=16,
+        time_embed_dim=8,
+        rope_inv_freq_len=16,
+        dtype=torch.float32,
+        operations=comfy.ops.disable_weight_init,
+    )
+    with torch.no_grad():
+        for parameter in model.parameters():
+            parameter.normal_(0, 0.03)
+        model.rope.inv_freq.fill_(0.01)
+    seen = []
+
+    class MixingBlock(torch.nn.Module):
+        def forward(self, h, t_emb, segments, rope, transformer_options):
+            seen.append((h.clone(), segments, rope.shape[1]))
+            # Deliberate global dependence proves which prefix conditions the suffix.
+            return h + h.mean(0)
+
+    model.blocks = torch.nn.ModuleList([MixingBlock(), MixingBlock()])
+    prefix = torch.randn(1, 24, 2, 8, 12)
+    prefix_noise = torch.randn_like(prefix)
+    plan = MixedGridPlan(prefix, 7, 4, 6, prefix_noise)
+    x = [torch.randn(1, 24, 7, 4, 6), torch.randn(1, 32, 2, 11)]
+    mask = torch.ones(1, 1, 7, 4, 6)
+    mask[:, :, :2] = 0
+    context = torch.randn(1, 3, 96)
+    metrics = H3FlowMetrics()
+    from h3_flow_regenerate.attention import make_layout_block_wrapper
+
+    options = {
+        MIXED_GRID_KEY: {"plan": plan, "metrics": metrics},
+        "patches_replace": {"dit": {("double_block", 0): make_layout_block_wrapper(0, metrics)}},
+    }
+    observed = []
+
+    class Executor:
+        class_obj = model
+
+        def __call__(self, x, timestep, context, options, **kwargs):
+            # Simulate Spectrum's actual last-block observation outside Flow.
+            existing = options["patches_replace"]["dit"][("double_block", 1)]
+
+            def observe(args, extra):
+                output = existing(args, extra)
+                observed.append(output["img"].shape[0])
+                return output
+
+            options["patches_replace"]["dit"][("double_block", 1)] = observe
+            return model._forward(x, timestep, context, options, **kwargs)
+
+    with torch.no_grad():
+        first = mixed_diffusion_wrapper(Executor(), x, torch.tensor([700.0]), context, options, denoise_mask=mask)
+        altered = [x[0].clone(), x[1]]
+        altered[0][:, :, :2] += 1000
+        second = mixed_diffusion_wrapper(
+            Executor(), altered, torch.tensor([700.0]), context, options, denoise_mask=mask
+        )
+        changed_plan = MixedGridPlan(prefix + 1, 7, 4, 6, prefix_noise)
+        changed = {MIXED_GRID_KEY: {"plan": changed_plan, "metrics": metrics}}
+        third = mixed_diffusion_wrapper(Executor(), x, torch.tensor([700.0]), context, changed, denoise_mask=mask)
+        changed_noise_plan = MixedGridPlan(prefix, 7, 4, 6, prefix_noise + 1)
+        changed_noise = {MIXED_GRID_KEY: {"plan": changed_noise_plan, "metrics": metrics}}
+        fourth = mixed_diffusion_wrapper(
+            Executor(), x, torch.tensor([700.0]), context, changed_noise, denoise_mask=mask
+        )
+    assert torch.equal(first[0], second[0])
+    assert torch.equal(first[1], second[1])
+    assert not torch.equal(first[0][:, :, 2:], third[0][:, :, 2:])
+    assert not torch.equal(first[0][:, :, 2:], fourth[0][:, :, 2:])
+    assert torch.count_nonzero(first[0][:, :, :2]) == 0
+    assert first[0].shape == x[0].shape
+    assert all(count == 3 + 22 + 7 * 6 for count in observed)
+    assert all(rows == 3 + 22 + plan.mixed_rows for _, _, rows in seen)
+    native_prefix = (
+        model_module.VISUAL_COND_TIMESTEP * prefix + (1.0 - model_module.VISUAL_COND_TIMESTEP) * prefix_noise
+    )
+    expected = model.video_patch_proj(model_module.patchify_video(native_prefix))
+    assert torch.equal(seen[0][0][25 : 25 + plan.prefix_rows], expected)
+    expected_suffix = model.video_patch_proj(model_module.patchify_video(x[0][:, :, 2:]))
+    assert torch.equal(seen[0][0][25 + plan.prefix_rows :], expected_suffix)

--- a/tests/test_mixed_grid_seam_diagnostics.py
+++ b/tests/test_mixed_grid_seam_diagnostics.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import math
+import sys
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+from test_handoff import FakeLearnedProvider
+
+from h3_flow_regenerate.geometry import pack_streams
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.runtime import FlowBinding, _run_progressive
+from h3_flow_regenerate.seam_diagnostics import (
+    measure_exact_prefix_splice,
+    recover_conditional_clean_for_diagnostics,
+)
+
+
+def _packed_inputs(t=7, prefix=2, h=8, w=12):
+    video = torch.randn(1, 24, t, h, w)
+    audio = torch.randn(1, 32, 2, 11)
+    packed, shapes = pack_streams((video, audio))
+    mask_video = torch.ones_like(video)
+    mask_video[:, :, :prefix] = 0
+    mask = pack_streams((mask_video, torch.ones_like(audio)))[0]
+    return packed, shapes, mask
+
+
+def test_conditional_clean_recovery_is_exact_for_float32_contract():
+    torch.manual_seed(3)
+    clean = torch.randn(1, 24, 4, 8, 8)
+    noise = torch.randn_like(clean)
+    sigma = 0.8575096726417542
+    state = (1.0 - sigma) * clean + sigma * noise
+    recovered = recover_conditional_clean_for_diagnostics(state, noise, sigma=sigma)
+    assert torch.allclose(recovered, clean, rtol=1e-5, atol=1e-5)
+
+
+def test_splice_diagnostics_detect_exact_prefix_restore_amplification():
+    learned = torch.zeros(1, 24, 4, 8, 8)
+    learned[:, :, 1] = 1.0
+    learned[:, :, 2] = 2.0
+    learned[:, :, 3] = 3.0
+    exact = learned[:, :, :2].clone()
+    exact[:, :, 1] = 10.0
+
+    fields = measure_exact_prefix_splice(learned, exact)
+
+    assert fields["splice_diagnostic_version"] == 1
+    assert fields["splice_prefix_temporal_length"] == 2
+    assert fields["splice_lowpass_kernel"] == 5
+    assert fields["upscaler_native_seam_rms"] == pytest.approx(1.0)
+    assert fields["exact_restored_seam_rms"] == pytest.approx(8.0)
+    assert fields["seam_rms_amplification"] == pytest.approx(8.0)
+    assert fields["upscaler_native_seam_lowpass_rms"] == pytest.approx(1.0)
+    assert fields["exact_restored_seam_lowpass_rms"] == pytest.approx(8.0)
+    assert fields["seam_lowpass_amplification"] == pytest.approx(8.0)
+    assert fields["upscaler_native_seam_spatial_mean_rms"] == pytest.approx(1.0)
+    assert fields["exact_restored_seam_spatial_mean_rms"] == pytest.approx(8.0)
+    assert fields["seam_spatial_mean_amplification"] == pytest.approx(8.0)
+    assert fields["corrected_exact_seam_rms"] == pytest.approx(8.0)
+    assert fields["corrected_exact_seam_lowpass_rms"] == pytest.approx(8.0)
+    assert fields["corrected_exact_seam_spatial_mean_rms"] == pytest.approx(8.0)
+    assert fields["corrected_over_uncorrected_exact_seam_rms_ratio"] == pytest.approx(1.0)
+    assert fields["prefix_restore_rms_tail_1"] == pytest.approx(9.0)
+    assert fields["prefix_restore_rms_tail_2"] == pytest.approx(9.0 / math.sqrt(2.0))
+
+
+def test_mixed_runtime_emits_transfer_and_final_seam_diagnostics(monkeypatch):
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+
+    packed, shapes, mask = _packed_inputs()
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=base),
+        conds={"positive": []},
+    )
+    binding = FlowBinding()
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        suffix_dc_bridge=True,
+    )
+
+    def execute(noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+        stage = guider.model_options["transformer_options"]["h3_flow_stage"]
+        if stage == "high":
+            assert latent_shapes == shapes
+            assert torch.equal(call_mask, mask)
+            binding.metrics.event("model_call", actual=True)
+            return packed.clone()
+        if stage == "probe":
+            return latent.clone()
+        return latent / (1.0 - sigmas[-1])
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    result = _run_progressive(
+        execute,
+        guider,
+        binding,
+        config,
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        list(shapes),
+    )
+    assert torch.equal(result, packed)
+
+    transfer = next(event for event in binding.metrics.events if event.kind == "mixed_grid_transfer")
+    required_transfer = {
+        "splice_diagnostic_version",
+        "splice_diagnostic_elapsed_ms",
+        "upscaler_native_seam_rms",
+        "exact_restored_seam_rms",
+        "seam_rms_amplification",
+        "upscaler_native_seam_lowpass_rms",
+        "exact_restored_seam_lowpass_rms",
+        "seam_lowpass_amplification",
+        "upscaler_native_seam_spatial_mean_rms",
+        "exact_restored_seam_spatial_mean_rms",
+        "seam_spatial_mean_amplification",
+        "corrected_exact_seam_rms",
+        "corrected_exact_seam_lowpass_rms",
+        "corrected_exact_seam_spatial_mean_rms",
+        "corrected_over_uncorrected_exact_seam_rms_ratio",
+        "suffix_dc_bridge_enabled",
+        "suffix_dc_bridge_corrected_tokens",
+        "prefix_restore_rms_tail_1",
+        "prefix_restore_rms_tail_2",
+    }
+    assert required_transfer <= transfer.fields.keys()
+    assert transfer.fields["suffix_dc_bridge_enabled"] is True
+    assert transfer.fields["suffix_dc_bridge_corrected_tokens"] == 1
+    numeric_transfer = required_transfer - {"splice_diagnostic_version", "suffix_dc_bridge_enabled"}
+    assert all(math.isfinite(float(transfer.fields[key])) for key in numeric_transfer)
+
+    complete = next(event for event in binding.metrics.events if event.kind == "mixed_grid_complete")
+    required_final = {
+        "final_seam_rms",
+        "final_seam_lowpass_rms",
+        "final_seam_spatial_mean_rms",
+        "final_over_transfer_exact_seam_rms_ratio",
+        "final_over_transfer_exact_seam_lowpass_ratio",
+        "final_over_transfer_exact_seam_spatial_mean_ratio",
+        "final_over_transfer_corrected_seam_rms_ratio",
+        "final_over_transfer_corrected_seam_lowpass_ratio",
+        "final_over_transfer_corrected_seam_spatial_mean_ratio",
+    }
+    assert required_final <= complete.fields.keys()
+    assert all(math.isfinite(float(complete.fields[key])) for key in required_final)
+
+
+def test_mixed_runtime_suffix_dc_bridge_reports_native_dc_boundary(monkeypatch):
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+
+    packed, shapes, mask = _packed_inputs()
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=base),
+        conds={"positive": []},
+    )
+    binding = FlowBinding()
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=FakeLearnedProvider(),
+        suffix_dc_bridge=True,
+    )
+
+    def execute(noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+        stage = guider.model_options["transformer_options"]["h3_flow_stage"]
+        if stage == "high":
+            binding.metrics.event("model_call", actual=True)
+            return packed.clone()
+        if stage == "probe":
+            return latent.clone()
+        return latent / (1.0 - sigmas[-1])
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    _run_progressive(
+        execute,
+        guider,
+        binding,
+        config,
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        list(shapes),
+    )
+
+    transfer = next(event for event in binding.metrics.events if event.kind == "mixed_grid_transfer")
+    assert transfer.fields["suffix_dc_bridge_enabled"] is True
+    assert transfer.fields["suffix_dc_bridge_corrected_tokens"] == 1
+    assert transfer.fields["suffix_dc_bridge_first_weight"] == pytest.approx(1.0)
+    assert transfer.fields["corrected_exact_seam_spatial_mean_rms"] == pytest.approx(
+        transfer.fields["upscaler_native_seam_spatial_mean_rms"], abs=2e-5
+    )
+    assert transfer.fields["suffix_dc_bridge_state_mapping"] == "affine_equivalent_pre_renoise"

--- a/tests/test_mixed_grid_tone_bridge.py
+++ b/tests/test_mixed_grid_tone_bridge.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from h3_flow_regenerate.tone_bridge import (
+    apply_suffix_dc_bridge,
+    disabled_suffix_dc_bridge_metrics,
+    map_clean_bridge_to_conditional_state,
+)
+
+
+def _fixture(dtype=torch.float32):
+    learned = torch.zeros(1, 3, 5, 2, 2, dtype=dtype)
+    learned[:, 0, 1] = torch.tensor([[1.0, 2.0], [3.0, 4.0]], dtype=dtype)
+    learned[:, 1, 1] = 10.0
+    learned[:, 2, 1] = -4.0
+    learned[:, 0, 2] = torch.tensor([[5.0, 6.0], [7.0, 8.0]], dtype=dtype)
+    learned[:, 1, 2] = 12.0
+    learned[:, 2, 2] = 1.0
+    learned[:, :, 3] = 20.0
+    learned[:, :, 4] = 30.0
+    exact = learned[:, :, :2].clone()
+    exact[:, 0, 1] += 3.0
+    exact[:, 1, 1] -= 2.0
+    exact[:, 2, 1] += 5.0
+    return learned, exact
+
+
+def test_weight_one_restores_native_per_channel_dc_boundary_exactly():
+    learned, exact = _fixture()
+    corrected, metrics = apply_suffix_dc_bridge(learned, exact)
+    learned_native = learned[:, :, 2].float().mean((-2, -1)) - learned[:, :, 1].float().mean((-2, -1))
+    corrected_exact = corrected[:, :, 2].float().mean((-2, -1)) - exact[:, :, 1].float().mean((-2, -1))
+    assert torch.allclose(corrected_exact, learned_native, rtol=0.0, atol=1e-6)
+    assert metrics["suffix_dc_bridge_corrected_tokens"] == 1
+    assert metrics["suffix_dc_bridge_first_weight"] == 1.0
+
+
+def test_bridge_is_per_channel_not_one_global_scalar():
+    learned, exact = _fixture()
+    corrected, _ = apply_suffix_dc_bridge(learned, exact)
+    shifts = (corrected[:, :, 2] - learned[:, :, 2]).float().mean((-2, -1))
+    assert shifts.shape == (1, 3)
+    assert torch.allclose(shifts, torch.tensor([[3.0, -2.0, 5.0]]))
+
+
+def test_bridge_preserves_spatial_detail_residual_and_later_suffix_tokens():
+    learned, exact = _fixture()
+    original = learned.clone()
+    corrected, _ = apply_suffix_dc_bridge(learned, exact)
+    before = learned[:, :, 2].float()
+    after = corrected[:, :, 2].float()
+    before_residual = before - before.mean((-2, -1), keepdim=True)
+    after_residual = after - after.mean((-2, -1), keepdim=True)
+    assert torch.allclose(after_residual, before_residual, rtol=0.0, atol=1e-6)
+    assert torch.equal(corrected[:, :, :2], original[:, :, :2])
+    assert torch.equal(corrected[:, :, 3:], original[:, :, 3:])
+    assert torch.equal(learned, original)
+
+
+def test_single_suffix_token_is_supported():
+    learned, exact = _fixture()
+    learned = learned[:, :, :3].clone()
+    exact = exact.clone()
+    corrected, metrics = apply_suffix_dc_bridge(learned, exact, weights=(1.0, 0.5))
+    assert corrected.shape == learned.shape
+    assert metrics["suffix_dc_bridge_corrected_tokens"] == 1
+    assert metrics["suffix_dc_bridge_last_weight"] == 1.0
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_bridge_preserves_dtype_and_device(dtype):
+    learned, exact = _fixture(dtype=dtype)
+    corrected, _ = apply_suffix_dc_bridge(learned, exact)
+    assert corrected.dtype == dtype
+    assert corrected.device == learned.device
+
+
+def test_conditional_state_mapping_matches_pre_renoise_bridge():
+    learned, exact = _fixture()
+    corrected, metrics = apply_suffix_dc_bridge(learned, exact)
+    sigma = 0.73
+    torch.manual_seed(8)
+    noise = torch.randn_like(learned)
+    state = (1.0 - sigma) * learned + sigma * noise
+    mapped = map_clean_bridge_to_conditional_state(
+        state,
+        learned,
+        corrected,
+        sigma=sigma,
+        prefix_t=2,
+        corrected_tokens=int(metrics["suffix_dc_bridge_corrected_tokens"]),
+    )
+    direct = (1.0 - sigma) * corrected + sigma * noise
+    assert torch.allclose(mapped, direct, rtol=1e-6, atol=1e-6)
+    assert torch.equal(mapped[:, :, :2], state[:, :, :2])
+    assert torch.equal(mapped[:, :, 3:], state[:, :, 3:])
+
+
+def test_disabled_metrics_are_explicit_and_zero_cost_semantics():
+    metrics = disabled_suffix_dc_bridge_metrics(prefix_t=12)
+    assert metrics["suffix_dc_bridge_enabled"] is False
+    assert metrics["suffix_dc_bridge_corrected_tokens"] == 0
+    assert metrics["suffix_dc_bridge_delta_rms"] == 0.0
+
+
+def test_bridge_rejects_nonfinite_and_malformed_geometry():
+    learned, exact = _fixture()
+    bad = learned.clone()
+    bad[:, :, 2, 0, 0] = float("nan")
+    with pytest.raises(RuntimeError, match="NaN or Inf"):
+        apply_suffix_dc_bridge(bad, exact)
+    with pytest.raises(ValueError, match="spatial geometry"):
+        apply_suffix_dc_bridge(learned, exact[..., :1, :])
+    with pytest.raises(ValueError, match="prefix shorter"):
+        apply_suffix_dc_bridge(learned, learned.clone())
+
+
+def test_bridge_rejects_invalid_weights_and_state_mapping_ranges():
+    learned, exact = _fixture()
+    with pytest.raises(ValueError, match="weights"):
+        apply_suffix_dc_bridge(learned, exact, weights=())
+    with pytest.raises(ValueError, match="weights"):
+        apply_suffix_dc_bridge(learned, exact, weights=(1.1,))
+    corrected, _ = apply_suffix_dc_bridge(learned, exact)
+    with pytest.raises(ValueError, match="corrected-token range"):
+        map_clean_bridge_to_conditional_state(
+            learned,
+            learned,
+            corrected,
+            sigma=0.5,
+            prefix_t=2,
+            corrected_tokens=99,
+        )

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -26,6 +26,17 @@ def test_project_declares_apache_license_and_tracks_license_file():
     assert "Copyright 2026 xmarre." in readme
 
 
+def test_comfy_registry_archive_excludes_development_only_paths():
+    root = Path(__file__).parents[1]
+    comfyignore = (root / ".comfyignore").read_text(encoding="utf-8").splitlines()
+
+    assert comfyignore == [
+        "# Development-only files must not be shipped in Comfy Registry archives.",
+        ".github/",
+        "tests/",
+    ]
+
+
 def test_custom_node_root_registration_smoke():
     root = Path(__file__).parents[1] / "__init__.py"
     spec = importlib.util.spec_from_file_location(
@@ -37,14 +48,17 @@ def test_custom_node_root_registration_smoke():
     assert spec.loader is not None
     spec.loader.exec_module(module)
     assert "H3ProgressiveHandoff" in module.NODE_CLASS_MAPPINGS
+    assert "H3ProgressiveTargetSparseHandoff" in module.NODE_CLASS_MAPPINGS
+    assert "H3ContinuumDecodeContext" in module.NODE_CLASS_MAPPINGS
     assert "H3RefineTargetGeometry" in module.NODE_CLASS_MAPPINGS
     assert "H3RuntimeMetricsProbe" in module.NODE_CLASS_MAPPINGS
 
 
 def test_progressive_nodes_expose_all_selectable_guidance_controls():
     from h3_flow_regenerate.nodes import H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff
+    from h3_flow_regenerate.target_sparse_node import H3ProgressiveTargetSparseHandoff
 
-    for node in (H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff):
+    for node in (H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff, H3ProgressiveTargetSparseHandoff):
         required = node.INPUT_TYPES()["required"]
         assert {
             "guidance_mode",
@@ -60,12 +74,31 @@ def test_progressive_nodes_expose_all_selectable_guidance_controls():
 
 def test_target_input_progressive_exposes_optional_learned_handoff_without_changing_default():
     from h3_flow_regenerate.nodes import H3ProgressiveHandoff, H3ProgressiveTargetInputHandoff
+    from h3_flow_regenerate.target_sparse_node import H3ProgressiveTargetSparseHandoff
+
+    for node in (H3ProgressiveTargetInputHandoff, H3ProgressiveTargetSparseHandoff):
+        target_schema = node.INPUT_TYPES()
+        assert target_schema["required"]["handoff_transfer"][0] == ["bicubic", "learned_3d"]
+        assert target_schema["required"]["handoff_transfer"][1]["default"] == "bicubic"
+        assert target_schema["optional"]["learned_upscaler"] == ("H3_LATENT_UPSCALER",)
+    assert "handoff_transfer" not in H3ProgressiveHandoff.INPUT_TYPES()["required"]
+
+
+def test_target_sparse_node_is_explicitly_experimental_and_only_adds_continuum_bridge_schema():
+    from h3_flow_regenerate.nodes import H3ProgressiveTargetInputHandoff
+    from h3_flow_regenerate.target_sparse_node import H3ProgressiveTargetSparseHandoff
 
     target_schema = H3ProgressiveTargetInputHandoff.INPUT_TYPES()
-    assert target_schema["required"]["handoff_transfer"][0] == ["bicubic", "learned_3d"]
-    assert target_schema["required"]["handoff_transfer"][1]["default"] == "bicubic"
-    assert target_schema["optional"]["learned_upscaler"] == ("H3_LATENT_UPSCALER",)
-    assert "handoff_transfer" not in H3ProgressiveHandoff.INPUT_TYPES()["required"]
+    sparse_schema = H3ProgressiveTargetSparseHandoff.INPUT_TYPES()
+    assert "suffix_dc_bridge" not in target_schema["required"]
+    sparse_required = sparse_schema["required"].copy()
+    bridge = sparse_required.pop("suffix_dc_bridge")
+    assert bridge[0] == "BOOLEAN"
+    assert bridge[1]["default"] is True
+    assert sparse_required == target_schema["required"]
+    assert sparse_schema["optional"] == target_schema["optional"]
+    assert H3ProgressiveTargetSparseHandoff.CATEGORY.endswith("/experimental")
+    assert "Exact Native Masked video prefixes stay on the target grid" in H3ProgressiveTargetSparseHandoff.DESCRIPTION
 
 
 def test_metrics_json_output_node_saves_unique_json_and_refreshes_after_sampler(monkeypatch, tmp_path):

--- a/tests/test_target_sparse.py
+++ b/tests/test_target_sparse.py
@@ -1,0 +1,363 @@
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.contracts import H3FlowTrajectory
+from h3_flow_regenerate.geometry import pack_streams
+from h3_flow_regenerate.guidance import GuidanceConfig
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.metrics import H3FlowMetrics
+from h3_flow_regenerate.runtime import FlowBinding, _run_progressive
+from h3_flow_regenerate.target_sparse import (
+    TARGET_SPARSE_CONTRACT_KEY,
+    TargetSparsePlan,
+    _lift_video_hidden,
+    build_target_sparse_plan,
+    exact_protected_video_patch_rows,
+    make_target_sparse_block_wrapper,
+    target_sparse_contract,
+)
+
+
+def _masked_target(*, target_t=2, target_h=4, target_w=4):
+    video = torch.randn(1, 24, target_t, target_h, target_w)
+    audio = torch.randn(1, 32, 2, 5)
+    latent, shapes = pack_streams((video, audio))
+    video_mask = torch.ones_like(video)
+    video_mask[:, :, 0] = 0
+    audio_mask = torch.ones_like(audio)
+    denoise_mask, mask_shapes = pack_streams((video_mask, audio_mask))
+    assert mask_shapes == shapes
+    return latent, shapes, denoise_mask
+
+
+def _layout_for(shapes):
+    target_t, target_h, target_w = shapes[0][-3:]
+    video_rows = target_t * (target_h // 2) * (target_w // 2)
+    video_start = 4
+    return SimpleNamespace(
+        segments=[(0, 2, "text"), (2, 4, "audio"), (video_start, video_start + video_rows, "video")],
+        signature=(2, target_t, target_h, target_w, 1),
+        seq_len=video_start + video_rows,
+    )
+
+
+def test_exact_protected_rows_match_native_2x2_max_semantics():
+    video = torch.ones(1, 24, 1, 4, 4)
+    audio = torch.ones(1, 32, 2, 2)
+    video[:, :, :, :2, :2] = 0
+    # One non-zero value in the neighbouring patch means that row is generated.
+    video[:, :, :, :2, 2:] = 0
+    video[:, :, :, 0, 2] = 0.25
+    packed, shapes = pack_streams((video, audio))
+
+    rows = exact_protected_video_patch_rows(packed, shapes)
+
+    assert rows.tolist() == [0]
+
+
+def test_target_sparse_plan_retains_every_protected_row_plus_coarse_anchors():
+    _latent, shapes, denoise_mask = _masked_target(target_t=2, target_h=8, target_w=8)
+    plan = build_target_sparse_plan(denoise_mask, shapes, source_h=4, source_w=4)
+
+    assert plan.target_video_rows == 32
+    assert plan.protected_video_rows.tolist() == list(range(16))
+    assert plan.anchor_video_row_count == 8
+    assert set(plan.protected_video_rows.tolist()).issubset(set(plan.selected_video_rows.tolist()))
+    assert set(plan.anchor_video_rows.tolist()).issubset(set(plan.selected_video_rows.tolist()))
+    assert plan.selected_video_row_count < plan.target_video_rows
+
+
+@pytest.mark.parametrize(
+    ("target_h", "target_w", "source_h", "source_w"),
+    [(2, 8, 2, 4), (8, 2, 4, 2)],
+)
+def test_target_sparse_lifter_endpoint_aligns_non_singleton_axis(target_h, target_w, source_h, source_w):
+    selected = torch.tensor([0, 3], dtype=torch.long)
+    plan = TargetSparsePlan(
+        target_t=1,
+        target_h=target_h,
+        target_w=target_w,
+        source_h=source_h,
+        source_w=source_w,
+        selected_video_rows=selected,
+        anchor_video_rows=selected,
+        protected_video_rows=torch.empty(0, dtype=torch.long),
+    )
+    compact = torch.tensor([[0.0], [1.0]])
+
+    lifted = _lift_video_hidden(
+        compact,
+        plan=plan,
+        selected_video=selected,
+        anchor_positions=torch.tensor([0, 1], dtype=torch.long),
+    )
+
+    assert torch.allclose(lifted[:, 0], torch.tensor([0.0, 1.0 / 3.0, 2.0 / 3.0, 1.0]))
+
+
+def test_target_sparse_block_contract_reduces_then_restores_dict_output():
+    _latent, shapes, denoise_mask = _masked_target(target_t=2, target_h=4, target_w=4)
+    plan = build_target_sparse_plan(denoise_mask, shapes, source_h=2, source_w=2)
+    contract = target_sparse_contract(plan)
+    layout = _layout_for(shapes)
+    full_len = layout.seq_len
+    hidden = 3
+    full_img = torch.arange(full_len * hidden, dtype=torch.float32).reshape(full_len, hidden)
+    rope = torch.arange(full_len, dtype=torch.float32).reshape(1, full_len, 1, 1, 1, 1)
+    video_start = layout.segments[-1][0]
+    video_mod = torch.arange(plan.target_video_rows, dtype=torch.long) + 10
+    mod_segments = [(0, 2, 1), (2, 4, 2), (video_start, full_len, video_mod)]
+    transformer_options = {TARGET_SPARSE_CONTRACT_KEY: contract}
+    metrics = H3FlowMetrics()
+    seen = []
+
+    def first_previous(args, _extra):
+        seen.append(args)
+        return {"img": args["img"] + 1.0, "sentinel": "keep"}
+
+    first = make_target_sparse_block_wrapper(0, 2, metrics, previous=first_previous)
+    first_out = first(
+        {
+            "img": full_img,
+            "t_emb": torch.zeros(1),
+            "mod_segments": mod_segments,
+            "rope_freqs": rope,
+            "layout": layout,
+            "transformer_options": transformer_options,
+        },
+        {"original_block": None},
+    )
+
+    reduced_len = video_start + plan.selected_video_row_count
+    assert first_out["sentinel"] == "keep"
+    assert first_out["img"].shape == (reduced_len, hidden)
+    assert seen[0]["rope_freqs"].shape[1] == reduced_len
+    reduced_video_mod = seen[0]["mod_segments"][-1][2]
+    assert torch.equal(reduced_video_mod, video_mod.index_select(0, plan.selected_video_rows))
+
+    def last_previous(args, _extra):
+        return {"img": args["img"] * 2.0, "sentinel": "still-keep"}
+
+    last = make_target_sparse_block_wrapper(1, 2, metrics, previous=last_previous)
+    last_out = last(
+        {
+            "img": first_out["img"],
+            "t_emb": torch.zeros(1),
+            "mod_segments": mod_segments,
+            "rope_freqs": rope,
+            "layout": layout,
+            "transformer_options": transformer_options,
+        },
+        {"original_block": None},
+    )
+
+    assert last_out["sentinel"] == "still-keep"
+    assert last_out["img"].shape == (full_len, hidden)
+    compact_after_last = first_out["img"][video_start:] * 2.0
+    restored_selected = last_out["img"][video_start:].index_select(0, plan.selected_video_rows)
+    assert torch.equal(restored_selected, compact_after_last)
+    assert metrics.counters["target_sparse_actual_calls"] == 1
+    assert any(event.kind == "target_sparse_lift" for event in metrics.events)
+
+
+def test_target_sparse_wrapper_requires_native_block_replacement_dict_contract():
+    _latent, shapes, denoise_mask = _masked_target()
+    plan = build_target_sparse_plan(denoise_mask, shapes, source_h=2, source_w=2)
+    layout = _layout_for(shapes)
+    wrapper = make_target_sparse_block_wrapper(
+        0,
+        1,
+        H3FlowMetrics(),
+        previous=lambda args, _extra: args["img"],
+    )
+    full_len = layout.seq_len
+
+    with pytest.raises(RuntimeError, match=r"must return .*img.*tensor"):
+        wrapper(
+            {
+                "img": torch.zeros(full_len, 2),
+                "mod_segments": [(0, 2, 1), (2, 4, 2), (4, full_len, 0)],
+                "rope_freqs": torch.zeros(1, full_len, 1, 1, 1, 1),
+                "layout": layout,
+                "transformer_options": {TARGET_SPARSE_CONTRACT_KEY: target_sparse_contract(plan)},
+            },
+            {"original_block": None},
+        )
+
+
+class _IdentitySamplerModel:
+    def __init__(self):
+        self.model_sampling = SimpleNamespace(noise_scale=1.0)
+        self.latent_shapes = None
+
+    def process_latent_in(self, value):
+        return value
+
+
+def test_target_sparse_runtime_splits_two_target_grid_lifetimes_without_resizing_exact_prefix():
+    target_latent, target_shapes, denoise_mask = _masked_target(target_t=2, target_h=8, target_w=6)
+    target_noise = torch.randn_like(target_latent)
+    sigmas = torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_sa_solver_pece"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=_IdentitySamplerModel()),
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+        conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+    calls = []
+    binding = FlowBinding(
+        trajectory=H3FlowTrajectory(),
+        guidance=GuidanceConfig(mode="off"),
+        capture_enabled=True,
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(
+            self,
+            noise,
+            latent,
+            call_sampler,
+            call_sigmas,
+            mask,
+            callback,
+            disable_pbar,
+            seed,
+            *,
+            latent_shapes,
+        ):
+            del callback, disable_pbar, seed
+            transformer = dict(guider.model_options["transformer_options"])
+            calls.append(
+                (
+                    noise.clone(),
+                    latent,
+                    call_sampler,
+                    call_sigmas.clone(),
+                    mask,
+                    list(latent_shapes),
+                    transformer,
+                )
+            )
+            if len(calls) == 1:
+                assert TARGET_SPARSE_CONTRACT_KEY in transformer
+                return latent / (1.0 - float(call_sigmas[-1]))
+            assert TARGET_SPARSE_CONTRACT_KEY not in transformer
+            binding.metrics.event("model_call", actual=True, stage="high")
+            return latent
+
+    mutable_shapes = list(target_shapes)
+    result = _run_progressive(
+        Executor(),
+        guider,
+        binding,
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            handoff_coordinate=0.3,
+            exact_prefix_mode="target_sparse_lifter",
+            suffix_dc_bridge=False,
+        ),
+        target_noise,
+        target_latent,
+        sampler,
+        sigmas,
+        denoise_mask,
+        None,
+        True,
+        7,
+        mutable_shapes,
+    )
+
+    assert result is target_latent
+    assert len(calls) == 2
+    assert calls[0][1] is target_latent
+    assert calls[0][4] is denoise_mask
+    assert calls[0][5] == target_shapes
+    assert calls[1][1] is target_latent
+    assert calls[1][4] is denoise_mask
+    assert calls[1][5] == target_shapes
+    protected = denoise_mask == 0
+    assert torch.equal(calls[1][0][protected], target_noise[protected])
+    assert mutable_shapes == target_shapes
+    handoff = [event for event in binding.metrics.events if event.kind == "handoff_complete"][-1]
+    assert handoff.fields["input_mode"] == "target_grid_sparse"
+    assert handoff.fields["exact_probe_performed"] is False
+    assert handoff.fields["source_latent_resize_performed"] is False
+    assert handoff.fields["learned_transfer_performed"] is False
+    assert handoff.fields["sampler_invocation_count"] == 2
+    assert handoff.fields["history_boundary_count"] == 1
+    assert binding.metrics.counters["progressive_target_sparse_runs"] == 1
+    assert binding.metrics.counters["progressive_sampler_invocations"] == 2
+    assert binding.metrics.counters["progressive_history_boundaries"] == 1
+
+
+def test_target_sparse_high_failure_invalidates_committed_low_trajectory():
+    target_latent, target_shapes, denoise_mask = _masked_target(target_t=2, target_h=8, target_w=6)
+    sigmas = torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0])
+
+    def native():
+        pass
+
+    native.__name__ = "sample_euler"
+    sampler = SimpleNamespace(sampler_function=native, extra_options={})
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=_IdentitySamplerModel()),
+        original_conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+        conds={"positive": [{"cross_attn": torch.zeros(1, 2, 4)}]},
+    )
+    calls = 0
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, call_sampler, call_sigmas, *args, latent_shapes):
+            nonlocal calls
+            del noise, call_sampler, args, latent_shapes
+            calls += 1
+            if calls == 1:
+                return latent / (1.0 - float(call_sigmas[-1]))
+            raise RuntimeError("synthetic target-sparse high failure")
+
+    trajectory = H3FlowTrajectory()
+    binding = FlowBinding(
+        trajectory=trajectory,
+        guidance=GuidanceConfig(mode="off"),
+        capture_enabled=True,
+    )
+    with pytest.raises(RuntimeError, match="synthetic target-sparse high failure"):
+        _run_progressive(
+            Executor(),
+            guider,
+            binding,
+            ProgressiveTargetInputConfig(
+                source_latent_h=4,
+                source_latent_w=4,
+                handoff_coordinate=0.3,
+                exact_prefix_mode="target_sparse_lifter",
+            ),
+            torch.randn_like(target_latent),
+            target_latent,
+            sampler,
+            sigmas,
+            denoise_mask,
+            None,
+            True,
+            7,
+            list(target_shapes),
+        )
+
+    assert len(trajectory.runs) == 1
+    assert not trajectory.runs[0].complete
+    assert "target-sparse progressive continuation failed" in trajectory.runs[0].abort_reason
+    assert any(event.kind == "trajectory_invalidate" for event in binding.metrics.events)

--- a/tests/test_target_sparse_install.py
+++ b/tests/test_target_sparse_install.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from h3_flow_regenerate.comfy_compat import _contains_target_sparse_wrapper, _install_target_sparse
+from h3_flow_regenerate.metrics import H3FlowMetrics
+
+
+class _PatchModel:
+    def __init__(self, existing):
+        self.model_options = {
+            "transformer_options": {
+                "patches_replace": {
+                    "dit": dict(existing),
+                }
+            }
+        }
+
+    def set_model_patch_replace(self, wrapper, namespace, block_kind, layer):
+        assert namespace == "dit"
+        patches = self.model_options["transformer_options"].setdefault("patches_replace", {}).setdefault("dit", {})
+        patches[(block_kind, layer)] = wrapper
+
+
+def _existing_wrapper(args, _extra):
+    return {"img": args["img"]}
+
+
+def test_target_sparse_install_composes_with_existing_block_replacements(monkeypatch):
+    model = _PatchModel({("double_block", 0): _existing_wrapper})
+    monkeypatch.setattr(
+        "h3_flow_regenerate.comfy_compat.validate_h3_model",
+        lambda _model: SimpleNamespace(blocks=[object(), object(), object()]),
+    )
+    metrics = H3FlowMetrics()
+
+    _install_target_sparse(model, metrics)
+
+    dit = model.model_options["transformer_options"]["patches_replace"]["dit"]
+    assert set(dit) == {("double_block", 0), ("double_block", 1), ("double_block", 2)}
+    assert _contains_target_sparse_wrapper(dit[("double_block", 0)])
+    assert dit[("double_block", 0)]._h3_flow_target_sparse_previous is _existing_wrapper
+    assert dit[("double_block", 1)]._h3_flow_target_sparse_previous is None
+    assert dit[("double_block", 2)]._h3_flow_target_sparse_previous is None
+
+
+def test_target_sparse_install_is_idempotent_through_flow_layout_wrapper(monkeypatch):
+    model = _PatchModel({})
+    monkeypatch.setattr(
+        "h3_flow_regenerate.comfy_compat.validate_h3_model",
+        lambda _model: SimpleNamespace(blocks=[object()]),
+    )
+    metrics = H3FlowMetrics()
+    _install_target_sparse(model, metrics)
+    dit = model.model_options["transformer_options"]["patches_replace"]["dit"]
+    sparse = dit[("double_block", 0)]
+
+    def layout_wrapper(args, extra):
+        return sparse(args, extra)
+
+    layout_wrapper._h3_flow_layout_wrapper = True
+    layout_wrapper._h3_flow_previous = sparse
+    dit[("double_block", 0)] = layout_wrapper
+
+    _install_target_sparse(model, metrics)
+
+    assert dit[("double_block", 0)] is layout_wrapper
+    assert _contains_target_sparse_wrapper(layout_wrapper)

--- a/tests/test_target_sparse_node.py
+++ b/tests/test_target_sparse_node.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.nodes import H3ProgressiveTargetInputHandoff
+from h3_flow_regenerate.target_sparse_node import H3ProgressiveMixedGridHandoff, H3ProgressiveTargetSparseHandoff
+
+
+def _patch_kwargs():
+    return {
+        "model": object(),
+        "trajectory": object(),
+        "source_mode": "scale",
+        "source_scale": 0.7,
+        "source_width": 864,
+        "source_height": 640,
+        "handoff_coordinate": 0.35,
+        "handoff_selection": "fixed",
+        "guidance_mode": "direction",
+        "direction_weight": 0.25,
+        "acceleration_weight": 0.0,
+        "consistency_weight": 0.0,
+        "low_frequency_cutoff": 0.25,
+        "temporal_weight": 0.2,
+        "handoff_transfer": "bicubic",
+        "learned_upscaler": None,
+    }
+
+
+def test_target_sparse_node_sets_opt_in_exact_prefix_mode(monkeypatch):
+    captured = {}
+
+    def fake_patch_flow_model(model, **kwargs):
+        captured.update(kwargs)
+        return model, object()
+
+    monkeypatch.setattr("h3_flow_regenerate.target_sparse_node.patch_flow_model", fake_patch_flow_model)
+    kwargs = _patch_kwargs()
+    model = kwargs["model"]
+
+    patched, metrics = H3ProgressiveTargetSparseHandoff().patch(**kwargs)
+
+    assert patched is model
+    assert metrics is captured["metrics"]
+    progressive = captured["progressive"]
+    assert isinstance(progressive, ProgressiveTargetInputConfig)
+    assert progressive.exact_prefix_mode == "target_sparse_lifter"
+    assert progressive.source_scale == 0.7
+    assert progressive.transfer_mode == "bicubic"
+    assert captured["capture_enabled"] is True
+    assert captured["capture_forecasts"] is False
+    assert captured["clear_guidance_conditioning_signature"] is True
+    assert captured["clear_guidance_run_id"] is True
+
+
+def test_target_sparse_node_pixel_mode_preserves_existing_source_geometry_semantics(monkeypatch):
+    captured = {}
+
+    def fake_patch_flow_model(model, **kwargs):
+        captured.update(kwargs)
+        return model, object()
+
+    monkeypatch.setattr("h3_flow_regenerate.target_sparse_node.patch_flow_model", fake_patch_flow_model)
+    kwargs = _patch_kwargs()
+    kwargs.update(source_mode="pixels", source_width=672, source_height=480)
+
+    H3ProgressiveTargetSparseHandoff().patch(**kwargs)
+
+    progressive = captured["progressive"]
+    assert progressive.exact_prefix_mode == "target_sparse_lifter"
+    assert progressive.source_scale is None
+    assert progressive.source_latent_h is not None
+    assert progressive.source_latent_w is not None
+
+
+def test_suffix_dc_bridge_is_exposed_only_on_continuum_specific_progressive_nodes():
+    target_inputs = H3ProgressiveTargetInputHandoff.INPUT_TYPES()
+    sparse_inputs = H3ProgressiveTargetSparseHandoff.INPUT_TYPES()
+    mixed_inputs = H3ProgressiveMixedGridHandoff.INPUT_TYPES()
+    assert "suffix_dc_bridge" not in target_inputs["required"]
+    for inputs in (sparse_inputs, mixed_inputs):
+        bridge = inputs["required"]["suffix_dc_bridge"]
+        assert bridge[0] == "BOOLEAN"
+        assert bridge[1]["default"] is True
+    assert mixed_inputs["required"]["handoff_transfer"][0] == ["learned_3d"]
+    assert sparse_inputs["required"]["handoff_transfer"][0] == ["bicubic", "learned_3d"]

--- a/tests/test_target_sparse_vdn_contract.py
+++ b/tests/test_target_sparse_vdn_contract.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.comfy_compat import _validate_vdn_target_sparse_compat
+from h3_flow_regenerate.metrics import H3FlowMetrics
+from h3_flow_regenerate.target_sparse import (
+    TARGET_SPARSE_CONTRACT_KEY,
+    VDN_EXTERNAL_SEQUENCE_API_VERSION,
+    VDN_EXTERNAL_SEQUENCE_KEY,
+    VDN_EXTERNAL_SEQUENCE_MODE,
+    TargetSparsePlan,
+    make_target_sparse_block_wrapper,
+    target_sparse_contract,
+)
+
+
+def _plan():
+    return TargetSparsePlan(
+        target_t=1,
+        target_h=4,
+        target_w=4,
+        source_h=2,
+        source_w=2,
+        selected_video_rows=torch.tensor([0, 3], dtype=torch.long),
+        anchor_video_rows=torch.tensor([3], dtype=torch.long),
+        protected_video_rows=torch.tensor([0], dtype=torch.long),
+    )
+
+
+def _layout():
+    return SimpleNamespace(
+        segments=[(0, 2, "text"), (2, 6, "video")],
+        seq_len=6,
+    )
+
+
+def test_target_sparse_block_publishes_vdn_external_sequence_contract():
+    plan = _plan()
+    full_img = torch.randn(6, 3)
+    rope = torch.randn(1, 6, 1, 1, 1, 1)
+    seen = {}
+
+    def previous(args, _extra):
+        seen.update(args["transformer_options"][VDN_EXTERNAL_SEQUENCE_KEY])
+        return {"img": args["img"]}
+
+    wrapper = make_target_sparse_block_wrapper(0, 2, H3FlowMetrics(), previous=previous)
+    out = wrapper(
+        {
+            "img": full_img,
+            "rope_freqs": rope,
+            "mod_segments": [(0, 2, 0), (2, 6, 0)],
+            "layout": _layout(),
+            "transformer_options": {TARGET_SPARSE_CONTRACT_KEY: target_sparse_contract(plan)},
+        },
+        {"original_block": None},
+    )
+
+    assert out["img"].shape[0] == 4
+    assert seen == {
+        "api": VDN_EXTERNAL_SEQUENCE_API_VERSION,
+        "mode": VDN_EXTERNAL_SEQUENCE_MODE,
+        "full_sequence_rows": 6,
+        "reduced_sequence_rows": 4,
+    }
+
+
+def test_target_sparse_block_refuses_to_overwrite_an_existing_vdn_contract():
+    plan = _plan()
+    wrapper = make_target_sparse_block_wrapper(
+        0,
+        1,
+        H3FlowMetrics(),
+        previous=lambda args, _extra: {"img": args["img"]},
+    )
+    options = {
+        TARGET_SPARSE_CONTRACT_KEY: target_sparse_contract(plan),
+        VDN_EXTERNAL_SEQUENCE_KEY: {"api": 999},
+    }
+
+    with pytest.raises(RuntimeError, match="existing VDN external-sequence contract"):
+        wrapper(
+            {
+                "img": torch.randn(6, 3),
+                "rope_freqs": torch.randn(1, 6, 1, 1, 1, 1),
+                "mod_segments": [(0, 2, 0), (2, 6, 0)],
+                "layout": _layout(),
+                "transformer_options": options,
+            },
+            {"original_block": None},
+        )
+
+
+def _vdn_owner(api=None):
+    def owner(*_args, **_kwargs):
+        raise AssertionError("owner should not execute during compatibility validation")
+
+    owner._vdn_forward = True
+    if api is not None:
+        owner._vdn_external_sequence_api = api
+    return owner
+
+
+def test_target_sparse_accepts_vdn_with_reduced_sequence_capability():
+    model = SimpleNamespace(
+        object_patches={"diffusion_model.blocks.0.attn.forward": _vdn_owner(VDN_EXTERNAL_SEQUENCE_API_VERSION)}
+    )
+    _validate_vdn_target_sparse_compat(model, 1)
+
+
+def test_target_sparse_fails_before_sampling_on_old_vdn_attention_patch():
+    model = SimpleNamespace(object_patches={"diffusion_model.blocks.0.attn.forward": _vdn_owner()})
+    with pytest.raises(RuntimeError, match="VDN-H3 attention without the required"):
+        _validate_vdn_target_sparse_compat(model, 1)
+
+
+def test_target_sparse_ignores_unrelated_attention_object_patch():
+    model = SimpleNamespace(object_patches={"diffusion_model.blocks.0.attn.forward": lambda *args, **kwargs: None})
+    _validate_vdn_target_sparse_compat(model, 1)

--- a/tools/check_source_contracts.py
+++ b/tools/check_source_contracts.py
@@ -36,6 +36,27 @@ def main() -> None:
     args = parser.parse_args()
 
     require(
+        args.comfy / "comfy/ldm/minimax/vae.py",
+        "clip_length=17",
+        "token_drop=3",
+        "time_down=(1, 2, 2, 1, 1, 1)",
+        "self.frame_pre_padding = (-clip_length) % self.vae_ratio_t",
+        "self.tokens_chunk_size = math.ceil(clip_length / self.vae_ratio_t)",
+        "self.token_overlap = (-token_drop) % self.tokens_chunk_size",
+        "self.frame_overlap = max(self.token_overlap * self.vae_ratio_t - self.frame_pre_padding, 0)",
+        "t_end_idx = t_start_idx + self.tokens_chunk_size + self.token_overlap",
+        "if i == num_chunks - 1 and dec_overlap is not None:",
+    )
+    require(
+        args.continuum / "v3/assembly.py",
+        "segment_images = raw_images[:total_frames][trim_frames:]",
+    )
+    require(
+        args.continuum / "hardening.py",
+        "if int(image.shape[0]) < total_frames:",
+    )
+
+    require(
         args.comfy / "comfy/ldm/minimax/model.py",
         "latents_dim=24",
         "audio_latents_dim=32",

--- a/tools/check_target_sparse_contracts.py
+++ b/tools/check_target_sparse_contracts.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def require(path: Path, *needles: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise SystemExit(f"{path}: missing mixed/sparse H3 contract fragments: {missing}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate mixed-grid and target-sparse H3 integration contracts")
+    parser.add_argument("--comfy", type=Path, required=True)
+    parser.add_argument("--spectrum", type=Path, required=True)
+    parser.add_argument("--continuum", type=Path, required=True)
+    parser.add_argument("--diffaid", type=Path, required=True)
+    parser.add_argument("--vdn", type=Path, required=True)
+    args = parser.parse_args()
+
+    require(
+        args.comfy / "comfy/ldm/minimax/model.py",
+        'segments.append(("audio"',
+        'segments.append(("video"',
+        'if ("double_block", i) in blocks_replace:',
+        '"mod_segments": mod_segments',
+        '"rope_freqs": rope_freqs',
+        '"layout": layout',
+        '})["img"]',
+        "def mask_row_values(mask, latent_t, lat_h, lat_w):",
+        "amax(dim=(2, 4))",
+    )
+    require(
+        args.comfy / "comfy/model_base.py",
+        "def scale_latent_inpaint(self, sigma, noise, latent_image, x=None, denoise_mask=None, **kwargs):",
+        "aug = comfy.ldm.minimax.model.VISUAL_COND_TIMESTEP",
+        "cleans[0] = aug * cleans[0] + (1.0 - aug) * noises[0]",
+    )
+    require(
+        args.spectrum / "comfyui_spectrum_h3/minimax_h3.py",
+        'existing = dit_replacements.get(("double_block", last_index))',
+        "output = existing(args, replacement_context) if existing is not None",
+        "\"final MiniMax H3 block replacement did not return {'img': tensor}\"",
+        "target = hidden[aa:vb].unsqueeze(0)",
+    )
+    require(
+        args.continuum / "masked_continuation.py",
+        "def apply_native_masked_continuation(",
+        "video[:, :, :video_steps].copy_(video_context)",
+        '"continuation video geometry does not match the new target latent"',
+        "video_mask = torch.ones(",
+        "video_mask[:, :, :video_steps] = 0",
+        'output["noise_mask"] = comfy.nested_tensor.NestedTensor((video_mask, audio_mask))',
+    )
+    require(
+        args.diffaid / "nodes.py",
+        "def _minimax_h3_language_ranges(",
+        'args.get("mod_segments", None)',
+        'new_args["img"] = new_img',
+    )
+    require(
+        args.vdn / "vdn_h3/hybrid.py",
+        'VDN_EXTERNAL_SEQUENCE_KEY = "vdn_h3_external_sequence_v1"',
+        'VDN_EXTERNAL_SEQUENCE_MODE = "dense_gate_no_linear"',
+        "def _external_reduced_sequence_active(",
+        'contract.get("full_sequence_rows", -1)',
+        'contract.get("reduced_sequence_rows", -1)',
+        "window_active = not layout.full_cover and not external_reduced",
+        "vdn_forward._vdn_external_sequence_api = VDN_EXTERNAL_SEQUENCE_API_VERSION",
+        "VDN_EXTERNAL_SEQUENCE_API_VERSION = 2",
+        '"native_sequence_rows"',
+        '"prefix_rows_per_frame"',
+        '"mixed_grid_low_suffix"',
+    )
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR finalizes **MiniMax H3 Flow-Aligned Regenerate v0.3.0**.

The main release result is the validated exact-prefix Continuum path:

- **Progressive Mixed-Grid Continuum [Experimental]** keeps the authoritative target-grid protected prefix for H3 conditioning while sampling a genuine lower-resolution generated suffix;
- it runs the exact handoff probe under the same mixed topology;
- it performs the learned 3D latent transfer before a fresh target-grid refinement stage;
- it composes with VDN-H3 external-sequence API 2, Spectrum/SA-PECE, DiffAid and Untwisting RoPE;
- the one-token `suffix_dc_bridge` fixes the previously observed Continuum boundary flash in the matched production workflow, including multiple chunk boundaries.

The generic **Progressive Handoff (Target Input)** remains a generic node and does **not** expose or apply the Continuum seam bridge.

## Mixed-Grid exact-prefix contract

For exact Native Masked continuation:

1. Snapshot the original model-domain target-grid prefix and target-grid sampler noise.
2. Run the private early sampler on a regular low-grid carrier.
3. Before H3 transformer block 0, independently patchify/project the authoritative target-grid protected prefix using native masked-conditioning semantics and replace only the carrier prefix rows.
4. Keep genuine source-grid suffix rows, mixed RoPE and coherent per-row modulation labels through every transformer block.
5. Before native output projection, discard target-prefix transformer outputs and restore the regular low-carrier layout.
6. Run the exact handoff probe through the same mixed contract in a separate sampler lifetime.
7. Feed the complete low-grid clean sequence to the versioned `learned_3d` provider.
8. Discard the learned prefix output, restore the authoritative target-grid prefix, reconstruct the high-stage conditional state/noise, and start a fresh full-grid sampler lifetime.
9. Require the first high-stage call to be an actual H3 evaluation and verify final prefix exactness.

The authoritative target-grid prefix is never spatially resized for H3 transformer conditioning.

## Suffix DC bridge

Mixed-Grid exposes `suffix_dc_bridge`, default **on**.

The learned 3D transfer produces `[U_prefix | U_suffix]` before its prefix is discarded. Flow computes the per-batch/per-channel spatial-mean difference between `P_exact[-1]` and `U_prefix[-1]`, then transfers that relation onto **only the first generated suffix latent token**.

The bridge is deliberately narrow:

- one generated suffix token;
- fixed weight `1.0`;
- per-channel DC/spatial-mean correction;
- authoritative prefix unchanged;
- later suffix tokens unchanged at bridge application;
- no video-space crossfade;
- no extra H3 transformer NFE.

Matched real-media evidence on RTX Pro 6000 reported approximately:

- uncorrected exact-boundary DC RMS: `0.207763`;
- corrected exact-boundary DC RMS: `0.093093`;
- learned-upscaler native boundary DC RMS: `0.093093`;
- corrected tokens: `1`;
- weight: `1.0`;
- `final_prefix_exact=true`.

The visible boundary flash was removed, and the multi-boundary Continuum run was also clean.

## Target-Sparse result

**Progressive Target-Sparse Continuum [Experimental]** remains available as a research/control path but is not promoted for production quality.

It was already tested with real decoded media. Because it sparsifies the early target-grid hidden stream without performing the learned latent upscale, approximation errors can cascade into later generation. Observed failures included skin imperfections, unstable/odd clothing details and spurious background additions.

That negative result closes the previous quality gate: the release recommendation for exact-prefix progressive Continuum is **Mixed-Grid + learned 3D transfer**, not Target-Sparse.

Target-Sparse still exposes the dedicated Continuum-only one-token bridge at its full-grid high-stage boundary for research/control use. This does not alter the broader quality conclusion above.

## Generic Target Input separation

**Progressive Handoff (Target Input)** is not a Continuum-specific exact-prefix node.

- normal unprotected calls can use the private low/probe/high progressive path;
- exact protected prefixes conservatively fall back to a target-grid sampler lifetime;
- `bicubic` and optional `learned_3d` remain available for the ordinary handoff path;
- it has no `suffix_dc_bridge` UI or runtime behavior.

Regression coverage enforces this separation.

## Continuum Decode Context

Adds **MiniMax H3 Continuum Decode Context** for a separate native temporal-VAE boundary issue.

The node supplies real future latent context to the preceding chunk's decode-only tensor at exact physical joins while preserving accepted sampling latents, continuation state, masks, plan and audio. The unchanged assembly trim discards the extra decode tail.

This is independent from the latent DC bridge; the bridge is what fixed the validated Mixed-Grid flash.

## VDN-H3 interoperability

The source-contract lane is coordinated with the merged VDN-H3 v1.5.0 release commit:

`xmarre/ComfyUI-VDN-H3@1fc9d0d979683e3410587fac17358d3dd583e551`

Mixed-Grid uses API 2 / `vdn_h3_external_sequence_v1` with `topology=mixed_grid_low_suffix`. VDN retains the learned dense softmax gate and disables only geometry-dependent local-window/linear-complement processing while the mixed sequence is active. The fresh target-grid high stage returns to normal VDN execution.

VDN v1.5.0 also contains the final Comfy-managed lifecycle work and backwards-compatible `ApplyVDNH3Advanced` positional-workflow migration.

## Release / README updates

- Package version: **0.3.0**.
- README is rewritten around the actual recommended paths rather than development gates.
- Mixed-Grid docs record the successful bridge/multi-boundary result.
- Target-Sparse docs record the negative decoded-media result instead of asking for another acceptance sweep.
- `RELEASE_NOTES.md` contains the v0.3.0 release notes.
- Existing release automation creates the GitHub ZIP + `SHA256SUMS` from the exact CI-tested main commit.
- Existing publish automation publishes the changed `0.3.0` package to the Comfy Registry only after successful main CI.

## Validation

Release staging tree:

`696c4885939ed8765c62c04bf5f7ca763269b271`

Staging CI:

`33987734118` — **success**

It includes:

- Python 3.10 / 3.11 / 3.12 / 3.13 lanes;
- Ruff and format checks;
- full pytest suite;
- compileall;
- sdist/wheel build;
- Apache-2.0 distribution metadata checks;
- isolated wheel import;
- pinned native/sibling source-contract checks, now against the merged VDN v1.5.0 commit;
- mixed-grid and temporal-VAE native source oracles.

## Final PR topology

- Base: `a0c93a436b703db473287dce90df271ddb32717b`
- Head: `b44547efcd394f2c2b9b14d6ddfcbb2d2950dd86`
- Tree: `696c4885939ed8765c62c04bf5f7ca763269b271`
- **1 commit ahead / 0 behind**

This PR is release-ready once the exact final-head PR CI completes successfully.