### PR TITLE
Fix exact-prefix sampler return roundoff in v0.3.1

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,27 @@
+# MiniMax H3 Flow-Aligned Regenerate v0.3.1
+
+v0.3.1 fixes an exact-prefix failure exposed by `res_multistep` and hardens the final exact-mask contract for every target-input progressive path.
+
+## Exact-mask sampler return canonicalization
+
+ComfyUI's inpaint wrapper restores `mask == 0` values to the caller's `latent_image` after every model evaluation. Some numerical solvers can still perform a final arithmetic update after that last evaluation. In particular, `res_multistep` reaches its terminal state through an Euler-form expression that is algebraically equal to the final denoised prediction but can differ by a few floating-point ULPs.
+
+Mixed-Grid correctly treated the protected prefix as immutable, but v0.3.0 then required the sampler's returned packed state to be bitwise identical without canonicalizing those post-model solver roundoff differences. A valid run could therefore finish all H3 work and then fail the final `torch.equal` exact-prefix assertion.
+
+The Comfy compatibility boundary now restores only exactly protected `mask == 0` packed elements from the authoritative target input after the final target-grid sampler lifetime returns. This happens before Mixed-Grid's strict final-prefix assertion and seam diagnostics. The hard bitwise invariant remains unchanged; it is not weakened to an `allclose` tolerance.
+
+The same final-return rule also covers Target-Sparse high-stage sampling and the generic Target Input exact-prefix fallback. Generated/unmasked values are left unchanged, already-exact sampler returns stay zero-copy, and no additional H3 transformer evaluation is introduced.
+
+New telemetry records an `exact_mask_output` event with sampler/source identity, protected and changed element counts, pre-restore exactness, finite/non-finite drift counts, maximum absolute drift and RMS drift. `exact_mask_output_canonicalizations` counts returns that required restoration.
+
+Regression coverage includes a deterministic reproduction of the `res_multistep` terminal Euler roundoff, verifies that only protected values are repaired, verifies a zero-copy already-exact path, and exercises both Mixed-Grid and conservative target-input fallback through the actual Flow outer-wrapper boundary.
+
+## Distribution
+
+The package version is bumped to `0.3.1`. Existing CI, GitHub release, checksum and Comfy Registry workflows remain unchanged; publication occurs only after the exact `main` commit passes CI.
+
+---
+
 # MiniMax H3 Flow-Aligned Regenerate v0.3.0
 
 v0.3.0 makes the real low-grid **Mixed-Grid Continuum** path the recommended exact-prefix progressive workflow, adds the one-token suffix DC seam bridge that fixed the observed Continuum boundary flash, adds native temporal decode context, and ships the VDN API-2 interoperability needed by the mixed sequence.

--- a/docs/MIXED_GRID_CONTINUUM.md
+++ b/docs/MIXED_GRID_CONTINUUM.md
@@ -1,6 +1,6 @@
 # Mixed-Grid Continuum continuation
 
-**MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]** is the recommended accelerated exact-prefix Continuum path in v0.3.0.
+**MiniMax H3 Progressive Mixed-Grid Continuum [Experimental]** is the recommended accelerated exact-prefix Continuum path in v0.3.x.
 
 It requires `handoff_transfer=learned_3d` and the companion `H3_LATENT_UPSCALER` provider. Continuum stays configured for the final target geometry.
 
@@ -21,9 +21,17 @@ Mixed-Grid instead keeps the exact target-grid prefix authoritative while genera
 7. Run the exact handoff probe through the same mixed topology in a separate sampler lifetime.
 8. Feed the complete clean low-grid sequence plus resized prefix context to the learned 3D upscaler.
 9. Discard the upscaler's prefix output, restore the authoritative target-grid prefix, rebuild the high-stage conditional state/noise, and start a fresh full-grid sampler lifetime.
-10. Require the first high-stage call to be an actual H3 evaluation and verify the returned protected prefix remains exact.
+10. Require the first high-stage call to be an actual H3 evaluation. At the final Comfy sampler-return boundary, restore only exact `mask == 0` packed elements from the authoritative target input, then verify the returned protected prefix bitwise and measure the final seam.
 
 The authoritative target-grid prefix is never spatially resized for H3 transformer conditioning.
+
+### Final exact-mask return canonicalization
+
+The final restoration in step 10 is intentionally narrower than a tolerance check. ComfyUI already restores protected values after each model evaluation, but some solvers can perform a terminal arithmetic update after the final evaluation. `res_multistep`, for example, reaches its zero-sigma endpoint through an Euler-form expression that is mathematically equal to the final denoised estimate but can differ by a few floating-point ULPs.
+
+Flow therefore canonicalizes exactly protected `mask == 0` packed elements at the Comfy sampler-return boundary before the existing strict `torch.equal` contract and before final seam diagnostics. It does not use `allclose`, does not edit any generated/unmasked value, performs no extra H3 NFE, and avoids a clone when the returned protected values are already bitwise exact.
+
+The runtime records an `exact_mask_output` event for final target-grid returns with the sampler/source identity, protected and changed element counts, pre-restore exactness, non-finite drift count, maximum absolute drift and RMS drift. `exact_mask_output_canonicalizations` counts returns that required restoration.
 
 ## Suffix DC bridge
 
@@ -105,12 +113,14 @@ Mixed-Grid records four seam states:
 - **A** — native learned-upscaler boundary `[U_prefix | U_suffix]`;
 - **B** — authoritative prefix restored without the bridge `[P_exact | U_suffix]`;
 - **C** — authoritative prefix plus corrected first suffix token;
-- **D** — final boundary after target-grid refinement.
+- **D** — final boundary after target-grid refinement and exact-mask return canonicalization.
 
-Diagnostics include raw RMS, spatial low-pass RMS, per-channel spatial-mean/DC RMS, bridge magnitude/count/weight and final/B/final/C ratios.
+Diagnostics include raw RMS, spatial low-pass RMS, per-channel spatial-mean/DC RMS, bridge magnitude/count/weight and final/B/final/C ratios. Exact-mask return telemetry separately reports whether final protected values needed canonicalization and the magnitude of any pre-restore solver drift.
 
 ## Current status
 
 The mixed-grid path is still labeled Experimental because it is an independent research topology, but its previously open production acceptance gate is closed for the tested stack: real GPU/media validation, multiple Continuum boundaries, VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact probe, fresh target-grid refinement and the suffix DC bridge have all been exercised together successfully.
+
+The v0.3.1 exact-mask return fix is structurally regression-tested against `res_multistep` endpoint roundoff. A real workflow rerun remains the empirical check for that sampler/configuration; the prior real-media validation above used the v0.3.0 stack before this patch.
 
 Quality/speed remain workflow dependent; the documented result is evidence for this implementation and tested stack, not a universal model guarantee.

--- a/h3_flow_regenerate/comfy_compat.py
+++ b/h3_flow_regenerate/comfy_compat.py
@@ -4,6 +4,8 @@ import copy
 from dataclasses import replace
 from typing import Any
 
+import torch
+
 from .attention import AttentionConfig, make_attention_override, make_layout_block_wrapper, mark_layout_wrapper
 from .contracts import H3FlowTrajectory
 from .guidance import GuidanceConfig
@@ -13,6 +15,7 @@ from .mixed_grid import MIXED_WRAPPER_KEY, mixed_diffusion_wrapper
 from .runtime import (
     CLONE_CALLBACK_KEY,
     FLOW_BINDING_KEY,
+    FLOW_STAGE_KEY,
     OUTER_WRAPPER_KEY,
     PREDICT_WRAPPER_KEY,
     PROGRESSIVE_KEY,
@@ -20,6 +23,7 @@ from .runtime import (
     flow_model_clone_callback,
     flow_outer_wrapper,
     flow_predict_wrapper,
+    sampler_name,
 )
 from .target_sparse import VDN_EXTERNAL_SEQUENCE_API_VERSION, make_target_sparse_block_wrapper
 
@@ -65,6 +69,200 @@ def _put_wrapper_last(model: Any, wrapper_type: str, key: str, wrapper) -> None:
     model.remove_wrappers_with_key(wrapper_type, key)
     existing = model.wrappers.get(wrapper_type, {})
     model.wrappers[wrapper_type] = {**existing, key: [wrapper]}
+
+
+def _canonicalize_exact_masked_output(
+    result: torch.Tensor,
+    latent_image: torch.Tensor,
+    denoise_mask: torch.Tensor | None,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Restore exact mask==0 sampler outputs without touching generated values.
+
+    Comfy's inpaint wrapper restores protected values for every model evaluation,
+    but a solver may perform one final arithmetic update after the last evaluation.
+    Algebraically equivalent endpoint formulas (notably res_multistep's final Euler
+    update) can therefore return a few-ULP difference in protected values. The
+    progressive exact-prefix contract is stronger: those caller-owned values must
+    be exact in the returned packed latent as well.
+    """
+
+    stats: dict[str, Any] = {
+        "protected_elements": 0,
+        "pre_restore_exact": True,
+        "canonicalized": False,
+        "changed_elements": 0,
+        "nonfinite_changed_elements": 0,
+        "max_abs_delta": 0.0,
+        "rms_delta": 0.0,
+        "final_exact": True,
+    }
+    if denoise_mask is None:
+        return result, stats
+    if result.shape != latent_image.shape or result.shape != denoise_mask.shape:
+        raise ValueError("exact-mask output canonicalization requires matching packed sampler tensors")
+
+    exact_mask = denoise_mask.to(device=result.device) == 0
+    protected_elements = int(torch.count_nonzero(exact_mask).item())
+    stats["protected_elements"] = protected_elements
+    if protected_elements == 0:
+        return result, stats
+
+    reference = latent_image.to(device=result.device, dtype=result.dtype)
+    mismatch = exact_mask & torch.ne(result, reference)
+    changed_elements = int(torch.count_nonzero(mismatch).item())
+    stats["pre_restore_exact"] = changed_elements == 0
+    stats["changed_elements"] = changed_elements
+
+    if changed_elements:
+        delta = result[mismatch].to(torch.float32) - reference[mismatch].to(torch.float32)
+        finite = torch.isfinite(delta)
+        finite_count = int(torch.count_nonzero(finite).item())
+        stats["nonfinite_changed_elements"] = changed_elements - finite_count
+        if finite_count:
+            finite_delta = delta[finite]
+            stats["max_abs_delta"] = float(finite_delta.abs().max().item())
+            stats["rms_delta"] = float(finite_delta.square().mean().sqrt().item())
+        else:
+            stats["max_abs_delta"] = None
+            stats["rms_delta"] = None
+
+        result = result.clone()
+        result[exact_mask] = reference[exact_mask]
+        stats["canonicalized"] = True
+
+    if bool(torch.any(exact_mask & torch.ne(result, reference)).item()):
+        raise RuntimeError("exact-mask output canonicalization failed")
+    return result, stats
+
+
+def _record_exact_mask_output(
+    binding: FlowBinding,
+    sampler: Any,
+    *,
+    source: str,
+    stats: dict[str, Any],
+) -> None:
+    if int(stats.get("protected_elements", 0)) <= 0:
+        return
+    if bool(stats.get("canonicalized")):
+        binding.metrics.increment("exact_mask_output_canonicalizations")
+    binding.metrics.event(
+        "exact_mask_output",
+        source=str(source),
+        sampler=sampler_name(sampler),
+        **stats,
+    )
+
+
+class _ProgressiveExactMaskExecutor:
+    """Adapt Comfy sampler returns before runtime exact-prefix postconditions."""
+
+    def __init__(
+        self,
+        executor: Any,
+        *,
+        binding: FlowBinding,
+        progressive: ProgressiveTargetInputConfig,
+        latent_image: torch.Tensor,
+        denoise_mask: torch.Tensor | None,
+        sampler: Any,
+    ) -> None:
+        self._executor = executor
+        self.class_obj = executor.class_obj
+        self._binding = binding
+        self._progressive = progressive
+        self._latent_image = latent_image
+        self._denoise_mask = denoise_mask
+        self._sampler = sampler
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._executor, name)
+
+    def __call__(self, *args: Any, **kwargs: Any):
+        result = self._executor(*args, **kwargs)
+        transformer = (getattr(self.class_obj, "model_options", None) or {}).get("transformer_options") or {}
+        stage = str(transformer.get(FLOW_STAGE_KEY, ""))
+        if stage == "high":
+            source = f"{self._progressive.exact_prefix_mode}_high"
+        elif stage == "" and self._progressive.exact_prefix_mode == "fallback":
+            # Conservative exact-prefix fallback is one ordinary target-grid
+            # sampler lifetime and therefore has no Flow stage marker.
+            source = "target_input_fallback_return"
+        else:
+            return result
+
+        result, stats = _canonicalize_exact_masked_output(
+            result,
+            self._latent_image,
+            self._denoise_mask,
+        )
+        _record_exact_mask_output(
+            self._binding,
+            self._sampler,
+            source=source,
+            stats=stats,
+        )
+        return result
+
+
+def flow_outer_wrapper_with_exact_mask(
+    executor,
+    noise,
+    latent_image,
+    sampler,
+    sigmas,
+    denoise_mask=None,
+    callback=None,
+    disable_pbar=False,
+    seed=None,
+    latent_shapes=None,
+):
+    """Comfy adapter around the sampler-agnostic Flow outer runtime.
+
+    Target-input exact masks are canonicalized at the framework boundary after
+    each final target-grid sampler lifetime returns. Progressive high stages are
+    fixed before runtime's hard exact-prefix check and seam diagnostics; the
+    conservative fallback is fixed inside its single stage-less target-grid call.
+    """
+
+    guider = executor.class_obj
+    model_options = getattr(guider, "model_options", None) or {}
+    binding = model_options.get(FLOW_BINDING_KEY)
+    progressive = model_options.get(PROGRESSIVE_KEY)
+    if not isinstance(binding, FlowBinding) or not isinstance(progressive, ProgressiveTargetInputConfig):
+        return flow_outer_wrapper(
+            executor,
+            noise,
+            latent_image,
+            sampler,
+            sigmas,
+            denoise_mask,
+            callback,
+            disable_pbar,
+            seed,
+            latent_shapes=latent_shapes,
+        )
+
+    adapted = _ProgressiveExactMaskExecutor(
+        executor,
+        binding=binding,
+        progressive=progressive,
+        latent_image=latent_image,
+        denoise_mask=denoise_mask,
+        sampler=sampler,
+    )
+    return flow_outer_wrapper(
+        adapted,
+        noise,
+        latent_image,
+        sampler,
+        sigmas,
+        denoise_mask,
+        callback,
+        disable_pbar,
+        seed,
+        latent_shapes=latent_shapes,
+    )
 
 
 def patch_flow_model(
@@ -136,7 +334,12 @@ def patch_flow_model(
 
     import comfy.patcher_extension
 
-    _put_wrapper_first(patched, comfy.patcher_extension.WrappersMP.OUTER_SAMPLE, OUTER_WRAPPER_KEY, flow_outer_wrapper)
+    _put_wrapper_first(
+        patched,
+        comfy.patcher_extension.WrappersMP.OUTER_SAMPLE,
+        OUTER_WRAPPER_KEY,
+        flow_outer_wrapper_with_exact_mask,
+    )
     # OUTER_SAMPLE must remain outside Spectrum so progressive low/probe/high
     # invocations each traverse Spectrum independently. PREDICT_NOISE must be
     # inside Spectrum so it receives Spectrum's per-call copied model_options

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "comfyui-minimax-h3-flow-aligned-regenerate"
-version = "0.3.0"
+version = "0.3.1"
 description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_exact_mask_output.py
+++ b/tests/test_exact_mask_output.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import torch
+
+from h3_flow_regenerate.comfy_compat import (
+    _canonicalize_exact_masked_output,
+    flow_outer_wrapper_with_exact_mask,
+)
+from h3_flow_regenerate.geometry import pack_streams, unpack_streams
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.runtime import FLOW_BINDING_KEY, PROGRESSIVE_KEY, FlowBinding
+
+
+def _res_multistep_endpoint_roundoff(reference: torch.Tensor) -> torch.Tensor:
+    """Reproduce x + ((x - denoised) / sigma) * -sigma rounding."""
+    x = reference.new_tensor(-0.4338788092136383)
+    sigma = reference.new_tensor(0.4)
+    return x + ((x - reference) / sigma) * (-sigma)
+
+
+def _packed_exact_prefix(t=7, prefix=2, h=8, w=12):
+    video = torch.arange(24 * t * h * w, dtype=torch.float32).reshape(1, 24, t, h, w)
+    video[0, 0, 0, 0, 0] = 0.7935083508491516
+    audio = torch.randn(1, 32, 2, 11)
+    packed, shapes = pack_streams((video, audio))
+    video_mask = torch.ones_like(video)
+    video_mask[:, :, :prefix] = 0
+    mask = pack_streams((video_mask, torch.ones_like(audio)))[0]
+    return packed, shapes, mask
+
+
+def _with_one_roundoff_value(packed: torch.Tensor) -> torch.Tensor:
+    result = packed.clone()
+    rounded = _res_multistep_endpoint_roundoff(result[..., 0])
+    assert not torch.equal(rounded, result[..., 0])
+    result[..., 0] = rounded
+    return result
+
+
+def test_exact_mask_canonicalization_repairs_res_multistep_roundoff_only():
+    latent = torch.tensor([[[0.7935083508491516, 2.0, 3.0, 4.0]]], dtype=torch.float32)
+    mask = torch.tensor([[[0.0, 1.0, 1.0, 1.0]]], dtype=torch.float32)
+    result = latent.clone()
+    result[..., 0] = _res_multistep_endpoint_roundoff(result[..., 0])
+    unprotected_before = result[..., 1:].clone()
+
+    canonical, stats = _canonicalize_exact_masked_output(result, latent, mask)
+
+    assert torch.equal(canonical[..., :1], latent[..., :1])
+    assert torch.equal(canonical[..., 1:], unprotected_before)
+    assert stats["protected_elements"] == 1
+    assert stats["pre_restore_exact"] is False
+    assert stats["canonicalized"] is True
+    assert stats["changed_elements"] == 1
+    assert stats["nonfinite_changed_elements"] == 0
+    assert stats["max_abs_delta"] > 0
+    assert stats["rms_delta"] > 0
+    assert stats["final_exact"] is True
+
+
+def test_exact_mask_canonicalization_is_zero_copy_when_already_exact():
+    latent = torch.tensor([[[1.0, 2.0, 3.0]]], dtype=torch.float32)
+    mask = torch.tensor([[[0.0, 1.0, 1.0]]], dtype=torch.float32)
+    result = latent.clone()
+    pointer = result.data_ptr()
+
+    canonical, stats = _canonicalize_exact_masked_output(result, latent, mask)
+
+    assert canonical.data_ptr() == pointer
+    assert stats["protected_elements"] == 1
+    assert stats["pre_restore_exact"] is True
+    assert stats["canonicalized"] is False
+    assert stats["changed_elements"] == 0
+    assert stats["max_abs_delta"] == 0.0
+    assert stats["rms_delta"] == 0.0
+
+
+def test_mixed_grid_runtime_sees_canonical_prefix_before_hard_postcondition(monkeypatch):
+    from test_handoff import FakeLearnedProvider
+
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+
+    packed, shapes, mask = _packed_exact_prefix()
+    binding = FlowBinding()
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+    )
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    patcher = SimpleNamespace(model=base, object_patches={})
+    guider = SimpleNamespace(
+        model_options={
+            "transformer_options": {},
+            FLOW_BINDING_KEY: binding,
+            PROGRESSIVE_KEY: config,
+        },
+        model_patcher=patcher,
+        conds={"positive": []},
+    )
+    calls = []
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+            stage = guider.model_options["transformer_options"].get("h3_flow_stage", "single")
+            calls.append(stage)
+            if stage == "high":
+                assert torch.equal(call_mask, mask)
+                binding.metrics.event("model_call", actual=True)
+                return _with_one_roundoff_value(packed)
+            if stage == "probe":
+                return latent.clone()
+            return latent / (1 - sigmas[-1])
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    result = flow_outer_wrapper_with_exact_mask(
+        Executor(),
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        latent_shapes=list(shapes),
+    )
+
+    assert torch.equal(result, packed)
+    assert calls == ["low", "probe", "high"]
+    events = [event for event in binding.metrics.events if event.kind == "exact_mask_output"]
+    assert len(events) == 1
+    event = events[0]
+    assert event.fields["source"] == "mixed_grid_low_suffix_high"
+    assert event.fields["canonicalized"] is True
+    assert event.fields["changed_elements"] == 1
+    assert binding.metrics.counters["exact_mask_output_canonicalizations"] == 1
+
+
+def test_target_input_fallback_canonicalizes_single_sampler_return():
+    packed, shapes, mask = _packed_exact_prefix()
+    binding = FlowBinding()
+    config = ProgressiveTargetInputConfig(source_latent_h=4, source_latent_w=6)
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={
+            "transformer_options": {},
+            FLOW_BINDING_KEY: binding,
+            PROGRESSIVE_KEY: config,
+        },
+        model_patcher=SimpleNamespace(model=base),
+        conds={"positive": []},
+    )
+
+    class Executor:
+        class_obj = guider
+
+        def __call__(self, noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+            assert latent_shapes == list(shapes)
+            assert torch.equal(call_mask, mask)
+            return _with_one_roundoff_value(packed)
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    result = flow_outer_wrapper_with_exact_mask(
+        Executor(),
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        latent_shapes=list(shapes),
+    )
+
+    assert torch.equal(result, packed)
+    result_video, result_audio = unpack_streams(result, shapes)
+    source_video, source_audio = unpack_streams(packed, shapes)
+    assert torch.equal(result_video, source_video)
+    assert torch.equal(result_audio, source_audio)
+    events = [event for event in binding.metrics.events if event.kind == "exact_mask_output"]
+    assert len(events) == 1
+    assert events[0].fields["source"] == "target_input_fallback_return"
+    assert events[0].fields["canonicalized"] is True
+    assert events[0].fields["changed_elements"] == 1


### PR DESCRIPTION
## Summary

Fix the Mixed-Grid exact-prefix crash exposed by `res_multistep` without weakening the bitwise prefix contract.

The failure occurs after the high-stage sampler finishes. ComfyUI's inpaint wrapper restores `mask == 0` values after every model evaluation, but `res_multistep` performs a terminal Euler-form arithmetic update after the final evaluation. That endpoint is algebraically equal to the final denoised prediction but can differ by a few floating-point ULPs, so v0.3.0 could finish all H3 work and then fail its final `torch.equal` prefix assertion.

## Fix

- keep the existing strict runtime exact-prefix assertion;
- do **not** replace it with `allclose`;
- at the Comfy sampler-return boundary, canonicalize only exactly protected `mask == 0` packed elements from the authoritative target input;
- perform that restoration before Mixed-Grid's final exact-prefix assertion and seam diagnostics;
- apply the same final-return rule to Target-Sparse high-stage sampling and the generic Target Input exact-prefix fallback;
- leave every generated/unmasked value unchanged;
- avoid cloning when the protected output is already bitwise exact;
- add no H3 transformer NFE.

The compatibility adapter is deliberately outside the sampler-agnostic Flow runtime invariant: it handles Comfy's exact-mask return semantics while the runtime continues to require exact returned state.

## Diagnostics

Adds `exact_mask_output` telemetry with:

- sampler/source identity;
- protected element count;
- changed element count;
- pre-restore exactness;
- finite/non-finite drift count;
- maximum absolute drift;
- RMS drift;
- final exactness.

`exact_mask_output_canonicalizations` counts returns that required restoration.

## Regression coverage

New tests:

- deterministically reproduce the `res_multistep` terminal Euler roundoff;
- prove only exact-mask values are repaired and unprotected values are unchanged;
- prove already-exact returns are zero-copy;
- exercise the Mixed-Grid Flow outer-wrapper path and its hard final postcondition;
- exercise the conservative target-input exact-prefix fallback.

## Validation

PR CI `34013176929` is green on final head:

- Python 3.10 / 3.11 / 3.12 / 3.13;
- Ruff + format;
- full pytest suite;
- compileall;
- wheel/sdist build and Apache-2.0 distribution checks;
- isolated wheel import;
- pinned native/sibling source-contract checks;
- mixed-grid and temporal-VAE native source oracles.

The matched real `res_multistep` Continuum workflow has also passed. The original failure was reproduced in the expected form by telemetry and repaired at the final sampler-return boundary:

- sampler: `sample_res_multistep`;
- source: `mixed_grid_low_suffix_high`;
- protected elements: `782912`;
- elements changed by terminal solver roundoff: `175045`;
- pre-restore exact: `false`;
- max absolute drift: `4.76837158203125e-07`;
- RMS drift: `7.637857635245382e-08`;
- non-finite changed elements: `0`;
- canonicalized: `true`;
- final exact: `true`.

The high stage completed normally, `mixed_grid_complete.final_prefix_exact=true`, and the progressive sampler finished with `failed=false`. The previous `mixed-grid high stage violated exact original-prefix preservation` exception did not recur.

This closes both the structural/CI gate and the real-workflow empirical gate for the v0.3.1 exact-mask fix.

## Release

- package version: `0.3.1`;
- release notes and Mixed-Grid contract docs updated;
- existing CI/release/registry automation is unchanged.

## Topology

- base: `e53dceb8558da78f947c7864d24e0e3fde51ba45`
- head: `f0cec7341f61aa53dbfabbed7cd9babb664632c2`
- **1 commit ahead / 0 behind**