### PR TITLE
Release Mixed-Grid attention-measure framing fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,15 @@ real low-grid generated suffix
             |
        mixed H3 sequence
             |
+  optional attention-measure
+ normalization in compatible
+     attention backend
+            |
        exact handoff probe
             |
       learned 3D upscale
+            |
+ optional exact-overlap repair
             |
   restore exact target prefix
             |
@@ -60,6 +66,8 @@ real low-grid generated suffix
 The protected prefix is never spatially resized for transformer conditioning. The low-grid suffix is real low-resolution H3 sampling, not a sparse subset of target-grid hidden rows.
 
 When VDN is enabled, this path uses VDN external-sequence API 2 (`mixed_grid_low_suffix`) during the mixed low stage and returns to normal VDN execution for the fresh target-grid stage.
+
+The optional legacy-named `suffix_geometric_bridge` remains off by default. Its former source-space warp is retired after matched testing showed that every finite verified horizon simply moved the discontinuity to the corrected-to-untouched transition. The active experiment instead publishes an upstream K/V attention-measure contract and independently retains the target exact-overlap representation repair. A compatible ComfyUI-Sol-H3 revision is required to consume the K/V measure contract.
 
 ### Suffix DC bridge
 
@@ -80,7 +88,7 @@ The bridge fixed the brief Continuum boundary flash in matched real-media testin
 
 **MiniMax H3 Continuum Decode Context** can be placed immediately before the normal Video VAE Decode. It supplies real future latent context to the native H3 temporal decoder at exact chunk joins while leaving accepted sampling latents, continuation state, masks, audio and the assembly plan unchanged.
 
-This solves a separate decoder-window boundary problem. It is not the mechanism that fixed the mixed-grid DC flash above.
+This solves a separate decoder-window boundary problem. It is not the mechanism that fixed the mixed-grid DC flash above and is not the current attention-measure experiment.
 
 See [docs/CONTINUUM_DECODE_CONTEXT.md](docs/CONTINUUM_DECODE_CONTEXT.md).
 
@@ -179,7 +187,8 @@ DiffAid, Untwisting RoPE, Spectrum and VDN are optional integrations.
 Important contracts:
 
 - **Spectrum:** actual/forecast provenance and sampler-history boundaries are preserved. Fresh target-grid stages start with an actual H3 evaluation where required.
-- **VDN-H3:** Mixed-Grid uses API 2 only during the external mixed sequence and resumes ordinary VDN behavior at full target resolution.
+- **VDN-H3:** Mixed-Grid uses API 2 only during the external mixed sequence and resumes ordinary VDN behavior at full target resolution. The optional attention-measure experiment does not change API 2 or VDN's learned gate ownership.
+- **Sol-H3:** a compatible revision can consume the independent Mixed-Grid attention-measure contract by keeping all Q rows while normalizing only the denser protected-prefix K/V sampling density.
 - **SA-Solver/PECE, SEEDS, ER-SDE, Euler/RES:** sampler objects are preserved; separate sampler lifetimes are used where geometry/history boundaries require them.
 - **Audio:** progressive spatial transfer affects video only. Audio is never spatially resized.
 - **Learned upscaler:** Mixed-Grid requires `learned_3d`; the generic Target Input node can use either `bicubic` or `learned_3d`.
@@ -192,7 +201,11 @@ The paths with the strongest real-media support are:
 - generic Progressive Handoff for unprotected calls;
 - **Mixed-Grid Continuum with learned 3D transfer and the suffix DC bridge** for exact-prefix continuation.
 
-The Mixed-Grid path has been exercised on a real RTX Pro 6000 workflow with VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact handoff probing and multiple Continuum boundaries. The previously observed boundary flashing is fixed by the suffix DC bridge in that tested workflow.
+The Mixed-Grid path has been exercised on a real RTX Pro 6000 workflow with VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact handoff probing and multiple Continuum boundaries. The previously observed brief boundary flashing is fixed by the suffix DC bridge in that tested workflow.
+
+A smaller whole-frame shrink/top-edge reveal remains under investigation. The source-space affine/trajectory correction family is now retired: `00318` exhausted every directly authorized finite horizon and every accepted boundary correction failed at a corrected-to-untouched transition, so the runtime deliberately returns the original source tensor instead of inventing a fade or extrapolation.
+
+The current off-by-default experiment moves farther upstream. For a representative matched geometry, protected prefix frames carry `1064` K/V rows while genuine source-grid suffix frames carry `540` (`~1.97x` spatial row density). Flow now publishes an independent attention-measure contract so a compatible Sol-H3 backend can keep every Q row while deterministically reducing only protected-prefix K/V to source-grid spatial density. The target exact-overlap representation reconciliation remains a second independent stage. Code-side contracts are green; decoded media is still required before this is treated as a fix.
 
 Target-Sparse is deliberately not promoted because its no-latent-upscale design produced cascading decoded-media defects in testing.
 
@@ -201,7 +214,8 @@ Quality and speed still depend on prompt, references, geometry, sampler, Spectru
 ## Documentation
 
 - [docs/USAGE.md](docs/USAGE.md) — wiring and parameter details
-- [docs/MIXED_GRID_CONTINUUM.md](docs/MIXED_GRID_CONTINUUM.md) — Mixed-Grid contract and diagnostics
+- [docs/MIXED_GRID_CONTINUUM.md](docs/MIXED_GRID_CONTINUUM.md) — Mixed-Grid contract, VDN/Sol ownership and diagnostics
+- [docs/mixed-grid-seam-repair.md](docs/mixed-grid-seam-repair.md) — framing-defect evidence chain, retired source warp and upstream attention-measure experiment
 - [docs/TARGET_SPARSE_CONTINUUM.md](docs/TARGET_SPARSE_CONTINUUM.md) — Target-Sparse research path
 - [docs/CONTINUUM_DECODE_CONTEXT.md](docs/CONTINUUM_DECODE_CONTEXT.md) — decoder right-context helper
 - [docs/BENCHMARKS.md](docs/BENCHMARKS.md) — decoded-media validation ledger

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,3 +1,57 @@
+# MiniMax H3 Flow-Aligned Regenerate v0.3.3
+
+v0.3.3 fixes the smaller whole-frame shrink/top-edge reveal that remained at some Mixed-Grid Continuum exact-prefix joins after the v0.3.0 one-token DC bridge had already removed the separate tone/flash boundary.
+
+## Mixed-Grid attention-measure normalization
+
+The root cause was upstream of latent transfer. Mixed-Grid correctly keeps the authoritative protected prefix on the target spatial grid while the generated suffix remains on the lower source grid, but ordinary attention treated every packed K/V row as equal measure. In the validated production geometry a protected-prefix frame contributed `28 x 38 = 1064` K/V rows while a source-grid suffix frame contributed `20 x 27 = 540`, about `1.97037x` the discrete spatial sampling density.
+
+When the existing off-by-default `suffix_geometric_bridge` experiment is enabled, Flow now publishes an independent `h3_flow_mixed_grid_attention_measure_v1` contract. A compatible Sol-H3 backend keeps every query row and all non-video/source-suffix K/V rows, while deterministically stratifying only protected-prefix K/V to the source-grid spatial measure using native MiniMax-H3 `_frame_grid` coordinates.
+
+Validated production accounting:
+
+```text
+Q:   56029 -> 56029
+K/V: 56029 -> 49741
+removed protected-prefix K/V rows: 6288 per attention call
+```
+
+The existing VDN external-sequence API 2 contract and learned gate ownership are unchanged.
+
+## Decoded-media result
+
+The original whole-frame framing jump is no longer visible in the matched real-SM120 runs. The previously problematic join remains approximately unit-scale in both the `dense_evaluations=0` validation run and the follow-up `dense_evaluations=1` quality run; neither shows the old shrink/top-edge reveal or a new delayed framing pulse at that boundary.
+
+Run `00324` also closes the technical acceptance gate with the ordinary Spectrum schedule restored after the companion Sol-H3 receipt fix:
+
+```text
+18 logical calls
+13 actual transformer NFE
+5 Spectrum forecasts
+
+low:   7 actual / 3 forecast
+high:  4 actual / 2 forecast
+probe: 2 actual
+```
+
+The real measure path executed 192 times with no compatibility fallback or numerical-backend transition, and final exact-prefix canonicalization remained bitwise exact.
+
+## Retired source-warp experiment
+
+The earlier source affine/trajectory repair family is permanently retired. Matched testing showed that every finite verified correction horizon simply moved the discontinuity to the corrected-to-untouched transition. The runtime therefore leaves the clean source trajectory unchanged instead of inventing a temporal fade or extrapolating unmeasured geometry.
+
+The independent target exact-overlap representation reconciliation and the released one-token DC bridge remain intact and separate from the attention-measure correction.
+
+## Companion release
+
+This feature requires the coordinated ComfyUI-Sol-H3 attention-measure support released alongside v0.3.3. The Flow option remains off by default and does not affect generic Progressive or Target-Sparse nodes.
+
+## Distribution
+
+The package version is bumped to `0.3.3`. Existing CI, GitHub release, checksum and Comfy Registry workflows remain unchanged; publication occurs only after the exact `main` commit passes CI.
+
+---
+
 # MiniMax H3 Flow-Aligned Regenerate v0.3.2
 
 v0.3.2 fixes the `KeyError: 'layout'` reported in issue #22 on MiniMax H3 block-patch callers that predate ComfyUI #15975, and adds complete executable workflow examples instead of leaving only topology overlays under `workflows/`.
@@ -126,7 +180,7 @@ This addresses the native temporal-decoder window boundary and is independent fr
 - The fresh target-grid stage receives no external mixed-sequence contract and resumes ordinary VDN behavior.
 - API 1 target-sparse compatibility remains available.
 
-The coordinated VDN release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
+The coordinated release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
 
 ## Validation
 

--- a/docs/MIXED_GRID_CONTINUUM.md
+++ b/docs/MIXED_GRID_CONTINUUM.md
@@ -19,15 +19,18 @@ Mixed-Grid instead keeps the exact target-grid prefix authoritative while genera
 5. Run all transformer blocks on the mixed sequence with matching per-row modulation metadata.
 6. Before native output projection, discard target-prefix transformer outputs and restore the normal low-carrier layout so native projection/unpatchification remains valid.
 7. Run the exact handoff probe through the same mixed topology in a separate sampler lifetime.
-8. Feed the complete clean low-grid sequence plus resized prefix context to the learned 3D upscaler.
-9. Discard the upscaler's prefix output, restore the authoritative target-grid prefix, rebuild the high-stage conditional state/noise, and start a fresh full-grid sampler lifetime.
-10. Require the first high-stage call to be an actual H3 evaluation. At the final Comfy sampler-return boundary, restore only exact `mask == 0` packed elements from the authoritative target input, then verify the returned protected prefix bitwise and measure the final seam.
+8. Reconstruct the clean source-grid probe sequence and restore the resized authoritative prefix only as private learned-upscaler context.
+9. Feed that clean source-grid sequence to the learned 3D upscaler.
+10. Independently apply the optional exact-overlap target representation reconciliation, then the existing suffix DC bridge, discard the upscaler's prefix output, and restore the authoritative target-grid prefix.
+11. Rebuild the high-stage conditional state/noise and start a fresh full-grid sampler lifetime. Require its first call to be an actual H3 evaluation. At the final Comfy sampler-return boundary, restore only exact `mask == 0` packed elements from the authoritative target input, then verify the returned protected prefix bitwise and measure the final seam.
 
 The authoritative target-grid prefix is never spatially resized for H3 transformer conditioning.
 
+When the optional legacy-named `suffix_geometric_bridge` is enabled, the low/probe mixed stages additionally publish the experimental attention-measure contract described below. The retired source-warp implementation does **not** modify the clean source sequence before step 9.
+
 ### Final exact-mask return canonicalization
 
-The final restoration in step 10 is intentionally narrower than a tolerance check. ComfyUI already restores protected values after each model evaluation, but some solvers can perform a terminal arithmetic update after the final evaluation. `res_multistep`, for example, reaches its zero-sigma endpoint through an Euler-form expression that is mathematically equal to the final denoised estimate but can differ by a few floating-point ULPs.
+The final restoration in step 11 is intentionally narrower than a tolerance check. ComfyUI already restores protected values after each model evaluation, but some solvers can perform a terminal arithmetic update after the final evaluation. `res_multistep`, for example, reaches its zero-sigma endpoint through an Euler-form expression that is mathematically equal to the final denoised estimate but can differ by a few floating-point ULPs.
 
 Flow therefore canonicalizes exactly protected `mask == 0` packed elements at the Comfy sampler-return boundary before the existing strict `torch.equal` contract and before final seam diagnostics. It does not use `allclose`, does not edit any generated/unmasked value, performs no extra H3 NFE, and avoids a clone when the returned protected values are already bitwise exact.
 
@@ -47,8 +50,6 @@ delta = mean(P_exact[-1]) - mean(U_prefix[-1])
 
 and adds `delta` to **only** `U_suffix[0]`.
 
-This preserves the learned upscaler's native boundary relation while keeping the exact prefix authoritative.
-
 The bridge:
 
 - corrects exactly one generated suffix latent token;
@@ -66,9 +67,9 @@ x_sigma = (1 - sigma) * x0 + sigma * noise
 
 The deterministic noise is unchanged.
 
-## Real-media result
+### Validated DC result
 
-The matched production test on RTX Pro 6000 removed the brief exact-prefix boundary flash. Multi-boundary continuation was also clean.
+Matched production testing on RTX Pro 6000 removed the earlier brief exact-prefix tone/flash boundary. Multi-boundary continuation was also clean.
 
 The validated metrics were approximately:
 
@@ -79,7 +80,7 @@ The validated metrics were approximately:
 - weight: `1.0`;
 - `final_prefix_exact=true`.
 
-This is the basis for making the bridge default on for Mixed-Grid in v0.3.0.
+This DC result is separate from the smaller whole-frame framing discontinuity currently under investigation.
 
 ## VDN-H3 contract
 
@@ -92,11 +93,88 @@ mode     = dense_gate_no_linear
 topology = mixed_grid_low_suffix
 ```
 
-VDN validates both target-prefix and source-suffix row identities, full sequence length, temporal partition and explicit RoPE.
+VDN validates target-prefix/source-suffix row identities, full sequence length, temporal partition and explicit RoPE.
 
-During the mixed sequence, VDN retains the learned dense softmax gate and disables only geometry-dependent local-window/linear-complement processing. The fresh target-grid high stage receives no external contract and resumes ordinary VDN behavior.
+During the mixed sequence, VDN retains the released learned dense softmax gate and disables only geometry-dependent local-window/linear-complement processing. The fresh target-grid high stage receives no external contract and resumes ordinary VDN behavior.
 
-The coordinated release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
+The experimental attention-measure contract does **not** change this API-2 contract or VDN ownership.
+
+## Experimental attention-measure normalization
+
+`suffix_geometric_bridge` remains **off by default**. The input name is retained for workflow compatibility, but the source-space affine/trajectory warp family has been retired after matched `00318` testing exhausted every directly authorized finite correction horizon without producing a verified source modification.
+
+The active upstream experiment addresses a different structural mismatch inside low/probe Mixed-Grid attention.
+
+### Unequal spatial K/V density
+
+For the matched `00318` geometry:
+
+```text
+protected target-grid prefix: 28 x 38 = 1064 video rows/frame
+genuine source-grid suffix:   20 x 27 =  540 video rows/frame
+ratio:                                  ~1.97037x
+```
+
+Mixed-Grid already uses native target-grid RoPE positions for the prefix and native source-grid positions for the suffix. However, ordinary softmax still gives each K/V row one equal discrete contribution. A protected-prefix frame therefore contributes almost twice as many K/V samples as a source-grid suffix frame.
+
+When the experimental option is enabled, Flow publishes:
+
+```text
+key  = h3_flow_mixed_grid_attention_measure_v1
+api  = 1
+mode = prefix_kv_stratified_subsample
+```
+
+This is independent of the VDN API-2 sequence contract.
+
+### Compatible backend behavior
+
+Flow does not itself shorten the transformer sequence. A compatible attention backend must validate and consume the measure metadata.
+
+The companion ComfyUI-Sol-H3 implementation:
+
+- preserves every Q row;
+- preserves all non-video K/V rows;
+- preserves every genuine source-grid suffix K/V row exactly and in order;
+- for each protected prefix frame, retains one K/V representative nearest each source-grid spatial coordinate under native MiniMax-H3 area-normalized `_frame_grid` geometry;
+- performs the selection only after explicit full-domain preprocessing such as Untwisting RoPE;
+- executes the resulting rectangular Q/KV domain through Sol-Attn;
+- fails closed if the measure metadata disagrees with the validated Flow API-2 sequence.
+
+For `00318`-equivalent geometry:
+
+```text
+Q:   56029 -> 56029
+K/V: 56029 -> 49741
+```
+
+`49741` is exactly the native low-carrier packed sequence row count. The operation changes K/V integration density, not query ownership or suffix content.
+
+If no compatible backend consumes the contract, the metadata alone does not normalize K/V.
+
+## Retired source-trajectory warp
+
+The source trajectory experiment is now a diagnostic no-op. When the legacy experimental option is requested, Flow reports:
+
+```text
+source_trajectory_bridge_reason = retired_source_warp_family
+source_trajectory_bridge_tokens_corrected = 0
+learned_upscaler_input_modified = false
+```
+
+The clean source-grid continuation reaches the learned upscaler unchanged except for the private authoritative-prefix context that Mixed-Grid already requires.
+
+See [mixed-grid-seam-repair.md](mixed-grid-seam-repair.md) for the evidence chain and the reason finite source warps were abandoned rather than weakened with an invented fade or extrapolation.
+
+## Independent exact-overlap target reconciliation
+
+The experimental option also enables the target exact-overlap representation bridge after learned 3D transfer.
+
+Let the discarded learned prefix boundary be `L_p`, the authoritative exact boundary be `E_p`, and the first learned suffix token be `L_s`. Flow transfers only the zero-spatial-mean component of `E_p - L_p` onto `L_s`; the released `suffix_dc_bridge` independently owns the spatial-mean component.
+
+Matched metrics showed the centered splice error collapse from about `0.400812` to `4.3e-08`. The decoded whole-frame framing jump nevertheless remained, so this algebraic closure is kept as a real splice correction but is not treated as a perceptual fix by itself.
+
+The target bridge never edits the authoritative prefix or target suffix token 1+.
 
 ## Continuum Decode Context
 
@@ -104,23 +182,51 @@ The coordinated release is `xmarre/ComfyUI-VDN-H3` v1.5.0.
 
 Place it immediately before the normal Video VAE Decode when using the native H3 temporal decoder. It changes only the decode-only tensor; accepted sampling latents, continuation state, masks, audio and the assembly plan remain unchanged.
 
-The suffix DC bridge, not Decode Context, is what fixed the mixed-grid latent tone flash in the validated workflow.
+The suffix DC bridge, not Decode Context, fixed the earlier latent tone flash. Decode Context is also not the current framing-measure experiment.
 
 ## Diagnostics
 
-Mixed-Grid records four seam states:
+Mixed-Grid records the established target seam states:
 
 - **A** — native learned-upscaler boundary `[U_prefix | U_suffix]`;
-- **B** — authoritative prefix restored without the bridge `[P_exact | U_suffix]`;
+- **B** — authoritative prefix restored without bridge `[P_exact | U_suffix]`;
 - **C** — authoritative prefix plus corrected first suffix token;
 - **D** — final boundary after target-grid refinement and exact-mask return canonicalization.
 
-Diagnostics include raw RMS, spatial low-pass RMS, per-channel spatial-mean/DC RMS, bridge magnitude/count/weight and final/B/final/C ratios. Exact-mask return telemetry separately reports whether final protected values needed canonicalization and the magnitude of any pre-restore solver drift.
+The experimental path additionally records:
 
-## Current status
+- Flow plan metadata showing whether attention measure was requested;
+- retired source-trajectory no-op telemetry;
+- target exact-overlap representation metrics;
+- compatible Sol-H3 external mixed-measure counters, including full Q rows and K/V rows before/after normalization.
 
-The mixed-grid path is still labeled Experimental because it is an independent research topology, but its previously open production acceptance gate is closed for the tested stack: real GPU/media validation, multiple Continuum boundaries, VDN API 2, Spectrum + SA-PECE, DiffAid, Untwisting RoPE, learned 3D transfer, exact probe, fresh target-grid refinement and the suffix DC bridge have all been exercised together successfully.
+For a `00318`-equivalent mixed call, the expected Sol-side K/V accounting is `56029 -> 49741` while Q remains `56029`.
 
-The v0.3.1 exact-mask return fix is structurally regression-tested against `res_multistep` endpoint roundoff. A real workflow rerun remains the empirical check for that sampler/configuration; the prior real-media validation above used the v0.3.0 stack before this patch.
+## Preserved contracts
 
-Quality/speed remain workflow dependent; the documented result is evidence for this implementation and tested stack, not a universal model guarantee.
+The current experiment:
+
+- never modifies or warps the authoritative target-grid protected prefix;
+- adds no H3 transformer NFE;
+- adds no VAE/model/optical-flow call;
+- performs no image-space/latent-space crossfade or decode-space repair;
+- does not change audio, caller noise, masks or conditioning;
+- does not change VDN API 2 or its learned gate ownership;
+- does not change Spectrum history, forecasts or NFE accounting;
+- leaves released `suffix_dc_bridge` arithmetic unchanged;
+- remains Mixed-Grid-only and off by default.
+
+## Current validation gate
+
+Code-side validation covers native MiniMax-H3 coordinates, production row accounting, exact preservation domains, rectangular Sol-Attn routing, malformed-contract rejection and the existing VDN/Spectrum/DiffAid/Untwist/Flow composition tests.
+
+Decoded media is still the release gate for the framing repair. The next matched run must keep the workflow otherwise unchanged and use:
+
+```text
+suffix_dc_bridge        = true
+suffix_geometric_bridge = true
+```
+
+with the compatible ComfyUI-Sol-H3 companion revision.
+
+Success requires the whole-frame shrink/top-edge reveal to disappear or materially reduce without a new pulse, delayed wobble, motion/detail regression, NFE change or exact-prefix violation. Until that result exists, `suffix_geometric_bridge` remains off by default and the work remains experimental.

--- a/docs/mixed-grid-seam-repair.md
+++ b/docs/mixed-grid-seam-repair.md
@@ -1,0 +1,262 @@
+# Experimental Mixed-Grid seam repair
+
+## Current status
+
+The remaining Continuum defect is a small whole-frame framing discontinuity at the exact-prefix join: a shrink/zoom-out/top-edge reveal that survived the released one-token DC bridge.
+
+This document records the current experimental repair architecture. The earlier source-space affine/trajectory warp family is **retired**. It is no longer applied to the learned-upscaler input. The active experiment now has two independent pieces:
+
+1. an **upstream Mixed-Grid attention-measure contract** during the low/probe H3 transformer stages; and
+2. the already validated **target exact-overlap representation reconciliation** after learned 3D transfer.
+
+The legacy workflow input name `suffix_geometric_bridge` is retained for compatibility. It remains **off by default** and is exposed only by the Mixed-Grid node.
+
+No decoded-media success is claimed yet. PR #24 remains draft until a matched real-GPU/media run passes the final gate.
+
+## Evidence chain
+
+### Target-grid affine was insufficient
+
+`metrics_00276` authorized a target-grid affine correction and reduced the measured signed `sy` residual from roughly `-0.01025` to `+0.00236`. The decoded framing jump remained.
+
+### Exact-overlap representation repair was real but insufficient
+
+`metrics_00281` repaired the learned-prefix replacement mismatch essentially to numerical noise before target-grid refinement:
+
+```text
+centered error: 0.400812 -> ~4.3e-08
+corrected/native raw seam ratio:          ~1.0
+corrected/native low-pass seam ratio:     ~1.0
+corrected/native spatial-mean seam ratio: ~1.0
+```
+
+The decoded framing defect still remained. The exact-prefix replacement splice is therefore a measurable seam amplifier, but not a sufficient explanation for the whole-frame framing discontinuity.
+
+### Source-space warping was falsified under the preserved contracts
+
+The source trajectory experiments then moved the correction before the learned upscaler and successively fixed authorization, temporal classification, cumulative safety, per-axis verification and finite-horizon backoff.
+
+`metrics_00318` exhausted every directly authorized finite source-warp horizon:
+
+```text
+axis_active_tokens_authorized     = [1, 1, 4, 5]
+round 1                           = [1, 1, 4, 5]
+round 2                           = [0, 0, 3, 4]
+round 3                           = [0, 0, 2, 3]
+round 4                           = [0, 0, 1, 2]
+round 5                           = [0, 0, 0, 1]
+axis_active_tokens_post_verified  = [0, 0, 0, 0]
+source_trajectory_bridge_accepted = false
+source_trajectory_bridge_tokens_corrected = 0
+learned_upscaler_input_modified   = false
+```
+
+The final one-token translation attempt still improved its boundary residual but created a much larger corrected-to-untouched transition immediately afterward. Shortening the finite warp only moved that compensating discontinuity earlier. Removing it would require a handcrafted fade/crossfade or unmeasured extrapolation, both explicitly outside this experiment's contracts.
+
+The runtime therefore no longer attempts source warping. When the legacy experimental option is requested, `mixed_grid_source_trajectory_bridge` reports a no-op with:
+
+```text
+source_trajectory_bridge_reason = retired_source_warp_family
+source_trajectory_bridge_tokens_corrected = 0
+learned_upscaler_input_modified = false
+```
+
+The original source-grid clean sequence reaches the learned 3D upscaler unchanged apart from the already required private resized authoritative-prefix context.
+
+## Upstream attention-measure hypothesis
+
+The surviving mismatch exists before the learned upscaler, inside the Mixed-Grid low-stage transformer sequence.
+
+For the matched `00318` geometry, one protected target-grid prefix frame contains:
+
+```text
+28 x 38 = 1064 video rows
+```
+
+while one genuine source-grid suffix frame contains:
+
+```text
+20 x 27 = 540 video rows
+```
+
+The per-frame row-density ratio is therefore:
+
+```text
+1064 / 540 ~= 1.97037
+```
+
+Mixed-Grid already gives the two regions their correct native MiniMax-H3 spatial RoPE coordinates and preserves temporal-coordinate continuity. Ordinary attention, however, still treats every K/V row as one equal discrete sample in the softmax sum. A protected-prefix frame consequently contributes almost twice as many K/V samples as a source-grid suffix frame.
+
+That is an attention-integration-measure mismatch, not a RoPE-coordinate mismatch.
+
+## Attention-measure contract
+
+When `suffix_geometric_bridge=true`, the Mixed-Grid low/probe wrapper now publishes an independent contract:
+
+```text
+key  = h3_flow_mixed_grid_attention_measure_v1
+api  = 1
+mode = prefix_kv_stratified_subsample
+```
+
+This contract does **not** modify VDN external-sequence API 2. The existing VDN contract remains:
+
+```text
+key      = vdn_h3_external_sequence_v1
+api      = 2
+mode     = dense_gate_no_linear
+topology = mixed_grid_low_suffix
+```
+
+The Flow contract describes the native source/target grids, temporal partition, packed-video start row and expected native-density K/V row count. Flow itself does not arbitrarily rewrite attention tensors. A compatible attention backend must explicitly validate and consume the contract.
+
+The companion implementation is in ComfyUI-Sol-H3. It performs the correction after any explicit full-domain Q/K/V preprocessing such as Untwisting RoPE and immediately before rectangular Sol-Attn execution.
+
+### Query domain is unchanged
+
+Every query row remains present. In the production `00318` geometry:
+
+```text
+Q: 56029 -> 56029
+```
+
+Protected-prefix queries are therefore not discarded or resampled.
+
+### Only the denser protected-prefix K/V region is normalized
+
+All packed rows before target video are preserved. Every source-grid suffix K/V row is preserved byte-for-byte and in order.
+
+For each protected prefix frame, the compatible backend maps each source-grid spatial coordinate to the nearest target-prefix coordinate under MiniMax-H3's native area-normalized `_frame_grid` construction and keeps that representative K/V row. The mapping is deterministic and one-to-one.
+
+For `00318`:
+
+```text
+K/V: 56029 -> 49741
+removed protected-prefix K/V rows: 6288
+```
+
+`49741` is exactly the native low-carrier packed row count:
+
+```text
+video_start + temporal * source_rows_per_frame
+```
+
+This converts the protected-prefix K/V integration measure to the same per-frame spatial sampling density as the genuine low-grid suffix without changing Q ownership, suffix K/V content or temporal topology.
+
+### Fail-closed behavior
+
+A compatible consumer rejects the measure contract if it disagrees with the already validated Mixed-Grid API-2 stream, including row counts, temporal partition, source/target grids or expected native K/V rows. A malformed measure request is not silently interpreted as the previous square-attention path.
+
+If no compatible consumer is present, the Flow metadata alone does not perform the K/V normalization. The independent target representation stage can still execute, but the upstream attention-measure experiment has not been exercised.
+
+## VDN ownership
+
+VDN API 2 remains unchanged.
+
+During an external Mixed-Grid sequence, VDN already disables its geometry-dependent local-window/linear complement and evaluates the released learned dense softmax branch through Comfy attention. With Sol-H3 installed as the attention provider, the measure contract changes only that softmax branch's K/V integration domain. VDN still applies its released learned gate to the resulting query outputs afterward.
+
+The experiment therefore does not retrain, replace or reinterpret VDN's learned gate, and does not alter VDN's normal high-grid behavior after the Mixed-Grid external contract is removed.
+
+## Independent target exact-overlap reconciliation
+
+The target representation stage remains independent of the attention-measure experiment.
+
+After learned 3D transfer, let:
+
+```text
+L_p = learned-upscaler last prefix token
+E_p = authoritative exact last prefix token
+L_s = learned first suffix token
+D   = E_p - L_p
+```
+
+The representation bridge transfers only the zero-spatial-mean component of `D` to `L_s`. The released `suffix_dc_bridge` independently owns the spatial-mean/DC component. The authoritative prefix is never edited, and target suffix token 1+ remains unchanged at bridge application.
+
+This stage has already demonstrated near-exact algebraic closure in matched metrics, but it did not by itself remove the decoded framing defect. It remains because it is a real exact-prefix splice correction, not because it is treated as proof of perceptual success.
+
+## Runtime order
+
+With the experimental option enabled, the relevant order is now:
+
+```text
+genuine source-grid low-stage continuation
+-> mixed target-prefix/source-suffix H3 sequence
+-> publish API-2 external sequence + attention-measure metadata
+-> compatible backend keeps all Q and normalizes protected-prefix K/V density
+-> exact handoff probe through the same mixed topology
+-> recover clean source-grid x0
+-> restore resized authoritative prefix only as private upscaler context
+-> source trajectory stage reports retired/no-op
+-> learned 3D target-grid upscaler
+-> exact-overlap target representation reconciliation
+-> released one-token DC bridge
+-> discard learned prefix output
+-> restore authoritative target-grid prefix exactly
+-> fresh target-grid refinement
+-> exact-mask final return canonicalization
+```
+
+## Preserved contracts
+
+The experiment:
+
+- never modifies or warps the authoritative target-grid protected prefix;
+- preserves every Mixed-Grid Q row;
+- preserves non-video K/V rows and all generated source-grid suffix K/V rows;
+- adds no H3 transformer evaluation/NFE;
+- adds no VAE/model/optical-flow call;
+- performs no image-space or latent-space crossfade;
+- performs no decode-space repair;
+- does not change audio, caller noise, masks or conditioning;
+- does not change VDN API 2;
+- does not change Spectrum history, forecast or NFE accounting;
+- leaves released `suffix_dc_bridge` arithmetic unchanged;
+- remains Mixed-Grid-only and off by default.
+
+## Code-side validation
+
+The implementation is covered by native/source and cross-repository tests that verify:
+
+- `00318` row accounting: `56029` Q rows, `49741` K/V rows;
+- all Q rows preserved;
+- non-video K/V and every suffix K/V row preserved exactly;
+- deterministic one-to-one protected-prefix representative selection;
+- representative coordinates agree row-for-row with pinned native ComfyUI MiniMax-H3 `_frame_grid` geometry;
+- rectangular Q/KV reaches the Sol-Attn path;
+- malformed contracts fail closed;
+- Untwist preprocessing occurs on the original full mixed domain before K/V selection;
+- existing VDN/Spectrum/DiffAid/Flow composition tests remain green;
+- the retired source warp cannot modify learned-upscaler input;
+- final exact-prefix and model-call accounting contracts remain intact.
+
+These tests establish execution semantics, not perceptual success.
+
+## Decoded-media gate
+
+The next matched run should leave the workflow otherwise unchanged and use:
+
+```text
+suffix_dc_bridge        = true
+suffix_geometric_bridge = true
+```
+
+A compatible ComfyUI-Sol-H3 build is required for the upstream measure experiment.
+
+The expected runtime evidence is:
+
+```text
+Flow:
+  attention_measure_requested = true
+  source_trajectory_bridge_reason = retired_source_warp_family
+  source_trajectory_bridge_tokens_corrected = 0
+  learned_upscaler_input_modified = false
+
+Sol-H3:
+  external_mixed_measure_calls > 0
+  external_mixed_measure_q_rows unchanged at the full mixed Q domain
+  external_mixed_measure_kv_rows_before > external_mixed_measure_kv_rows_after
+```
+
+For a `00318`-equivalent mixed call, the expected per-call geometry is `56029 -> 49741` K/V rows while Q stays `56029`.
+
+The release gate is the decoded boundary itself: the shrink/top-edge reveal must be gone or materially reduced without a new pulse, delayed wobble, detail loss, motion regression, NFE change or exact-prefix violation. Until then, the option remains off by default and PR #24 remains draft.

--- a/h3_flow_regenerate/handoff.py
+++ b/h3_flow_regenerate/handoff.py
@@ -150,6 +150,7 @@ class ProgressiveTargetInputConfig:
     exact_prefix_mode: str = "fallback"
     suffix_dc_bridge: bool = False
     learned_upscaler: Any | None = field(default=None, repr=False, compare=False)
+    suffix_geometric_bridge: bool = False
 
     def __post_init__(self) -> None:
         explicit = self.source_latent_h is not None or self.source_latent_w is not None
@@ -182,6 +183,10 @@ class ProgressiveTargetInputConfig:
             raise TypeError("suffix_dc_bridge must be boolean")
         if self.suffix_dc_bridge and self.exact_prefix_mode not in {"target_sparse_lifter", "mixed_grid_low_suffix"}:
             raise ValueError("suffix_dc_bridge is only supported by Continuum-specific exact-prefix modes")
+        if not isinstance(self.suffix_geometric_bridge, bool):
+            raise TypeError("suffix_geometric_bridge must be boolean")
+        if self.suffix_geometric_bridge and self.exact_prefix_mode != "mixed_grid_low_suffix":
+            raise ValueError("suffix_geometric_bridge requires mixed-grid Continuum")
         if self.min_high_steps < 1:
             raise ValueError("min_high_steps must be positive")
 

--- a/h3_flow_regenerate/mixed_grid.py
+++ b/h3_flow_regenerate/mixed_grid.py
@@ -3,6 +3,13 @@
 The sampler and native output projection use a regular low-grid carrier. Only
 the transformer sees the larger exact prefix. No generated hidden rows are
 interpolated: suffix rows enter and leave unchanged in native source order.
+
+When the experimental attention-measure repair is enabled, Flow also publishes
+an independent backend contract describing how the denser protected-prefix K/V
+rows can be stratified down to the source-grid density. Q rows remain untouched,
+so the authoritative target-grid prefix representation and all generated suffix
+rows keep their original hidden-state topology. The existing VDN external
+sequence API-2 contract is deliberately unchanged.
 """
 
 from __future__ import annotations
@@ -16,6 +23,8 @@ from .geometry import unpack_streams
 
 MIXED_GRID_KEY = "h3_flow_mixed_grid_v1"
 MIXED_WRAPPER_KEY = "h3_flow_regenerate.mixed_grid.v1"
+MIXED_GRID_MEASURE_KEY = "h3_flow_mixed_grid_attention_measure_v1"
+MIXED_GRID_MEASURE_MODE = "prefix_kv_stratified_subsample"
 
 
 @dataclass(frozen=True, slots=True)
@@ -25,6 +34,7 @@ class MixedGridPlan:
     source_h: int
     source_w: int
     prefix_noise: torch.Tensor | None = None
+    attention_measure: bool = False
 
     @property
     def prefix_t(self):
@@ -33,6 +43,14 @@ class MixedGridPlan:
     @property
     def target_hw(self):
         return tuple(map(int, self.prefix.shape[-2:]))
+
+    @property
+    def source_grid(self):
+        return self.source_h // 2, self.source_w // 2
+
+    @property
+    def target_grid(self):
+        return self.target_hw[0] // 2, self.target_hw[1] // 2
 
     @property
     def source_rows(self):
@@ -51,7 +69,16 @@ class MixedGridPlan:
         return self.prefix_rows + (self.temporal - self.prefix_t) * self.source_rows
 
 
-def build_mixed_grid_plan(mask, shapes, internal_latent, sampler_noise, *, source_h, source_w):
+def build_mixed_grid_plan(
+    mask,
+    shapes,
+    internal_latent,
+    sampler_noise,
+    *,
+    source_h,
+    source_w,
+    attention_measure=False,
+):
     video_mask, _ = unpack_streams(mask, shapes)
     video, _ = unpack_streams(internal_latent, shapes)
     video_noise, _ = unpack_streams(sampler_noise, shapes)
@@ -82,7 +109,47 @@ def build_mixed_grid_plan(mask, shapes, internal_latent, sampler_noise, *, sourc
         source_h,
         source_w,
         video_noise[:, :, :prefix_t].detach().clone(),
+        bool(attention_measure),
     )
+
+
+def mixed_attention_measure_contract(plan: MixedGridPlan, *, video_start: int, sequence_rows: int):
+    """Describe an optional uniform-measure K/V domain without changing VDN API 2.
+
+    The mixed hidden stream has target-grid prefix frames and source-grid suffix
+    frames. Equal softmax weight per row therefore gives every protected prefix
+    frame ``target_rows/source_rows`` times as much spatial measure as a suffix
+    frame. A compatible attention backend can remove that representation-density
+    artifact by retaining all Q rows while selecting one target-prefix K/V row
+    nearest each source-grid spatial coordinate. The suffix K/V domain is already
+    at source density and is copied unchanged.
+    """
+    if not plan.attention_measure:
+        return None
+    if type(video_start) is not int or type(sequence_rows) is not int:
+        raise TypeError("mixed-grid attention-measure row counts must be integers")
+    if video_start <= 0 or sequence_rows != video_start + plan.mixed_rows:
+        raise ValueError("mixed-grid attention-measure rows do not match the mixed sequence")
+    source_grid_h, source_grid_w = plan.source_grid
+    prefix_grid_h, prefix_grid_w = plan.target_grid
+    expected_kv_rows = video_start + plan.temporal * plan.source_rows
+    return {
+        "api": 1,
+        "mode": MIXED_GRID_MEASURE_MODE,
+        "video_start": video_start,
+        "sequence_rows": sequence_rows,
+        "temporal": plan.temporal,
+        "prefix_t": plan.prefix_t,
+        "source_grid_h": source_grid_h,
+        "source_grid_w": source_grid_w,
+        "prefix_grid_h": prefix_grid_h,
+        "prefix_grid_w": prefix_grid_w,
+        "source_rows_per_frame": plan.source_rows,
+        "prefix_rows_per_frame": plan.target_rows,
+        "expected_kv_rows": expected_kv_rows,
+        "exact_prefix_queries_preserved": True,
+        "suffix_kv_unchanged": True,
+    }
 
 
 def carrier_layout(native, plan, text_len, audio_t, payload):
@@ -166,6 +233,11 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
     keep = layout.img_pos < va
     mixed_layout.img_pos = torch.cat((layout.img_pos[keep], torch.arange(va, mixed_layout.seq_len)))
     mixed_layout.img_update = torch.cat((layout.img_update[keep], torch.ones(plan.mixed_rows, dtype=torch.bool)))
+    measure_contract = mixed_attention_measure_contract(
+        plan,
+        video_start=va,
+        sequence_rows=mixed_layout.seq_len,
+    )
     local = dict(options)
     patches = dict(local.get("patches_replace") or {})
     blocks = dict(patches.get("dit") or {})
@@ -199,6 +271,15 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
                     mixed_sequence_rows=mixed_layout.seq_len,
                     vdn_external_sequence_mode="dense_gate_no_linear",
                     vdn_external_sequence_api=2,
+                    attention_measure_requested=bool(plan.attention_measure),
+                    attention_measure_mode=(MIXED_GRID_MEASURE_MODE if measure_contract is not None else "disabled"),
+                    attention_measure_prefix_kv_rows_before=plan.prefix_rows,
+                    attention_measure_prefix_kv_rows_after=plan.prefix_t * plan.source_rows,
+                    attention_measure_kv_rows_before=mixed_layout.seq_len,
+                    attention_measure_kv_rows_after=(
+                        layout.seq_len if measure_contract is not None else mixed_layout.seq_len
+                    ),
+                    attention_measure_prefix_density_ratio=plan.target_rows / plan.source_rows,
                     prefix_exact_latent_resized=False,
                     prefix_native_inpaint_augmentation=True,
                     prefix_visual_cond_timestep=aug,
@@ -230,6 +311,10 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
                 "source_rows_per_frame": plan.source_rows,
                 "prefix_rows_per_frame": plan.target_rows,
             }
+            if measure_contract is not None:
+                if MIXED_GRID_MEASURE_KEY in block_options:
+                    raise RuntimeError("mixed-grid found an already-owned attention-measure contract")
+                block_options[MIXED_GRID_MEASURE_KEY] = measure_contract
             forwarded["transformer_options"] = block_options
             output = previous(forwarded, extra) if previous else extra["original_block"](forwarded)
             result = output["img"]

--- a/h3_flow_regenerate/representation_bridge.py
+++ b/h3_flow_regenerate/representation_bridge.py
@@ -1,0 +1,153 @@
+"""Exact-prefix representation reconciliation for Mixed-Grid Continuum.
+
+The learned 3D upscaler produces a coherent target-grid prefix and suffix, but
+Mixed-Grid must discard that learned prefix and restore Continuum's authoritative
+prefix.  The overlap therefore gives us an exact, same-frame measurement of the
+representation residual introduced by that replacement.
+
+This module transfers only the zero-spatial-mean part of the last overlap
+residual onto the first generated suffix token.  The existing DC bridge owns the
+spatial-mean component.  When both bridges are enabled their sum is exactly the
+full same-frame residual, so the exact-prefix -> corrected-suffix transition
+matches the upscaler's native learned-prefix -> learned-suffix transition before
+fresh target-grid refinement.
+
+No prefix value, later suffix token, audio value, noise, mask, conditioning, VAE
+state, or model evaluation is changed here.  Disabled and already-matched paths
+return the original tensor object.
+"""
+
+from __future__ import annotations
+
+import math
+
+import torch
+
+
+def _rms(value: torch.Tensor) -> float:
+    result = float(value.float().square().mean().sqrt().detach().cpu().item())
+    if not math.isfinite(result):
+        raise RuntimeError("representation bridge produced a non-finite RMS")
+    return result
+
+
+def _validate_pair(learned: torch.Tensor, exact_prefix: torch.Tensor) -> int:
+    if not torch.is_tensor(learned) or not torch.is_tensor(exact_prefix):
+        raise TypeError("representation bridge expects torch.Tensor inputs")
+    if learned.ndim != 5 or exact_prefix.ndim != 5:
+        raise ValueError("representation bridge expects BxCxTxHxW tensors")
+    if not learned.is_floating_point() or not exact_prefix.is_floating_point():
+        raise TypeError("representation bridge expects floating-point tensors")
+    if learned.shape[:2] != exact_prefix.shape[:2] or learned.shape[-2:] != exact_prefix.shape[-2:]:
+        raise ValueError("representation bridge learned/exact geometry differs")
+    prefix_t = int(exact_prefix.shape[2])
+    if prefix_t < 1 or prefix_t >= int(learned.shape[2]):
+        raise ValueError("representation bridge requires a non-empty prefix and suffix")
+    if not bool(torch.isfinite(learned).all().item()) or not bool(torch.isfinite(exact_prefix).all().item()):
+        raise RuntimeError("representation bridge inputs contain NaN or Inf")
+    return prefix_t
+
+
+def disabled_suffix_representation_bridge_metrics(*, prefix_t: int, requested: bool = False) -> dict:
+    p = int(prefix_t)
+    if p < 1:
+        raise ValueError("representation bridge prefix length must be positive")
+    return {
+        "suffix_representation_bridge_version": 1,
+        "suffix_representation_bridge_requested": bool(requested),
+        "suffix_representation_bridge_enabled": False,
+        "suffix_representation_bridge_accepted": False,
+        "suffix_representation_bridge_reason": "disabled" if not requested else "not_applied",
+        "suffix_representation_bridge_prefix_t": p,
+        "suffix_representation_bridge_corrected_tokens": 0,
+        "suffix_representation_bridge_delta_rms": 0.0,
+        "suffix_representation_bridge_dc_rms": 0.0,
+        "suffix_representation_bridge_structural_rms": 0.0,
+        "suffix_representation_bridge_centered_error_before": 0.0,
+        "suffix_representation_bridge_centered_error_after": 0.0,
+        "suffix_representation_bridge_centered_error_ratio": 1.0,
+    }
+
+
+@torch.no_grad()
+def apply_suffix_representation_bridge(
+    learned_clean_video: torch.Tensor,
+    exact_prefix: torch.Tensor,
+    *,
+    requested: bool = True,
+) -> tuple[torch.Tensor, dict]:
+    """Transplant the measured overlap representation residual to suffix token 0.
+
+    The correction is not a temporal fade or image-space blend.  Let ``L_p`` be
+    the learned upscaler's last prefix token, ``E_p`` the exact token that will
+    replace it, and ``L_s`` the first learned suffix token.  The measured overlap
+    residual is ``D = E_p - L_p``.  This function applies ``D - mean_spatial(D)``
+    to ``L_s``; the independent DC bridge may apply ``mean_spatial(D)``.
+
+    Consequently, with both bridges active, ``(L_s + D) - E_p == L_s - L_p``:
+    exact-prefix restoration preserves the upscaler's native boundary transition
+    algebraically instead of fitting an affine camera transform after the fact.
+    """
+
+    prefix_t = _validate_pair(learned_clean_video, exact_prefix)
+    if not isinstance(requested, bool):
+        raise TypeError("representation bridge requested flag must be boolean")
+    if not requested:
+        return learned_clean_video, disabled_suffix_representation_bridge_metrics(prefix_t=prefix_t)
+
+    learned_last = learned_clean_video[:, :, prefix_t - 1].float()
+    exact_last = exact_prefix[:, :, -1].to(device=learned_clean_video.device, dtype=torch.float32)
+    suffix_first = learned_clean_video[:, :, prefix_t].float()
+    delta = exact_last - learned_last
+    dc = delta.mean(dim=(-2, -1), keepdim=True)
+    structural = delta - dc
+
+    native_transition = suffix_first - learned_last
+    hard_transition = suffix_first - exact_last
+    native_centered = native_transition - native_transition.mean(dim=(-2, -1), keepdim=True)
+    hard_centered = hard_transition - hard_transition.mean(dim=(-2, -1), keepdim=True)
+    before_error = _rms(hard_centered - native_centered)
+
+    metrics = disabled_suffix_representation_bridge_metrics(prefix_t=prefix_t, requested=True)
+    metrics.update(
+        suffix_representation_bridge_delta_rms=_rms(delta),
+        suffix_representation_bridge_dc_rms=_rms(dc),
+        suffix_representation_bridge_structural_rms=_rms(structural),
+        suffix_representation_bridge_centered_error_before=before_error,
+    )
+    if before_error == 0.0 or not bool(torch.count_nonzero(structural).item()):
+        metrics.update(
+            suffix_representation_bridge_reason="structural_overlap_already_matched",
+            suffix_representation_bridge_centered_error_after=before_error,
+            suffix_representation_bridge_centered_error_ratio=1.0,
+        )
+        return learned_clean_video, metrics
+
+    corrected = learned_clean_video.clone()
+    corrected[:, :, prefix_t].add_(structural.to(dtype=corrected.dtype))
+    if not bool(torch.isfinite(corrected).all().item()):
+        raise RuntimeError("representation bridge produced NaN or Inf")
+    if not torch.equal(corrected[:, :, :prefix_t], learned_clean_video[:, :, :prefix_t]):
+        raise RuntimeError("representation bridge modified prefix values")
+    if not torch.equal(corrected[:, :, prefix_t + 1 :], learned_clean_video[:, :, prefix_t + 1 :]):
+        raise RuntimeError("representation bridge modified unmeasured later suffix tokens")
+
+    corrected_transition = corrected[:, :, prefix_t].float() - exact_last
+    corrected_centered = corrected_transition - corrected_transition.mean(dim=(-2, -1), keepdim=True)
+    after_error = _rms(corrected_centered - native_centered)
+    ratio = after_error / max(before_error, 1e-12)
+    metrics.update(
+        suffix_representation_bridge_centered_error_after=after_error,
+        suffix_representation_bridge_centered_error_ratio=ratio,
+    )
+    if not after_error < before_error:
+        metrics.update(suffix_representation_bridge_reason="projection_did_not_reduce_measured_overlap_error")
+        return learned_clean_video, metrics
+
+    metrics.update(
+        suffix_representation_bridge_enabled=True,
+        suffix_representation_bridge_accepted=True,
+        suffix_representation_bridge_reason="exact_overlap_structural_residual_transplanted",
+        suffix_representation_bridge_corrected_tokens=1,
+    )
+    return corrected, metrics

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -24,12 +24,17 @@ from .handoff import (
 )
 from .metrics import H3FlowMetrics
 from .mixed_grid import MIXED_GRID_KEY, build_mixed_grid_plan
+from .representation_bridge import (
+    apply_suffix_representation_bridge,
+    disabled_suffix_representation_bridge_metrics,
+)
 from .seam_diagnostics import (
     measure_exact_prefix_splice,
     measure_video_boundary,
     recover_conditional_clean_for_diagnostics,
 )
 from .sigma import H3_AUDIO_SHIFT, H3_VIDEO_SHIFT, audio_sigma, normalized_coordinate
+from .source_trajectory_bridge import disabled_source_trajectory_bridge_metrics
 from .target_sparse import TARGET_SPARSE_CONTRACT_KEY, build_target_sparse_plan, target_sparse_contract
 from .tone_bridge import (
     apply_suffix_dc_bridge,
@@ -1359,6 +1364,7 @@ def _run_progressive(
                 noise,
                 source_h=source_h,
                 source_w=source_w,
+                attention_measure=bool(getattr(config, "suffix_geometric_bridge", False)),
             )
             binding.metrics.event(
                 "mixed_grid_plan",
@@ -1378,6 +1384,10 @@ def _run_progressive(
                 suffix_source_grid_rope=True,
                 continuous_temporal_rope=True,
                 low_suffix_real_latent=True,
+                attention_measure_requested=bool(mixed_plan.attention_measure),
+                attention_measure_contract=(
+                    "h3_flow_mixed_grid_attention_measure_v1" if mixed_plan.attention_measure else None
+                ),
             )
         source_shapes = list(target_shapes)
         source_shapes[0] = (*source_shapes[0][:-2], source_h, source_w)
@@ -1530,6 +1540,27 @@ def _run_progressive(
             clean_video[:, :, : mixed_plan.prefix_t] = resize_spatial_5d(
                 mixed_plan.prefix.to(clean_video), source_h, source_w, mode="bicubic"
             )
+            source_bridge_requested = bool(getattr(config, "suffix_geometric_bridge", False))
+            # 00318 exhausted every finite verified source-warp horizon. Shortening
+            # a non-zero warp only moved the compensating corrected->untouched
+            # transition earlier, so this repair family is retired rather than
+            # weakened with a fade or unmeasured extrapolation. The experimental
+            # option now owns only the upstream attention-measure and target-side
+            # exact-overlap reconciliation paths.
+            source_trajectory_metrics = disabled_source_trajectory_bridge_metrics(
+                prefix_t=mixed_plan.prefix_t,
+                requested=source_bridge_requested,
+            )
+            if source_bridge_requested:
+                source_trajectory_metrics["source_trajectory_bridge_reason"] = "retired_source_warp_family"
+            binding.metrics.event(
+                "mixed_grid_source_trajectory_bridge",
+                legacy_option_name="suffix_geometric_bridge",
+                authoritative_source_prefix_modified=False,
+                later_suffix_extrapolated=False,
+                learned_upscaler_input_modified=False,
+                **source_trajectory_metrics,
+            )
             source_x0 = pack_streams((clean_video, clean_audio))[0]
         transfer_started = time.perf_counter()
         transfer_metrics: dict[str, Any] = {}
@@ -1561,24 +1592,43 @@ def _run_progressive(
                 sigma=sigma,
             )
             exact_prefix = mixed_plan.prefix.to(device=learned_clean.device, dtype=learned_clean.dtype)
-            bridge_enabled = bool(getattr(config, "suffix_dc_bridge", False))
-            if bridge_enabled:
-                corrected_clean, bridge_metrics = apply_suffix_dc_bridge(
+            representation_requested = bool(getattr(config, "suffix_geometric_bridge", False))
+            if representation_requested:
+                corrected_clean, representation_metrics = apply_suffix_representation_bridge(
                     learned_clean,
+                    exact_prefix,
+                    requested=True,
+                )
+            else:
+                corrected_clean = learned_clean
+                representation_metrics = disabled_suffix_representation_bridge_metrics(
+                    prefix_t=mixed_plan.prefix_t,
+                    requested=False,
+                )
+
+            dc_enabled = bool(getattr(config, "suffix_dc_bridge", False))
+            if dc_enabled:
+                corrected_clean, bridge_metrics = apply_suffix_dc_bridge(
+                    corrected_clean,
                     exact_prefix,
                     weights=(1.0,),
                 )
+            else:
+                bridge_metrics = disabled_suffix_dc_bridge_metrics(prefix_t=mixed_plan.prefix_t)
+
+            corrected_tokens = max(
+                int(representation_metrics["suffix_representation_bridge_corrected_tokens"]),
+                int(bridge_metrics["suffix_dc_bridge_corrected_tokens"]),
+            )
+            if corrected_tokens:
                 target_video = map_clean_bridge_to_conditional_state(
                     target_video,
                     learned_clean,
                     corrected_clean,
                     sigma=sigma,
                     prefix_t=mixed_plan.prefix_t,
-                    corrected_tokens=int(bridge_metrics["suffix_dc_bridge_corrected_tokens"]),
+                    corrected_tokens=corrected_tokens,
                 )
-            else:
-                corrected_clean = learned_clean
-                bridge_metrics = disabled_suffix_dc_bridge_metrics(prefix_t=mixed_plan.prefix_t)
             splice_diagnostics = measure_exact_prefix_splice(
                 learned_clean,
                 exact_prefix,
@@ -1587,12 +1637,23 @@ def _run_progressive(
             splice_diagnostics["splice_diagnostic_elapsed_ms"] = (time.perf_counter() - diagnostic_started) * 1000.0
             splice_diagnostics["splice_recovery"] = "inverse_conditional_renoise"
             splice_diagnostics["suffix_dc_bridge_state_mapping"] = (
-                "affine_equivalent_pre_renoise" if bridge_enabled else "disabled"
+                "affine_equivalent_pre_renoise" if dc_enabled else "disabled"
+            )
+            splice_diagnostics["suffix_representation_bridge_state_mapping"] = (
+                "affine_equivalent_pre_renoise"
+                if representation_metrics["suffix_representation_bridge_accepted"]
+                else "disabled_or_noop"
             )
             binding.metrics.increment("mixed_grid_splice_diagnostic_runs")
-            del diagnostic_noise, learned_clean, corrected_clean
+            binding.metrics.event(
+                "mixed_grid_representation_bridge",
+                legacy_option_name="suffix_geometric_bridge",
+                authoritative_prefix_modified=False,
+                later_suffix_extrapolated=False,
+                **representation_metrics,
+            )
 
-            if not bridge_enabled:
+            if not corrected_tokens:
                 target_video = target_video.clone()
             target_video[:, :, : mixed_plan.prefix_t] = mixed_plan.prefix.to(target_video)
             target_raw = pack_streams((target_video, target_audio))[0]
@@ -1603,9 +1664,23 @@ def _run_progressive(
                 upscaler_prefix_output_discarded=True,
                 final_original_prefix_restored=True,
                 transfer_mode="learned_3d_suffix",
+                source_trajectory_bridge_requested=source_trajectory_metrics["source_trajectory_bridge_requested"],
+                source_trajectory_bridge_accepted=source_trajectory_metrics["source_trajectory_bridge_accepted"],
+                source_trajectory_bridge_reason=source_trajectory_metrics["source_trajectory_bridge_reason"],
+                source_trajectory_bridge_tokens_corrected=source_trajectory_metrics[
+                    "source_trajectory_bridge_tokens_corrected"
+                ],
+                source_trajectory_axis_authorized=source_trajectory_metrics.get(
+                    "source_trajectory_axis_authorized", [False] * 4
+                ),
+                source_trajectory_residual_reduction_ratio=source_trajectory_metrics.get(
+                    "source_trajectory_residual_reduction_ratio", [None] * 4
+                ),
+                **representation_metrics,
                 **bridge_metrics,
                 **splice_diagnostics,
             )
+            del diagnostic_noise, learned_clean, corrected_clean
         if config.transfer_mode == "learned_3d":
             binding.metrics.event(
                 "handoff_learned_upscale_wall",

--- a/h3_flow_regenerate/source_trajectory_bridge.py
+++ b/h3_flow_regenerate/source_trajectory_bridge.py
@@ -1,0 +1,1194 @@
+"""Source-grid trajectory correction for Mixed-Grid Continuum seams.
+
+The Mixed-Grid low stage can generate a genuine low-resolution suffix whose
+first temporal tokens drift geometrically from the recent protected-prefix
+motion. This module detects that drift on the clean source-grid trajectory and,
+when source evidence and measured temporal evolution are strong enough,
+corrects only the affected early suffix tokens before the learned 3D upscaler.
+
+Transforms use output-to-input sampling coordinates about image centre, in
+latent pixels. The authoritative prefix is never modified. No extra model or
+VAE call is performed.
+"""
+
+from __future__ import annotations
+
+import copy
+import math
+import time
+
+import numpy as np
+import torch
+from torch.nn import functional as F
+
+IDENTITY = (1.0, 1.0, 0.0, 0.0)
+MOTION_BASELINE_TRANSITIONS = 6
+PERSISTENCE_TRANSITIONS = 4
+_SCALE_FLOOR = 0.005
+_TRANSLATION_FLOOR = 0.25
+_MAX_SCALE = math.log(1.03)
+# Source authorization is deliberately multi-gate rather than a transplanted
+# scalar threshold. _motion_residual_candidate already requires the measured
+# residual to clear its estimator floor, improve the registration objective,
+# and stay inside the geometric safety bound. _temporal_profile then requires
+# directly observed safe temporal support, and apply_source_trajectory_bridge
+# finally verifies that the applied warp strictly reduces the measured residual.
+# axis_evidence_score is retained as a diagnostic only.
+
+
+def invert_transform(transform: tuple[float, ...]) -> tuple[float, float, float, float]:
+    sx, sy, tx, ty = (float(value) for value in transform)
+    if not all(math.isfinite(value) for value in (sx, sy, tx, ty)) or min(sx, sy) <= 0:
+        raise ValueError("cannot invert invalid geometric transform")
+    return (1.0 / sx, 1.0 / sy, -tx / sx, -ty / sy)
+
+
+def compose_transform(
+    first: tuple[float, ...],
+    second: tuple[float, ...],
+) -> tuple[float, float, float, float]:
+    sx1, sy1, tx1, ty1 = first
+    sx2, sy2, tx2, ty2 = second
+    return (sx1 * sx2, sy1 * sy2, sx1 * tx2 + tx1, sy1 * ty2 + ty1)
+
+
+def residual_transform(
+    observed: tuple[float, ...],
+    expected: tuple[float, ...],
+) -> tuple[float, float, float, float]:
+    return compose_transform(observed, invert_transform(expected))
+
+
+def _signed_components(transform: tuple[float, ...]) -> tuple[float, float, float, float]:
+    return (math.log(transform[0]), math.log(transform[1]), transform[2], transform[3])
+
+
+def _features(video: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor]:
+    b, c, t, h, w = video.shape
+    features = video.detach().permute(0, 2, 1, 3, 4).reshape(b * t, c, h, w).float()
+    features = F.avg_pool2d(F.pad(features, (2, 2, 2, 2), mode="replicate"), 5, stride=1)
+    ratio = min(1.0, 48.0 / max(h, w))
+    features = F.interpolate(
+        features,
+        size=(round(h * ratio), round(w * ratio)),
+        mode="area",
+    )
+    features = features.cpu()
+    features = features - features.mean((-2, -1), keepdim=True)
+    rms = features.square().mean((-2, -1), keepdim=True).sqrt()
+    return features / rms.clamp_min(1e-4), rms
+
+
+def _errors(reference, moving, transform, original_hw):
+    h, w = original_hw
+    fh, fw = moving.shape[-2:]
+    sx, sy, tx, ty = transform
+    xx = np.clip(
+        sx * (np.arange(fw, dtype=np.float32) - (fw - 1) / 2) + (fw - 1) / 2 + tx * fw / w,
+        0,
+        fw - 1,
+    )
+    yy = np.clip(
+        sy * (np.arange(fh, dtype=np.float32) - (fh - 1) / 2) + (fh - 1) / 2 + ty * fh / h,
+        0,
+        fh - 1,
+    )
+    x0, y0 = xx.astype(np.int64), yy.astype(np.int64)
+    x1, y1 = np.minimum(x0 + 1, fw - 1), np.minimum(y0 + 1, fh - 1)
+    wx, wy = xx - x0, yy - y0
+    top = moving[..., y0[:, None], x0] * (1 - wx) + moving[..., y0[:, None], x1] * wx
+    bottom = moving[..., y1[:, None], x0] * (1 - wx) + moving[..., y1[:, None], x1] * wx
+    warped = top * (1 - wy[:, None]) + bottom * wy[:, None]
+    ref_crop = reference[..., 3:-3, 3:-3]
+    warped_crop = warped[..., 3:-3, 3:-3]
+    ref_crop = ref_crop - ref_crop.mean((-2, -1), keepdims=True)
+    warped_crop = warped_crop - warped_crop.mean((-2, -1), keepdims=True)
+    ref_crop = ref_crop / np.maximum(
+        np.sqrt((ref_crop * ref_crop).mean((-2, -1), keepdims=True)),
+        1e-4,
+    )
+    warped_crop = warped_crop / np.maximum(
+        np.sqrt((warped_crop * warped_crop).mean((-2, -1), keepdims=True)),
+        1e-4,
+    )
+    return np.minimum((ref_crop - warped_crop) ** 2, 4).mean((1, 2, 3))
+
+
+def _fit(a, z, hw):
+    theta = list(IDENTITY)
+    loss = float(_errors(a, z, theta, hw).mean())
+    bounds = (0.06, 0.06, 3.0, 3.0)
+    for scale_step, translation_step in ((0.02, 1.0), (0.01, 0.5), (0.005, 0.25), (0.0025, 0.125)):
+        for _ in range(3):
+            changed = False
+            for axis, step in enumerate((scale_step, scale_step, translation_step, translation_step)):
+                best = theta
+                best_loss = loss
+                for sign in (-1, 1):
+                    candidate = theta.copy()
+                    candidate[axis] += sign * step
+                    if abs(candidate[axis] - IDENTITY[axis]) > bounds[axis] + 1e-8:
+                        continue
+                    value = float(_errors(a, z, candidate, hw).mean())
+                    if value < best_loss - 1e-8:
+                        best = candidate
+                        best_loss = value
+                if best is not theta:
+                    changed = True
+                theta, loss = best, best_loss
+            if not changed:
+                break
+    return tuple(theta), loss
+
+
+def _estimate_registration(
+    reference: torch.Tensor,
+    moving: torch.Tensor,
+    *,
+    comparison: tuple[float, ...] | None = None,
+) -> dict:
+    report = {
+        "accepted": False,
+        "reason": "invalid_geometry",
+        "transform": IDENTITY,
+        "identity_error": None,
+        "aligned_error": None,
+        "improvement": 0.0,
+    }
+    if reference.ndim != 5 or reference.shape != moving.shape or reference.shape[0] != 1:
+        return report
+    hw = tuple(reference.shape[-2:])
+    if min(hw) < 16 or not reference.is_floating_point() or not moving.is_floating_point():
+        report["reason"] = "unsupported_geometry"
+        return report
+    reference = reference[:, :, -3:]
+    moving = moving[:, :, -3:]
+    if not bool(torch.isfinite(reference).all() and torch.isfinite(moving).all()):
+        report["reason"] = "nonfinite_input"
+        return report
+    ref_features, ref_rms = _features(reference)
+    moving_features, moving_rms = _features(moving)
+    informative = (ref_rms > 1e-4) & (moving_rms > 1e-4)
+    if float(informative.float().mean()) < 0.5:
+        report["reason"] = "insufficient_structure"
+        return report
+    grad_x = (ref_features[..., 1:] - ref_features[..., :-1]).square().mean()
+    grad_y = (ref_features[..., 1:, :] - ref_features[..., :-1, :]).square().mean()
+    if min(float(grad_x), float(grad_y)) < 1e-3:
+        report["reason"] = "insufficient_axis_structure"
+        return report
+    ref_np = ref_features.numpy()
+    moving_np = moving_features.numpy()
+    identity = float(_errors(ref_np, moving_np, IDENTITY, hw).mean())
+    theta, error = _fit(ref_np, moving_np, hw)
+    improvement = max(0.0, (identity - error) / max(identity, 1e-8))
+    report.update(
+        transform=theta,
+        identity_error=identity,
+        aligned_error=error,
+        improvement=improvement,
+        paired_tokens=ref_np.shape[0],
+    )
+    if comparison is not None:
+        comparison = tuple(float(value) for value in comparison)
+        comparison_error = float(_errors(ref_np, moving_np, comparison, hw).mean())
+        axis_gains = []
+        for axis in range(4):
+            probe = list(theta)
+            probe[axis] = comparison[axis]
+            axis_gains.append(float(_errors(ref_np, moving_np, probe, hw).mean()) - error)
+        report.update(
+            comparison_transform=comparison,
+            comparison_error=comparison_error,
+            comparison_improvement=max(
+                0.0,
+                (comparison_error - error) / max(comparison_error, 1e-8),
+            ),
+            residual_axis_gains=axis_gains,
+        )
+    report["reason"] = "measured"
+    return report
+
+
+def register_pair(
+    reference: torch.Tensor,
+    moving: torch.Tensor,
+    *,
+    comparison: tuple[float, ...] | None = None,
+) -> dict:
+    report = _estimate_registration(reference, moving, comparison=comparison)
+    if report["reason"] == "measured":
+        report["reason"] = "single_transition_diagnostic"
+    return report
+
+
+def _theil_sen_predict(
+    samples: list[tuple[int, float]],
+    next_index: int,
+) -> tuple[float, float, float, float]:
+    indices = np.asarray([item[0] for item in samples], dtype=np.float64)
+    values = np.asarray([item[1] for item in samples], dtype=np.float64)
+    slopes = [
+        (values[j] - values[i]) / (indices[j] - indices[i])
+        for i in range(len(samples))
+        for j in range(i + 1, len(samples))
+        if indices[j] != indices[i]
+    ]
+    slope = float(np.median(slopes)) if slopes else 0.0
+    intercept = float(np.median(values - slope * indices))
+    predicted = intercept + slope * next_index
+    residuals = values - (intercept + slope * indices)
+    dispersion = float(1.4826 * np.median(np.abs(residuals - np.median(residuals))))
+    return float(predicted), slope, dispersion, intercept
+
+
+def _motion_model(video: torch.Tensor, prefix_t: int) -> dict:
+    p = int(prefix_t)
+    transitions = []
+    start = max(1, p - MOTION_BASELINE_TRANSITIONS)
+    for index in range(start, p):
+        item = register_pair(video[:, :, index - 1 : index], video[:, :, index : index + 1])
+        item["transition_index"] = index
+        transitions.append(item)
+    usable = [
+        item
+        for item in transitions
+        if item.get("aligned_error") is not None
+        and math.isfinite(float(item["aligned_error"]))
+        and item["aligned_error"] <= 0.30
+    ]
+    report = {
+        "transitions": transitions,
+        "usable_transitions": len(usable),
+        "accepted": False,
+        "reason": "insufficient_motion_history",
+        "next_transition_index": p,
+    }
+    if len(usable) < 3 or usable[-1]["transition_index"] - usable[0]["transition_index"] < 2:
+        return report
+    params: list[list[tuple[int, float]]] = [[], [], [], []]
+    for item in usable:
+        index = int(item["transition_index"])
+        sx, sy, tx, ty = item["transform"]
+        values = (math.log(sx), math.log(sy), tx, ty)
+        for axis, value in enumerate(values):
+            params[axis].append((index, value))
+    fits = [_theil_sen_predict(values, p) for values in params]
+    expected = (
+        math.exp(fits[0][0]),
+        math.exp(fits[1][0]),
+        fits[2][0],
+        fits[3][0],
+    )
+    report.update(
+        accepted=True,
+        reason="robust_recent_motion",
+        expected_transform=expected,
+        trend=tuple(item[1] for item in fits),
+        dispersion=tuple(item[2] for item in fits),
+        intercept=tuple(item[3] for item in fits),
+    )
+    return report
+
+
+def _predict_motion_transform(motion: dict, offset: int) -> tuple[float, float, float, float] | None:
+    if not motion.get("accepted"):
+        return None
+    base = motion["expected_transform"]
+    trend = motion["trend"]
+    return (
+        math.exp(math.log(base[0]) + trend[0] * offset),
+        math.exp(math.log(base[1]) + trend[1] * offset),
+        base[2] + trend[2] * offset,
+        base[3] + trend[3] * offset,
+    )
+
+
+def _motion_residual_candidate(boundary: dict, motion: dict, hw) -> dict:
+    report = {
+        "accepted": False,
+        "provisional": False,
+        "reason": "motion_model_unavailable",
+        "transform": IDENTITY,
+        "axis_applied": [False] * 4,
+        "axis_evidence_score": [0.0] * 4,
+    }
+    if not motion.get("accepted") or boundary.get("aligned_error") is None:
+        return report
+    expected = motion["expected_transform"]
+    observed = boundary["transform"]
+    correction = residual_transform(observed, expected)
+    comparison_error = boundary.get("comparison_error")
+    if (
+        comparison_error is None
+        or boundary["aligned_error"] > 0.25
+        or comparison_error <= boundary["aligned_error"] + 1e-12
+    ):
+        report.update(reason="boundary_alignment_unusable", raw_transform=correction)
+        return report
+
+    dispersions = tuple(float(value) for value in motion["dispersion"])
+    axis_gains = tuple(float(value) for value in boundary.get("residual_axis_gains", [0.0] * 4))
+    h, w = hw
+    signed = _signed_components(correction)
+    magnitudes = tuple(abs(value) for value in signed)
+    floors = (_SCALE_FLOOR, _SCALE_FLOOR, _TRANSLATION_FLOOR, _TRANSLATION_FLOOR)
+    evidence_units = tuple(max(floors[index], dispersions[index]) for index in range(4))
+    evidence_scores = tuple(magnitudes[index] / evidence_units[index] for index in range(4))
+    gain_floor = max(1e-4, 0.002 * comparison_error)
+    safety = (_MAX_SCALE, _MAX_SCALE, min(1.5, w * 0.025), min(1.5, h * 0.025))
+    axis_applied = [
+        magnitudes[index] >= floors[index]
+        and axis_gains[index] >= gain_floor
+        and magnitudes[index] <= safety[index] + 1e-8
+        for index in range(4)
+    ]
+    applied = (
+        correction[0] if axis_applied[0] else 1.0,
+        correction[1] if axis_applied[1] else 1.0,
+        correction[2] if axis_applied[2] else 0.0,
+        correction[3] if axis_applied[3] else 0.0,
+    )
+    report.update(
+        raw_transform=correction,
+        raw_signed_residual=signed,
+        transform=applied,
+        axis_applied=axis_applied,
+        axis_magnitude=magnitudes,
+        axis_estimator_floor=floors,
+        axis_safety_bound=safety,
+        axis_motion_dispersion=dispersions,
+        axis_evidence_unit=evidence_units,
+        axis_evidence_score=evidence_scores,
+        axis_objective_gain=axis_gains,
+        axis_objective_gain_floor=gain_floor,
+    )
+    if not any(axis_applied):
+        report["reason"] = "motion_residual_not_provisional"
+        return report
+    report.update(
+        accepted=True,
+        provisional=True,
+        reason="provisional_motion_residual",
+    )
+    return report
+
+
+def _temporal_axis_state(
+    boundary_signed_residual: float,
+    followup_signed_residuals: list[float],
+    *,
+    estimator_floor: float,
+    suffix_length: int,
+    safety_limit: float | None = None,
+) -> dict:
+    boundary = float(boundary_signed_residual)
+    floor = float(estimator_floor)
+    report = {
+        "accepted": False,
+        "mode": "ambiguous",
+        "reason": "invalid_temporal_state",
+        "boundary_signed_residual": boundary,
+        "followup_signed_residuals": [float(value) for value in followup_signed_residuals],
+        "cumulative_signed_state": [],
+        "normalized_raw_envelope": [],
+        "monotonic_envelope": [],
+        "estimator_floor": floor,
+        "recovery_suffix_token": None,
+        "active_tokens": 0,
+        "applied_envelope": {"kind": "none", "active_tokens": 0},
+    }
+    if suffix_length < 1 or floor <= 0 or not math.isfinite(boundary) or abs(boundary) < floor:
+        return report
+    if any(not math.isfinite(float(value)) for value in followup_signed_residuals):
+        report["reason"] = "nonfinite_followup_residual"
+        return report
+
+    states = [boundary]
+    for residual in followup_signed_residuals:
+        states.append(states[-1] + float(residual))
+
+    raw = [1.0]
+    recovery_index = None
+    best_abs = abs(boundary)
+    recovery_unsafe = False
+    for index, state in enumerate(states[1:], start=1):
+        if recovery_index is not None:
+            raw.append(0.0)
+            continue
+        if state * boundary <= 0 or abs(state) <= floor:
+            recovery_index = index
+            raw.append(0.0)
+            continue
+        state_abs = abs(state)
+        if state_abs > best_abs + floor:
+            recovery_unsafe = True
+        best_abs = min(best_abs, state_abs)
+        raw.append(max(0.0, min(1.0, state / boundary)))
+
+    monotonic = [raw[0]]
+    for value in raw[1:]:
+        monotonic.append(min(monotonic[-1], value))
+    report.update(
+        cumulative_signed_state=states,
+        normalized_raw_envelope=raw,
+        monotonic_envelope=monotonic,
+        recovery_suffix_token=recovery_index,
+    )
+
+    if recovery_index is not None and not recovery_unsafe:
+        weights = monotonic[: recovery_index + 1]
+        active_tokens = min(
+            suffix_length,
+            max(
+                (index + 1 for index, weight in enumerate(weights) if weight > 0.0),
+                default=0,
+            ),
+        )
+        report.update(
+            accepted=True,
+            mode="recovering",
+            reason="observed_recovery",
+            active_tokens=active_tokens,
+            applied_envelope={
+                "kind": "measured_monotonic",
+                "weights": weights,
+                "active_tokens": active_tokens,
+                "terminal_zero_observed": True,
+            },
+        )
+        return report
+
+    if len(followup_signed_residuals) < 2:
+        report["reason"] = "insufficient_temporal_evidence"
+        return report
+
+    if all(abs(state - boundary) <= floor for state in states[1:]):
+        observed_tokens = min(suffix_length, len(followup_signed_residuals) + 1)
+        if observed_tokens < suffix_length:
+            report.update(
+                mode="persistent",
+                reason="persistent_state_without_observed_recovery",
+                active_tokens=0,
+                applied_envelope={
+                    "kind": "none",
+                    "active_tokens": 0,
+                    "measured_tokens_available": observed_tokens,
+                    "measured_followup_transitions": len(followup_signed_residuals),
+                    "terminal_recovery_observed": False,
+                    "extrapolated_beyond_observation": False,
+                },
+            )
+            return report
+        report.update(
+            accepted=True,
+            mode="persistent",
+            reason="persistent_state_observed_through_suffix_end",
+            active_tokens=observed_tokens,
+            applied_envelope={
+                "kind": "constant",
+                "value": 1.0,
+                "active_tokens": observed_tokens,
+                "measured_followup_transitions": len(followup_signed_residuals),
+                "terminal_recovery_observed": False,
+                "extrapolated_beyond_observation": False,
+            },
+        )
+        return report
+
+    same_direction = all(
+        float(residual) * boundary >= 0 or abs(float(residual)) <= floor for residual in followup_signed_residuals
+    )
+    same_side = all(state * boundary > 0 and abs(state) > floor for state in states[1:])
+    if same_direction and same_side:
+        observed_tokens = min(suffix_length, len(states))
+        measured_states = states[:observed_tokens]
+        safe_tokens = observed_tokens
+        if safety_limit is not None:
+            limit = float(safety_limit)
+            if not math.isfinite(limit) or limit <= 0:
+                report["reason"] = "invalid_axis_safety_limit"
+                return report
+            safe_tokens = 0
+            for state in measured_states:
+                if abs(float(state)) > limit + 1e-8:
+                    break
+                safe_tokens += 1
+            if safe_tokens <= 0:
+                report["reason"] = "measured_drift_exceeds_safety_at_boundary"
+                return report
+        else:
+            limit = None
+        signed_states = measured_states[:safe_tokens]
+        report.update(
+            accepted=True,
+            mode="measured_drift",
+            reason=(
+                "observed_same_direction_cumulative_drift_safety_limited"
+                if safe_tokens < observed_tokens
+                else "observed_same_direction_cumulative_drift"
+            ),
+            active_tokens=safe_tokens,
+            applied_envelope={
+                "kind": "measured_cumulative",
+                "signed_states": signed_states,
+                "active_tokens": safe_tokens,
+                "measured_tokens_available": observed_tokens,
+                "measured_followup_transitions": len(followup_signed_residuals),
+                "safety_limit": limit,
+                "safety_limited": safe_tokens < observed_tokens,
+                "extrapolated_beyond_observation": False,
+            },
+        )
+        return report
+
+    if recovery_index is not None and recovery_unsafe:
+        report["reason"] = "recovery_after_unresolved_excursion"
+    else:
+        report["reason"] = "unresolved_temporal_drift"
+    return report
+
+
+def _temporal_profile(video: torch.Tensor, prefix_t: int, motion: dict, candidate: dict) -> dict:
+    report = {
+        "accepted": False,
+        "reason": "candidate_unavailable",
+        "transitions": [],
+        "usable_transitions": 0,
+        "contiguous_usable_transitions": 0,
+        "axis_accepted": [False] * 4,
+        "axis_mode": ["inactive"] * 4,
+        "axis": [],
+    }
+    if not candidate.get("accepted") or not motion.get("accepted"):
+        return report
+    available = int(video.shape[2]) - prefix_t - 1
+    if available < 1:
+        report["reason"] = "insufficient_suffix_temporal_evidence"
+        return report
+
+    transitions = []
+    contiguous = []
+    contiguous_open = True
+    usable_count = 0
+    for offset in range(min(PERSISTENCE_TRANSITIONS, available)):
+        expected = _predict_motion_transform(motion, offset + 1)
+        index = prefix_t + offset
+        item = register_pair(
+            video[:, :, index : index + 1],
+            video[:, :, index + 1 : index + 2],
+            comparison=expected,
+        )
+        item["suffix_transition_offset"] = offset + 1
+        usable = (
+            item.get("aligned_error") is not None
+            and math.isfinite(float(item["aligned_error"]))
+            and item["aligned_error"] <= 0.30
+        )
+        if usable:
+            item["motion_residual_transform"] = residual_transform(item["transform"], expected)
+            item["motion_residual_signed"] = _signed_components(item["motion_residual_transform"])
+            usable_count += 1
+        item["temporal_state_usable"] = usable
+        if contiguous_open and usable:
+            contiguous.append(item)
+        elif not usable:
+            contiguous_open = False
+        transitions.append(item)
+
+    floors = candidate["axis_estimator_floor"]
+    safety = candidate.get("axis_safety_bound")
+    boundary_signed = candidate["raw_signed_residual"]
+    scores = candidate["axis_evidence_score"]
+    suffix_length = int(video.shape[2]) - prefix_t
+    axis_reports = []
+    axis_accepted = []
+    axis_modes = []
+    for axis in range(4):
+        provisional = bool(candidate["axis_applied"][axis])
+        evidence = float(scores[axis])
+        # Do not gate a source-only measurement with the old two-domain
+        # quadrature threshold. Reaching this point already means the axis
+        # cleared the estimator floor, objective-gain floor, and safety bound.
+        # The measured temporal state below is the independent authorization
+        # evidence for whether that provisional residual is safe to correct.
+        selected = provisional
+        if not selected:
+            axis_reports.append(
+                {
+                    "selected": False,
+                    "accepted": False,
+                    "mode": "inactive",
+                    "reason": "axis_not_provisional",
+                    "source_evidence_score": evidence,
+                    "source_evidence_gate": "diagnostic_only",
+                }
+            )
+            axis_accepted.append(False)
+            axis_modes.append("inactive")
+            continue
+
+        values = [float(item["motion_residual_signed"][axis]) for item in contiguous]
+        axis_report = _temporal_axis_state(
+            float(boundary_signed[axis]),
+            values,
+            estimator_floor=float(floors[axis]),
+            suffix_length=suffix_length,
+            safety_limit=float(safety[axis]) if safety is not None else None,
+        )
+        axis_report.update(
+            selected=True,
+            source_evidence_score=evidence,
+            source_evidence_gate="diagnostic_only",
+        )
+        if len(contiguous) < len(transitions) and not axis_report.get("accepted"):
+            axis_report["reason"] = "noncontiguous_temporal_evidence"
+        axis_reports.append(axis_report)
+        axis_accepted.append(bool(axis_report["accepted"]))
+        axis_modes.append(axis_report["mode"])
+
+    report.update(
+        transitions=transitions,
+        usable_transitions=usable_count,
+        contiguous_usable_transitions=len(contiguous),
+        axis=axis_reports,
+        axis_accepted=axis_accepted,
+        axis_mode=axis_modes,
+    )
+    if not any(axis_accepted):
+        report["reason"] = "no_source_axis_temporally_authorized"
+        return report
+    report.update(accepted=True, reason="source_evidence_and_temporal_state_authorized")
+    return report
+
+
+def _axis_weight(axis_report: dict, token_index: int) -> float:
+    if not axis_report.get("accepted"):
+        return 0.0
+    policy = axis_report.get("applied_envelope", {})
+    if policy.get("kind") == "constant":
+        if token_index < int(policy.get("active_tokens", 0)):
+            return float(policy.get("value", 1.0))
+        return 0.0
+    if policy.get("kind") == "measured_monotonic":
+        weights = policy.get("weights", [])
+        if token_index < len(weights):
+            return float(weights[token_index])
+    return 0.0
+
+
+def _axis_signed_component(
+    axis_report: dict,
+    token_index: int,
+    base_component: float,
+) -> float:
+    if not axis_report.get("accepted"):
+        return 0.0
+    policy = axis_report.get("applied_envelope", {})
+    if policy.get("kind") == "measured_cumulative":
+        states = policy.get("signed_states", [])
+        if token_index < len(states):
+            return float(states[token_index])
+        return 0.0
+    return _axis_weight(axis_report, token_index) * float(base_component)
+
+
+def _effective_transform(
+    base_transform: tuple[float, ...],
+    axis_reports: list[dict],
+    token_index: int,
+) -> tuple[float, float, float, float]:
+    base_signed = _signed_components(base_transform)
+    components = [_axis_signed_component(axis_reports[axis], token_index, base_signed[axis]) for axis in range(4)]
+    return (
+        math.exp(components[0]),
+        math.exp(components[1]),
+        components[2],
+        components[3],
+    )
+
+
+def _warp_suffix(
+    video: torch.Tensor,
+    prefix_t: int,
+    base_transform: tuple[float, ...],
+    profile: dict,
+) -> tuple[torch.Tensor, dict]:
+    suffix = video[:, :, prefix_t:]
+    axis_reports = profile["axis"]
+    active_t = max(
+        (int(axis.get("active_tokens", 0)) for axis in axis_reports if axis.get("accepted")),
+        default=0,
+    )
+    active_t = min(active_t, int(suffix.shape[2]))
+    metadata = {
+        "tokens_corrected": 0,
+        "effective_active_temporal_length": 0,
+        "applied_transforms": [],
+        "applied_transform_sequence_length": 0,
+        "applied_transforms_compact": False,
+        "out_of_bounds_fraction": 0.0,
+    }
+    if active_t <= 0:
+        return video, metadata
+
+    transforms = [_effective_transform(base_transform, axis_reports, token) for token in range(active_t)]
+    non_identity = [token for token, transform in enumerate(transforms) if transform != IDENTITY]
+    if not non_identity:
+        return video, metadata
+    active_t = non_identity[-1] + 1
+    transforms = transforms[:active_t]
+
+    corrected = video.clone()
+    b, c, _, h, w = suffix.shape
+    active = suffix[:, :, :active_t]
+    flat = active.permute(0, 2, 1, 3, 4).reshape(b * active_t, c, h, w)
+    with torch.autocast(device_type=video.device.type, enabled=False):
+        theta = torch.zeros((active_t, 2, 3), device=video.device, dtype=torch.float32)
+        for token, (sx, sy, tx, ty) in enumerate(transforms):
+            theta[token, 0, 0] = sx
+            theta[token, 0, 2] = 2.0 * tx / w
+            theta[token, 1, 1] = sy
+            theta[token, 1, 2] = 2.0 * ty / h
+        theta = theta.repeat(b, 1, 1)
+        grid = F.affine_grid(theta, flat.shape, align_corners=False)
+        warped = F.grid_sample(
+            flat.float(),
+            grid,
+            mode="bilinear",
+            padding_mode="border",
+            align_corners=False,
+        ).to(video.dtype)
+        outside = (grid[..., 0].abs() > 1.0) | (grid[..., 1].abs() > 1.0)
+        out_of_bounds = float(outside.float().mean())
+    corrected[:, :, prefix_t : prefix_t + active_t] = warped.reshape(b, active_t, c, h, w).permute(
+        0,
+        2,
+        1,
+        3,
+        4,
+    )
+    same_transform = all(transform == transforms[0] for transform in transforms[1:])
+    metadata.update(
+        tokens_corrected=active_t,
+        effective_active_temporal_length=active_t,
+        applied_transforms=[transforms[0]] if same_transform else transforms,
+        applied_transform_sequence_length=active_t,
+        applied_transforms_compact=bool(same_transform and active_t > 1),
+        out_of_bounds_fraction=out_of_bounds,
+    )
+    return corrected, metadata
+
+
+def _profile_with_axis_limits(
+    profile: dict,
+    axis_mask: list[bool],
+    active_limits: list[int],
+) -> dict:
+    """Return a profile view with only selected axes and verified temporal horizons."""
+    masked = copy.deepcopy(profile)
+    selected = [bool(value) for value in axis_mask]
+    limits = [max(0, int(value)) for value in active_limits]
+    for axis, keep in enumerate(selected):
+        if axis >= len(masked.get("axis", [])):
+            selected[axis] = False
+            continue
+        axis_report = masked["axis"][axis]
+        if not keep:
+            axis_report["accepted"] = False
+            continue
+        original_active = int(axis_report.get("active_tokens", 0))
+        limit = min(original_active, limits[axis])
+        if limit <= 0:
+            axis_report["accepted"] = False
+            selected[axis] = False
+            continue
+        axis_report["active_tokens"] = limit
+        envelope = axis_report.get("applied_envelope")
+        if isinstance(envelope, dict):
+            envelope["active_tokens"] = limit
+            if envelope.get("kind") == "measured_cumulative":
+                envelope["signed_states"] = list(envelope.get("signed_states", []))[:limit]
+            elif envelope.get("kind") == "measured_monotonic":
+                envelope["weights"] = list(envelope.get("weights", []))[:limit]
+        if limit < original_active:
+            axis_report["verification_horizon_limited"] = True
+            axis_report["verification_horizon_original_tokens"] = original_active
+    masked["axis_accepted"] = selected
+    return masked
+
+
+def _verify_source_warp(
+    video: torch.Tensor,
+    corrected: torch.Tensor,
+    prefix_t: int,
+    motion: dict,
+    candidate: dict,
+    profile: dict,
+    axis_mask: list[bool],
+    warp: dict,
+) -> dict:
+    """Verify each selected axis independently at the boundary and affected transitions."""
+    selected = [bool(value) for value in axis_mask]
+    expected = motion.get("expected_transform") if motion.get("accepted") else None
+    after = register_pair(
+        corrected[:, :, prefix_t - 1 : prefix_t],
+        corrected[:, :, prefix_t : prefix_t + 1],
+        comparison=expected,
+    )
+    before_signed = candidate.get("raw_signed_residual", _signed_components(candidate.get("transform", IDENTITY)))
+    after_signed = None
+    if after.get("aligned_error") is not None and expected is not None:
+        after_signed = _signed_components(residual_transform(after["transform"], expected))
+
+    floors = candidate.get(
+        "axis_estimator_floor",
+        (_SCALE_FLOOR, _SCALE_FLOOR, _TRANSLATION_FLOOR, _TRANSLATION_FLOOR),
+    )
+    axis_verified = [False] * 4
+    boundary_axis_verified = [None] * 4
+    reductions = [None] * 4
+    for axis in range(4):
+        if not selected[axis]:
+            continue
+        if after_signed is None:
+            boundary_axis_verified[axis] = False
+            continue
+        before_value = float(before_signed[axis])
+        after_value = float(after_signed[axis])
+        before_abs = abs(before_value)
+        after_abs = abs(after_value)
+        reductions[axis] = after_abs / max(before_abs, 1e-12)
+        ok = after_abs < before_abs
+        if after_value * before_value < 0 and after_abs > float(floors[axis]):
+            ok = False
+        boundary_axis_verified[axis] = ok
+        axis_verified[axis] = ok
+
+    transition_verification = []
+    active = int(warp.get("tokens_corrected", 0))
+    suffix_length = int(video.shape[2]) - int(prefix_t)
+    max_transition_offset = min(active, max(0, suffix_length - 1))
+    base_signed = _signed_components(candidate.get("transform", IDENTITY))
+    for offset in range(1, max_transition_offset + 1):
+        affected_axes = []
+        for axis in range(4):
+            if not selected[axis]:
+                continue
+            axis_report = profile["axis"][axis]
+            previous_component = _axis_signed_component(axis_report, offset - 1, base_signed[axis])
+            current_component = _axis_signed_component(axis_report, offset, base_signed[axis])
+            if abs(previous_component) > 1e-12 or abs(current_component) > 1e-12:
+                affected_axes.append(axis)
+        if not affected_axes:
+            continue
+
+        expected_transition = _predict_motion_transform(motion, offset)
+        item_report = {
+            "suffix_transition_offset": offset,
+            "before_signed_residual": None,
+            "after_signed_residual": None,
+            "axis_reduction_ratio": [None] * 4,
+            "axis_verified": [None] * 4,
+            "verified": True,
+        }
+        if expected_transition is None:
+            for axis in affected_axes:
+                axis_verified[axis] = False
+                item_report["axis_verified"][axis] = False
+            item_report["verified"] = False
+            transition_verification.append(item_report)
+            continue
+
+        before_transition_signed = None
+        stored = profile.get("transitions", [])
+        if offset - 1 < len(stored):
+            before_transition_signed = stored[offset - 1].get("motion_residual_signed")
+        if before_transition_signed is None:
+            before_item = register_pair(
+                video[:, :, prefix_t + offset - 1 : prefix_t + offset],
+                video[:, :, prefix_t + offset : prefix_t + offset + 1],
+                comparison=expected_transition,
+            )
+            if before_item.get("aligned_error") is not None:
+                before_transition_signed = _signed_components(
+                    residual_transform(before_item["transform"], expected_transition)
+                )
+
+        after_item = register_pair(
+            corrected[:, :, prefix_t + offset - 1 : prefix_t + offset],
+            corrected[:, :, prefix_t + offset : prefix_t + offset + 1],
+            comparison=expected_transition,
+        )
+        after_transition_signed = None
+        if after_item.get("aligned_error") is not None:
+            after_transition_signed = _signed_components(
+                residual_transform(after_item["transform"], expected_transition)
+            )
+        item_report["before_signed_residual"] = before_transition_signed
+        item_report["after_signed_residual"] = after_transition_signed
+
+        if before_transition_signed is None or after_transition_signed is None:
+            for axis in affected_axes:
+                axis_verified[axis] = False
+                item_report["axis_verified"][axis] = False
+            item_report["verified"] = False
+            transition_verification.append(item_report)
+            continue
+
+        for axis in affected_axes:
+            before_value = float(before_transition_signed[axis])
+            after_value = float(after_transition_signed[axis])
+            before_abs = abs(before_value)
+            after_abs = abs(after_value)
+            item_report["axis_reduction_ratio"][axis] = after_abs / max(before_abs, 1e-12)
+            ok = after_abs < before_abs if before_abs > float(floors[axis]) else after_abs <= float(floors[axis])
+            if after_value * before_value < 0 and after_abs > float(floors[axis]):
+                ok = False
+            item_report["axis_verified"][axis] = ok
+            if not ok:
+                axis_verified[axis] = False
+                item_report["verified"] = False
+        transition_verification.append(item_report)
+
+    ok = any(selected) and all(axis_verified[axis] for axis in range(4) if selected[axis])
+    return {
+        "ok": ok,
+        "axis_verified": axis_verified,
+        "boundary_axis_verified": boundary_axis_verified,
+        "boundary_after": after,
+        "post_signed_residual": after_signed,
+        "residual_reduction_ratio": reductions,
+        "transition_verification": transition_verification,
+    }
+
+
+def disabled_source_trajectory_bridge_metrics(*, prefix_t: int, requested: bool = False) -> dict:
+    p = int(prefix_t)
+    if p < 1:
+        raise ValueError("source trajectory bridge prefix length must be positive")
+    return {
+        "source_trajectory_bridge_version": 1,
+        "source_trajectory_bridge_requested": bool(requested),
+        "source_trajectory_bridge_enabled": False,
+        "source_trajectory_bridge_accepted": False,
+        "source_trajectory_bridge_reason": "disabled" if not requested else "not_applied",
+        "source_trajectory_bridge_prefix_t": p,
+        "source_trajectory_bridge_tokens_corrected": 0,
+        "source_trajectory_bridge_effective_active_temporal_length": 0,
+        "source_trajectory_bridge_applied_transforms": [],
+        "source_trajectory_bridge_applied_transform_sequence_length": 0,
+        "source_trajectory_bridge_applied_transforms_compact": False,
+        "source_trajectory_bridge_out_of_bounds_fraction": 0.0,
+        "source_trajectory_bridge_minimum_evidence": None,
+        "source_trajectory_bridge_evidence_policy": (
+            "estimator_floor+objective_gain+safety+observed_temporal_state+post_warp_reduction"
+        ),
+    }
+
+
+@torch.no_grad()
+def apply_source_trajectory_bridge(
+    video: torch.Tensor,
+    prefix_t: int,
+    *,
+    requested: bool = True,
+) -> tuple[torch.Tensor, dict]:
+    """Close a measured source-grid boundary residual before learned upscaling."""
+    if not torch.is_tensor(video) or video.ndim != 5 or not video.is_floating_point():
+        raise TypeError("source trajectory bridge expects a floating BxCxTxHxW tensor")
+    p = int(prefix_t)
+    temporal = int(video.shape[2])
+    if not 1 <= p < temporal:
+        raise ValueError("source trajectory bridge requires a non-empty prefix and suffix")
+    if not bool(torch.isfinite(video).all()):
+        raise RuntimeError("source trajectory bridge input contains NaN or Inf")
+    if not isinstance(requested, bool):
+        raise TypeError("source trajectory bridge requested flag must be boolean")
+    if not requested:
+        return video, disabled_source_trajectory_bridge_metrics(prefix_t=p)
+    if p < 3 or p >= temporal - 1:
+        metrics = disabled_source_trajectory_bridge_metrics(prefix_t=p, requested=True)
+        metrics["source_trajectory_bridge_reason"] = "insufficient_source_motion_window"
+        return video, metrics
+
+    started = time.perf_counter()
+    motion = _motion_model(video, p)
+    expected = motion.get("expected_transform") if motion.get("accepted") else None
+    boundary = register_pair(
+        video[:, :, p - 1 : p],
+        video[:, :, p : p + 1],
+        comparison=expected,
+    )
+    candidate = _motion_residual_candidate(boundary, motion, tuple(video.shape[-2:]))
+    profile = _temporal_profile(video, p, motion, candidate)
+    authorized = profile.get("axis_accepted", [False] * 4)
+    candidate_transform = candidate.get("transform", IDENTITY)
+    base_transform = (
+        candidate_transform[0] if authorized[0] else 1.0,
+        candidate_transform[1] if authorized[1] else 1.0,
+        candidate_transform[2] if authorized[2] else 0.0,
+        candidate_transform[3] if authorized[3] else 0.0,
+    )
+    metrics = disabled_source_trajectory_bridge_metrics(prefix_t=p, requested=True)
+    metrics.update(
+        source_trajectory_natural_motion_model=motion,
+        source_trajectory_boundary_before=boundary,
+        source_trajectory_motion_residual=candidate,
+        source_trajectory_temporal_profile=profile,
+        source_trajectory_axis_authorized=authorized,
+        source_trajectory_base_transform=base_transform,
+    )
+    if not motion.get("accepted"):
+        metrics["source_trajectory_bridge_reason"] = motion["reason"]
+        return video, metrics
+    if not candidate.get("accepted"):
+        metrics["source_trajectory_bridge_reason"] = candidate["reason"]
+        return video, metrics
+    if not profile.get("accepted"):
+        metrics["source_trajectory_bridge_reason"] = profile["reason"]
+        return video, metrics
+
+    initial_axis_limits = [
+        int(profile["axis"][axis].get("active_tokens", 0)) if bool(authorized[axis]) else 0 for axis in range(4)
+    ]
+    attempted_axis_limits = list(initial_axis_limits)
+    attempted_axis_mask = [bool(authorized[axis]) and attempted_axis_limits[axis] > 0 for axis in range(4)]
+    verification_rounds = []
+    final_verification = None
+    final_profile = None
+    corrected = video
+    warp = {
+        "tokens_corrected": 0,
+        "effective_active_temporal_length": 0,
+        "applied_transforms": [],
+        "applied_transform_sequence_length": 0,
+        "applied_transforms_compact": False,
+        "out_of_bounds_fraction": 0.0,
+    }
+    accepted = False
+    # Every failed finite-horizon axis gets a chance to retreat by one directly
+    # observed token and is then re-warped/re-verified from the untouched source.
+    # Boundary failures cannot be repaired by shortening and are pruned immediately.
+    max_rounds = 1 + sum(initial_axis_limits)
+    for round_index in range(max_rounds):
+        if not any(attempted_axis_mask):
+            break
+        attempt_profile = _profile_with_axis_limits(profile, attempted_axis_mask, attempted_axis_limits)
+        attempted_axis_mask = [bool(value) for value in attempt_profile.get("axis_accepted", attempted_axis_mask)]
+        if not any(attempted_axis_mask):
+            break
+        base_transform = (
+            candidate_transform[0] if attempted_axis_mask[0] else 1.0,
+            candidate_transform[1] if attempted_axis_mask[1] else 1.0,
+            candidate_transform[2] if attempted_axis_mask[2] else 0.0,
+            candidate_transform[3] if attempted_axis_mask[3] else 0.0,
+        )
+        corrected, warp = _warp_suffix(video, p, base_transform, attempt_profile)
+        if corrected is video:
+            final_profile = attempt_profile
+            break
+        verification = _verify_source_warp(
+            video,
+            corrected,
+            p,
+            motion,
+            candidate,
+            attempt_profile,
+            attempted_axis_mask,
+            warp,
+        )
+        verification_rounds.append(
+            {
+                "round": round_index + 1,
+                "axis_attempted": list(attempted_axis_mask),
+                "axis_active_tokens": list(attempted_axis_limits),
+                "axis_verified": list(verification["axis_verified"]),
+                "tokens_corrected": int(warp["tokens_corrected"]),
+                "residual_reduction_ratio": verification["residual_reduction_ratio"],
+                "transition_count": len(verification["transition_verification"]),
+            }
+        )
+        final_verification = verification
+        final_profile = attempt_profile
+        if verification["ok"]:
+            accepted = True
+            break
+
+        next_mask = list(attempted_axis_mask)
+        next_limits = list(attempted_axis_limits)
+        changed = False
+        boundary_verified = verification.get("boundary_axis_verified", [None] * 4)
+        for axis in range(4):
+            if not attempted_axis_mask[axis] or bool(verification["axis_verified"][axis]):
+                continue
+            if boundary_verified[axis] is True and next_limits[axis] > 1:
+                next_limits[axis] -= 1
+                changed = True
+            else:
+                next_mask[axis] = False
+                next_limits[axis] = 0
+                changed = True
+        if not changed:
+            break
+        attempted_axis_mask = next_mask
+        attempted_axis_limits = next_limits
+
+    final_axis_mask = list(attempted_axis_mask) if accepted else [False] * 4
+    final_axis_limits = list(attempted_axis_limits) if accepted else [0] * 4
+    pruned_axes = [bool(authorized[axis]) and not final_axis_mask[axis] for axis in range(4)]
+    metrics.update(
+        source_trajectory_axis_post_verified=final_axis_mask,
+        source_trajectory_axis_pruned_post_verification=pruned_axes,
+        source_trajectory_axis_active_tokens_authorized=initial_axis_limits,
+        source_trajectory_axis_active_tokens_post_verified=final_axis_limits,
+        source_trajectory_post_verification_rounds=verification_rounds,
+        source_trajectory_base_transform=base_transform,
+    )
+    if final_verification is not None:
+        metrics.update(
+            source_trajectory_boundary_after=final_verification["boundary_after"],
+            source_trajectory_post_signed_residual=final_verification["post_signed_residual"],
+            source_trajectory_residual_reduction_ratio=final_verification["residual_reduction_ratio"],
+            source_trajectory_post_transition_verification=final_verification["transition_verification"],
+            source_trajectory_boundary_axis_verified=final_verification["boundary_axis_verified"],
+            source_trajectory_bridge_tokens_corrected=int(warp["tokens_corrected"]),
+            source_trajectory_bridge_effective_active_temporal_length=int(warp["effective_active_temporal_length"]),
+            source_trajectory_bridge_applied_transforms=warp["applied_transforms"],
+            source_trajectory_bridge_applied_transform_sequence_length=int(warp["applied_transform_sequence_length"]),
+            source_trajectory_bridge_applied_transforms_compact=bool(warp["applied_transforms_compact"]),
+            source_trajectory_bridge_out_of_bounds_fraction=float(warp["out_of_bounds_fraction"]),
+            source_trajectory_bridge_elapsed_ms=(time.perf_counter() - started) * 1000.0,
+        )
+    if not accepted or final_profile is None or corrected is video:
+        if final_verification is not None:
+            metrics.update(
+                source_trajectory_bridge_attempted_tokens_corrected=int(warp["tokens_corrected"]),
+                source_trajectory_bridge_attempted_transforms=warp["applied_transforms"],
+                source_trajectory_bridge_attempted_out_of_bounds_fraction=float(warp["out_of_bounds_fraction"]),
+                source_trajectory_bridge_tokens_corrected=0,
+                source_trajectory_bridge_effective_active_temporal_length=0,
+                source_trajectory_bridge_applied_transforms=[],
+                source_trajectory_bridge_applied_transform_sequence_length=0,
+                source_trajectory_bridge_applied_transforms_compact=False,
+                source_trajectory_bridge_out_of_bounds_fraction=0.0,
+            )
+        metrics["source_trajectory_bridge_reason"] = (
+            "post_warp_residual_verification_failed"
+            if final_verification is not None
+            else "no_nonidentity_source_transform"
+        )
+        return video, metrics
+
+    if not torch.equal(corrected[:, :, :p], video[:, :, :p]):
+        raise RuntimeError("source trajectory bridge modified protected source prefix")
+    active = int(warp["tokens_corrected"])
+    if not torch.equal(corrected[:, :, p + active :], video[:, :, p + active :]):
+        raise RuntimeError("source trajectory bridge modified recovered later suffix")
+
+    metrics.update(
+        source_trajectory_bridge_enabled=True,
+        source_trajectory_bridge_accepted=True,
+        source_trajectory_bridge_reason="source_trajectory_residual_closed_before_upscale",
+    )
+    return corrected, metrics

--- a/h3_flow_regenerate/target_sparse_node.py
+++ b/h3_flow_regenerate/target_sparse_node.py
@@ -66,6 +66,7 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
         handoff_transfer="bicubic",
         learned_upscaler=None,
         suffix_dc_bridge=True,
+        suffix_geometric_bridge=False,
     ):
         if source_mode == "scale":
             progressive = ProgressiveTargetInputConfig(
@@ -75,6 +76,7 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
                 transfer_mode=handoff_transfer,
                 exact_prefix_mode=self.EXACT_PREFIX_MODE,
                 suffix_dc_bridge=bool(suffix_dc_bridge),
+                suffix_geometric_bridge=bool(suffix_geometric_bridge),
                 learned_upscaler=learned_upscaler,
             )
         else:
@@ -87,6 +89,7 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
                 transfer_mode=handoff_transfer,
                 exact_prefix_mode=self.EXACT_PREFIX_MODE,
                 suffix_dc_bridge=bool(suffix_dc_bridge),
+                suffix_geometric_bridge=bool(suffix_geometric_bridge),
                 learned_upscaler=learned_upscaler,
             )
         guidance = GuidanceConfig(
@@ -118,8 +121,11 @@ class H3ProgressiveMixedGridHandoff(H3ProgressiveTargetSparseHandoff):
         "Real low-resolution Continuum suffix generation with original target-grid protected-prefix "
         "conditioning, learned 3D handoff, exact prefix restoration, and fresh target-grid refinement. "
         "Requires an H3 latent-upscaler provider and VDN external-sequence API v2 when VDN is enabled. "
-        "The one-token suffix DC bridge is enabled by default because it removed the validated boundary "
-        "flash while preserving the authoritative prefix bit-exactly."
+        "The validated one-token DC bridge remains enabled by default. The optional legacy-named "
+        "suffix_geometric_bridge now enables an experimental two-stage seam repair: it first attempts to "
+        "close an independently strong, temporally safe geometric residual on the genuine source-grid clean "
+        "trajectory before learned upscaling, and independently reconciles the exact-prefix representation "
+        "splice on the first target-grid suffix token. It remains off by default pending decoded-media validation."
     )
 
     @classmethod
@@ -139,6 +145,22 @@ class H3ProgressiveMixedGridHandoff(H3ProgressiveTargetSparseHandoff):
                     "One-token suffix-only per-channel DC bridge. Uses the discarded learned prefix as "
                     "calibration while keeping the authoritative Continuum prefix bit-exact. Enabled by "
                     "default after matched multi-boundary decoded-media validation removed the handoff flash."
+                ),
+            },
+        )
+        inputs.setdefault("optional", {})["suffix_geometric_bridge"] = (
+            "BOOLEAN",
+            {
+                "default": False,
+                "tooltip": (
+                    "Experimental Mixed-Grid source-trajectory + exact-overlap repair (legacy input name "
+                    "kept for workflow compatibility). Before the learned 3D upscaler it measures the genuine "
+                    "source-grid clean continuation against robust recent prefix motion, requires strong "
+                    "source evidence plus a measured recovering/persistent temporal state, and corrects only "
+                    "the authorized, directly observed early suffix tokens. Independently, the target exact-overlap "
+                    "bridge preserves the upscaler's native prefix→suffix transition while suffix_dc_bridge owns "
+                    "the DC component. No protected-prefix warp, handcrafted fade, extra H3 call, "
+                    "audio/noise/mask/conditioning change, or unmeasured later-suffix correction."
                 ),
             },
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [{ name = "xmarre" }]
 license = "Apache-2.0"
 license-files = ["LICENSE"]
 keywords = ["comfyui", "minimax-h3", "rectified-flow", "video", "audio"]
-dependencies = []
+dependencies = ["numpy>=1.25"]
 
 [project.urls]
 Repository = "https://github.com/xmarre/MiniMax-H3-Flow-Aligned-Regenerate"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "comfyui-minimax-h3-flow-aligned-regenerate"
-version = "0.3.2"
+version = "0.3.3"
 description = "H3-native flow-aligned and progressive-resolution regeneration for ComfyUI"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/test_handoff.py
+++ b/tests/test_handoff.py
@@ -261,3 +261,32 @@ def test_target_input_source_rejects_mixed_expand_shrink_geometry():
 def test_default_scale_maps_motivating_grid_without_odd_padding():
     config = ProgressiveHandoffConfig(target_scale=1.2)
     assert config.resolve_target(40, 54) == (48, 64)
+
+
+def test_suffix_geometric_bridge_legacy_flag_is_boolean_and_mixed_grid_only():
+    provider = FakeLearnedProvider()
+    with pytest.raises(ValueError, match="requires mixed-grid Continuum"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            exact_prefix_mode="target_sparse_lifter",
+            suffix_geometric_bridge=True,
+        )
+    mixed = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=4,
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        suffix_geometric_bridge=True,
+    )
+    assert mixed.suffix_geometric_bridge is True
+    with pytest.raises(TypeError, match="must be boolean"):
+        ProgressiveTargetInputConfig(
+            source_latent_h=4,
+            source_latent_w=4,
+            transfer_mode="learned_3d",
+            learned_upscaler=provider,
+            exact_prefix_mode="mixed_grid_low_suffix",
+            suffix_geometric_bridge=1,
+        )

--- a/tests/test_mixed_grid.py
+++ b/tests/test_mixed_grid.py
@@ -14,6 +14,7 @@ from h3_flow_regenerate.mixed_grid import (
     MixedGridPlan,
     build_mixed_grid_plan,
     carrier_layout,
+    mixed_attention_measure_contract,
     mixed_mod_segments,
     mixed_positions,
 )
@@ -231,6 +232,106 @@ def test_stage_lifetimes_learned_context_and_original_prefix(monkeypatch, fail_s
     assert MIXED_GRID_KEY not in guider.model_options["transformer_options"]
 
 
+def test_retired_source_warp_does_not_modify_learned_upscaler_input(monkeypatch):
+    import sys
+    from types import ModuleType, SimpleNamespace
+
+    from test_handoff import FakeLearnedProvider
+
+    from h3_flow_regenerate.geometry import resize_spatial_5d, unpack_streams
+    from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+    from h3_flow_regenerate.runtime import FlowBinding, _run_progressive
+
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+
+    packed, shapes, mask = inputs(t=9, prefix=6)
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=base),
+        conds={"positive": []},
+    )
+    binding = FlowBinding()
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        suffix_geometric_bridge=True,
+    )
+
+    def execute(noise, latent, sampler, sigmas, call_mask, *args, latent_shapes):
+        stage = guider.model_options["transformer_options"]["h3_flow_stage"]
+        contract = guider.model_options["transformer_options"].get("h3_flow_mixed_grid_v1")
+        if stage != "high":
+            assert contract is not None
+            assert contract["plan"].attention_measure is True
+        if stage == "high":
+            binding.metrics.event("model_call", actual=True)
+            return packed.clone()
+        if stage == "probe":
+            return latent.clone()
+        return latent / (1 - sigmas[-1])
+
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    _run_progressive(
+        execute,
+        guider,
+        binding,
+        config,
+        torch.randn_like(packed),
+        packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        list(shapes),
+    )
+    provider_input = provider.calls[0][0]
+    original_video, _ = unpack_streams(packed, shapes)
+    expected_video = resize_spatial_5d(original_video, 4, 6, mode="bicubic")
+    assert torch.equal(provider_input, expected_video)
+    source_events = [event for event in binding.metrics.events if event.kind == "mixed_grid_source_trajectory_bridge"]
+    assert len(source_events) == 1
+    assert source_events[0].fields["source_trajectory_bridge_reason"] == "retired_source_warp_family"
+    assert source_events[0].fields["source_trajectory_bridge_tokens_corrected"] == 0
+    assert source_events[0].fields["learned_upscaler_input_modified"] is False
+
+
+def test_mixed_attention_measure_contract_00318_geometry():
+    plan = MixedGridPlan(
+        torch.randn(1, 24, 12, 56, 76),
+        62,
+        40,
+        54,
+        attention_measure=True,
+    )
+    contract = mixed_attention_measure_contract(plan, video_start=16261, sequence_rows=56029)
+    assert contract is not None
+    assert plan.target_grid == (28, 38)
+    assert plan.source_grid == (20, 27)
+    assert plan.target_rows == 1064
+    assert plan.source_rows == 540
+    assert contract["sequence_rows"] == 56029
+    assert contract["expected_kv_rows"] == 49741
+    assert contract["prefix_rows_per_frame"] / contract["source_rows_per_frame"] == pytest.approx(1064 / 540)
+    assert contract["exact_prefix_queries_preserved"] is True
+    assert contract["suffix_kv_unchanged"] is True
+
+
+def test_mixed_attention_measure_is_off_by_default():
+    plan = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6)
+    assert mixed_attention_measure_contract(plan, video_start=5, sequence_rows=83) is None
+
+
 def test_native_forward_uses_authoritative_prefix_and_real_suffix(monkeypatch, native):
 
     from h3_flow_regenerate.metrics import H3FlowMetrics
@@ -335,3 +436,17 @@ def test_native_forward_uses_authoritative_prefix_and_real_suffix(monkeypatch, n
     assert torch.equal(seen[0][0][25 : 25 + plan.prefix_rows], expected)
     expected_suffix = model.video_patch_proj(model_module.patchify_video(x[0][:, :, 2:]))
     assert torch.equal(seen[0][0][25 + plan.prefix_rows :], expected_suffix)
+
+
+def test_representation_bridge_ui_is_mixed_grid_only():
+    from h3_flow_regenerate.target_sparse_node import (
+        H3ProgressiveMixedGridHandoff,
+        H3ProgressiveTargetSparseHandoff,
+    )
+
+    sparse = H3ProgressiveTargetSparseHandoff.INPUT_TYPES()
+    assert all("suffix_geometric_bridge" not in group for group in sparse.values())
+    mixed = H3ProgressiveMixedGridHandoff.INPUT_TYPES()
+    assert "suffix_geometric_bridge" in mixed.get("optional", {})
+    spec = mixed["optional"]["suffix_geometric_bridge"]
+    assert spec[1]["default"] is False

--- a/tests/test_representation_bridge.py
+++ b/tests/test_representation_bridge.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from h3_flow_regenerate.representation_bridge import (
+    apply_suffix_representation_bridge,
+    disabled_suffix_representation_bridge_metrics,
+)
+from h3_flow_regenerate.tone_bridge import apply_suffix_dc_bridge
+
+
+def _pair(dtype=torch.float32):
+    torch.manual_seed(91)
+    learned = torch.randn(1, 24, 5, 8, 10, dtype=torch.float32)
+    exact = learned[:, :, :2].clone()
+    yy = torch.linspace(-1, 1, 8).view(1, 1, 1, 8, 1)
+    xx = torch.linspace(-1, 1, 10).view(1, 1, 1, 1, 10)
+    exact = exact + 0.12 + 0.08 * yy - 0.05 * xx
+    return learned.to(dtype), exact.to(dtype)
+
+
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_structure_plus_dc_preserves_upscaler_native_boundary_transition(dtype):
+    learned, exact = _pair(dtype)
+    before = learned.clone()
+    structured, report = apply_suffix_representation_bridge(learned, exact, requested=True)
+    assert report["suffix_representation_bridge_accepted"] is True
+    assert report["suffix_representation_bridge_corrected_tokens"] == 1
+    assert torch.equal(structured[:, :, :2], before[:, :, :2])
+    assert torch.equal(structured[:, :, 3:], before[:, :, 3:])
+
+    combined, dc = apply_suffix_dc_bridge(structured, exact, weights=(1.0,))
+    assert dc["suffix_dc_bridge_corrected_tokens"] == 1
+    native = before[:, :, 2].float() - before[:, :, 1].float()
+    restored = combined[:, :, 2].float() - exact[:, :, 1].float()
+
+    # The algebra is exact in float32. For half/bfloat16 the structural and DC
+    # corrections are each rounded back to the required output dtype. Bound that
+    # unavoidable error by two output-ULPs at the largest participating value;
+    # this checks the implementation contract rather than using a hand-tuned
+    # tolerance that merely happens to pass this fixture.
+    if dtype == torch.float32:
+        assert torch.allclose(restored, native, atol=2e-6, rtol=0)
+    else:
+        scale = torch.maximum(restored.abs(), native.abs()).clamp_min(1.0)
+        quantization_bound = 2.0 * torch.finfo(dtype).eps * scale
+        assert bool(((restored - native).abs() <= quantization_bound).all())
+
+    assert torch.equal(combined[:, :, :2], before[:, :, :2])
+    assert torch.equal(combined[:, :, 3:], before[:, :, 3:])
+
+
+def test_structure_bridge_transfers_zero_mean_residual_only():
+    learned, exact = _pair()
+    corrected, report = apply_suffix_representation_bridge(learned, exact, requested=True)
+    change = corrected[:, :, 2].float() - learned[:, :, 2].float()
+    assert torch.allclose(change.mean(dim=(-2, -1)), torch.zeros_like(change.mean(dim=(-2, -1))), atol=2e-7)
+    assert (
+        report["suffix_representation_bridge_centered_error_after"]
+        < report["suffix_representation_bridge_centered_error_before"]
+    )
+    assert report["suffix_representation_bridge_centered_error_ratio"] < 1e-4
+
+
+def test_bridge_has_no_unmeasured_temporal_fade():
+    learned, exact = _pair()
+    corrected, report = apply_suffix_representation_bridge(learned, exact, requested=True)
+    assert report["suffix_representation_bridge_corrected_tokens"] == 1
+    assert not torch.equal(corrected[:, :, 2], learned[:, :, 2])
+    assert torch.equal(corrected[:, :, 3:], learned[:, :, 3:])
+
+
+def test_disabled_and_already_matched_paths_are_exact_object_noops():
+    learned, exact = _pair()
+    disabled, report = apply_suffix_representation_bridge(learned, exact, requested=False)
+    assert disabled is learned
+    assert report == disabled_suffix_representation_bridge_metrics(prefix_t=2)
+
+    exact_match = learned[:, :, :2].clone()
+    matched, report = apply_suffix_representation_bridge(learned, exact_match, requested=True)
+    assert matched is learned
+    assert report["suffix_representation_bridge_accepted"] is False
+    assert report["suffix_representation_bridge_reason"] == "structural_overlap_already_matched"
+
+
+def test_nonfinite_input_is_rejected():
+    learned, exact = _pair()
+    learned = learned.clone()
+    learned[0, 0, 0, 0, 0] = float("nan")
+    with pytest.raises(RuntimeError, match="NaN or Inf"):
+        apply_suffix_representation_bridge(learned, exact)

--- a/tests/test_source_trajectory_bridge.py
+++ b/tests/test_source_trajectory_bridge.py
@@ -1,0 +1,488 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from torch.nn import functional as F
+
+import h3_flow_regenerate.source_trajectory_bridge as source_bridge
+from h3_flow_regenerate.source_trajectory_bridge import (
+    _effective_transform,
+    _temporal_axis_state,
+    apply_source_trajectory_bridge,
+)
+
+
+def _texture() -> torch.Tensor:
+    torch.manual_seed(77)
+    frame = torch.randn(1, 24, 32, 40)
+    return F.avg_pool2d(F.pad(frame, (2, 2, 2, 2), mode="reflect"), 5, stride=1)
+
+
+def _warp(frame: torch.Tensor, *, sy: float) -> torch.Tensor:
+    b, _c, _h, _w = frame.shape
+    theta = frame.new_tensor([[1.0, 0.0, 0.0], [0.0, sy, 0.0]], dtype=torch.float32)
+    grid = F.affine_grid(theta[None].expand(b, -1, -1), frame.shape, align_corners=False)
+    return F.grid_sample(frame, grid, mode="bilinear", padding_mode="border", align_corners=False)
+
+
+def _recovering_video() -> torch.Tensor:
+    frame = _texture()
+    prefix = [frame.clone() for _ in range(6)]
+    # Registration of the first suffix against an identity-motion prefix is ~0.9775 sy.
+    first_suffix = _warp(frame, sy=1.0 / 0.975)
+    return torch.stack([*prefix, first_suffix, frame.clone(), frame.clone()], dim=2)
+
+
+def test_recovering_source_sy_is_closed_before_upscale_and_tail_is_exact():
+    video = _recovering_video()
+    before = video.clone()
+    corrected, report = apply_source_trajectory_bridge(video, 6, requested=True)
+
+    assert report["source_trajectory_bridge_accepted"] is True
+    assert report["source_trajectory_bridge_reason"] == "source_trajectory_residual_closed_before_upscale"
+    assert report["source_trajectory_axis_authorized"] == [False, True, False, False]
+    assert report["source_trajectory_temporal_profile"]["axis_mode"][1] == "recovering"
+    assert report["source_trajectory_temporal_profile"]["axis"][1]["source_evidence_gate"] == "diagnostic_only"
+    assert report["source_trajectory_bridge_tokens_corrected"] == 1
+    assert report["source_trajectory_residual_reduction_ratio"][1] < 1.0
+    assert torch.equal(corrected[:, :, :6], before[:, :, :6])
+    assert not torch.equal(corrected[:, :, 6:7], before[:, :, 6:7])
+    assert torch.equal(corrected[:, :, 7:], before[:, :, 7:])
+    assert torch.equal(video, before)
+
+
+def test_disabled_bridge_is_exact_object_noop():
+    video = _recovering_video()
+    corrected, report = apply_source_trajectory_bridge(video, 6, requested=False)
+    assert corrected is video
+    assert report["source_trajectory_bridge_accepted"] is False
+    assert report["source_trajectory_bridge_reason"] == "disabled"
+
+
+@pytest.mark.parametrize("prefix_t", [1, 2, 8])
+def test_insufficient_motion_window_fails_safe(prefix_t):
+    video = torch.randn(1, 24, 9, 32, 40)
+    corrected, report = apply_source_trajectory_bridge(video, prefix_t, requested=True)
+    assert corrected is video
+    assert report["source_trajectory_bridge_accepted"] is False
+    assert report["source_trajectory_bridge_reason"] == "insufficient_source_motion_window"
+
+
+def test_estimator_floor_residual_can_be_temporally_authorized_without_cross_domain_gate():
+    # Mirrors the 00288 ty evidence. The boundary residual is exactly one
+    # estimator floor and the first observed follow-up does not move farther
+    # away, so the state is already inside the unresolved/recovered band.
+    # Correct only token 0; do not project a persistent correction.
+    report = _temporal_axis_state(
+        0.25,
+        [0.0, 0.0, -0.125, 0.125],
+        estimator_floor=0.25,
+        suffix_length=8,
+    )
+    assert report["accepted"] is True
+    assert report["mode"] == "recovering"
+    assert report["recovery_suffix_token"] == 1
+    assert report["active_tokens"] == 1
+    assert report["applied_envelope"]["kind"] == "measured_monotonic"
+    assert report["applied_envelope"]["weights"] == [1.0, 0.0]
+    assert report["applied_envelope"]["terminal_zero_observed"] is True
+
+
+def test_same_direction_source_drift_uses_measured_cumulative_state_only():
+    report = _temporal_axis_state(
+        0.010161524669189069,
+        [0.007677082358897666, 0.012664654887307421, 0.020149107614304457, 0.01762725812058288],
+        estimator_floor=0.005,
+        suffix_length=8,
+    )
+    assert report["accepted"] is True
+    assert report["mode"] == "measured_drift"
+    assert report["active_tokens"] == 5
+    envelope = report["applied_envelope"]
+    assert envelope["kind"] == "measured_cumulative"
+    assert envelope["measured_followup_transitions"] == 4
+    assert envelope["extrapolated_beyond_observation"] is False
+    assert envelope["signed_states"] == pytest.approx(report["cumulative_signed_state"])
+
+
+def test_measured_drift_truncates_at_existing_axis_safety_bound():
+    report = _temporal_axis_state(
+        0.026772269063550715,
+        [0.022834929080955513, 0.038891567782737106, 0.04992944577483918, 0.0459608545226586],
+        estimator_floor=0.005,
+        suffix_length=8,
+        safety_limit=float(torch.log(torch.tensor(1.03))),
+    )
+    assert report["accepted"] is True
+    assert report["mode"] == "measured_drift"
+    assert report["reason"] == "observed_same_direction_cumulative_drift_safety_limited"
+    assert report["active_tokens"] == 1
+    envelope = report["applied_envelope"]
+    assert envelope["signed_states"] == pytest.approx([0.026772269063550715])
+    assert envelope["measured_tokens_available"] == 5
+    assert envelope["safety_limited"] is True
+    assert envelope["extrapolated_beyond_observation"] is False
+
+
+def test_measured_cumulative_transform_uses_observed_state_not_scaled_boundary():
+    axis_reports = [
+        {
+            "accepted": True,
+            "mode": "measured_drift",
+            "applied_envelope": {
+                "kind": "measured_cumulative",
+                "signed_states": [0.01, 0.03, 0.06],
+                "active_tokens": 3,
+            },
+        },
+        {"accepted": False},
+        {"accepted": False},
+        {"accepted": False},
+    ]
+    transform = _effective_transform((1.01, 1.0, 0.0, 0.0), axis_reports, 2)
+    assert transform[0] == pytest.approx(torch.exp(torch.tensor(0.06)).item(), rel=1e-6)
+    assert transform[1:] == pytest.approx((1.0, 0.0, 0.0))
+
+
+def test_persistent_source_state_without_observed_recovery_fails_safe():
+    frame = _texture()
+    prefix = [frame.clone() for _ in range(6)]
+    shifted = _warp(frame, sy=1.0 / 0.975)
+    suffix = [shifted.clone() for _ in range(7)]
+    video = torch.stack([*prefix, *suffix], dim=2)
+    before = video.clone()
+    corrected, report = apply_source_trajectory_bridge(video, 6, requested=True)
+    assert report["source_trajectory_bridge_accepted"] is False
+    assert report["source_trajectory_temporal_profile"]["axis_mode"][1] == "persistent"
+    axis = report["source_trajectory_temporal_profile"]["axis"][1]
+    assert axis["reason"] == "persistent_state_without_observed_recovery"
+    assert axis["applied_envelope"]["measured_followup_transitions"] == 4
+    assert axis["applied_envelope"]["extrapolated_beyond_observation"] is False
+    assert corrected is video
+    assert torch.equal(corrected, before)
+
+
+def test_persistent_source_state_observed_through_suffix_end_can_apply():
+    frame = _texture()
+    prefix = [frame.clone() for _ in range(6)]
+    shifted = _warp(frame, sy=1.0 / 0.975)
+    suffix = [shifted.clone() for _ in range(5)]
+    video = torch.stack([*prefix, *suffix], dim=2)
+    before = video.clone()
+    corrected, report = apply_source_trajectory_bridge(video, 6, requested=True)
+    assert report["source_trajectory_bridge_accepted"] is True
+    assert report["source_trajectory_temporal_profile"]["axis_mode"][1] == "persistent"
+    axis = report["source_trajectory_temporal_profile"]["axis"][1]
+    assert axis["reason"] == "persistent_state_observed_through_suffix_end"
+    assert report["source_trajectory_bridge_tokens_corrected"] == 5
+    assert not torch.equal(corrected[:, :, 6:], before[:, :, 6:])
+
+
+def test_one_token_axis_is_verified_at_its_trailing_transition(monkeypatch):
+    video = torch.zeros(1, 24, 6, 8, 8)
+    corrected = video.clone()
+    motion = {"accepted": True, "expected_transform": (1.0, 1.0, 0.0, 0.0)}
+    candidate = {
+        "raw_signed_residual": (0.02, 0.0, 0.0, 0.0),
+        "transform": (float(torch.exp(torch.tensor(0.02))), 1.0, 0.0, 0.0),
+        "axis_estimator_floor": (0.005, 0.005, 0.25, 0.25),
+    }
+    profile = {
+        "axis": [
+            {
+                "accepted": True,
+                "mode": "measured_drift",
+                "active_tokens": 1,
+                "applied_envelope": {
+                    "kind": "measured_cumulative",
+                    "signed_states": [0.02],
+                    "active_tokens": 1,
+                },
+            },
+            {"accepted": False},
+            {"accepted": False},
+            {"accepted": False},
+        ],
+        "transitions": [{"motion_residual_signed": (0.01, 0.0, 0.0, 0.0)}],
+    }
+    results = iter(
+        [
+            {"aligned_error": 0.1, "transform": (float(torch.exp(torch.tensor(0.01))), 1.0, 0.0, 0.0)},
+            {"aligned_error": 0.1, "transform": (float(torch.exp(torch.tensor(0.02))), 1.0, 0.0, 0.0)},
+        ]
+    )
+    monkeypatch.setattr(source_bridge, "register_pair", lambda *args, **kwargs: next(results))
+    monkeypatch.setattr(source_bridge, "_predict_motion_transform", lambda *args, **kwargs: (1.0, 1.0, 0.0, 0.0))
+
+    report = source_bridge._verify_source_warp(
+        video,
+        corrected,
+        3,
+        motion,
+        candidate,
+        profile,
+        [True, False, False, False],
+        {"tokens_corrected": 1},
+    )
+    assert report["ok"] is False
+    assert report["axis_verified"] == [False, False, False, False]
+    assert len(report["transition_verification"]) == 1
+    transition = report["transition_verification"][0]
+    assert transition["suffix_transition_offset"] == 1
+    assert transition["axis_reduction_ratio"][0] == pytest.approx(2.0, rel=1e-4)
+    assert transition["axis_verified"][0] is False
+
+
+def test_failed_axis_is_pruned_and_surviving_axis_is_retried(monkeypatch):
+    video = torch.zeros(1, 24, 7, 8, 8)
+    prefix_t = 3
+    motion = {
+        "accepted": True,
+        "reason": "robust_recent_motion",
+        "expected_transform": (1.0, 1.0, 0.0, 0.0),
+    }
+    boundary = {"aligned_error": 0.1, "transform": (1.0, 1.0, 0.0, 0.0)}
+    candidate = {
+        "accepted": True,
+        "reason": "provisional_motion_residual",
+        "axis_applied": [True, True, False, False],
+        "raw_signed_residual": (0.02, -0.02, 0.0, 0.0),
+        "transform": (float(torch.exp(torch.tensor(0.02))), float(torch.exp(torch.tensor(-0.02))), 0.0, 0.0),
+        "axis_estimator_floor": (0.005, 0.005, 0.25, 0.25),
+    }
+    profile = {
+        "accepted": True,
+        "reason": "source_evidence_and_temporal_state_authorized",
+        "axis_accepted": [True, True, False, False],
+        "axis_mode": ["measured_drift", "measured_drift", "inactive", "inactive"],
+        "axis": [
+            {
+                "accepted": True,
+                "mode": "measured_drift",
+                "active_tokens": 1,
+                "applied_envelope": {"kind": "measured_cumulative", "signed_states": [0.02], "active_tokens": 1},
+            },
+            {
+                "accepted": True,
+                "mode": "measured_drift",
+                "active_tokens": 1,
+                "applied_envelope": {"kind": "measured_cumulative", "signed_states": [-0.02], "active_tokens": 1},
+            },
+            {"accepted": False, "mode": "inactive"},
+            {"accepted": False, "mode": "inactive"},
+        ],
+        "transitions": [],
+    }
+    monkeypatch.setattr(source_bridge, "_motion_model", lambda *args, **kwargs: motion)
+    monkeypatch.setattr(source_bridge, "register_pair", lambda *args, **kwargs: boundary)
+    monkeypatch.setattr(source_bridge, "_motion_residual_candidate", lambda *args, **kwargs: candidate)
+    monkeypatch.setattr(source_bridge, "_temporal_profile", lambda *args, **kwargs: profile)
+
+    def fake_warp(source, p, base_transform, attempt_profile):
+        corrected = source.clone()
+        corrected[:, :, p : p + 1] += 0.001
+        return corrected, {
+            "tokens_corrected": 1,
+            "effective_active_temporal_length": 1,
+            "applied_transforms": [base_transform],
+            "applied_transform_sequence_length": 1,
+            "applied_transforms_compact": False,
+            "out_of_bounds_fraction": 0.0,
+        }
+
+    verification_masks = []
+
+    def fake_verify(source, corrected, p, motion_arg, candidate_arg, attempt_profile, axis_mask, warp):
+        verification_masks.append(list(axis_mask))
+        if axis_mask[0]:
+            verified = [False, True, False, False]
+            ok = False
+        else:
+            verified = [False, True, False, False]
+            ok = True
+        return {
+            "ok": ok,
+            "axis_verified": verified,
+            "boundary_axis_verified": [False, True, None, None],
+            "boundary_after": boundary,
+            "post_signed_residual": (0.02, 0.001, 0.0, 0.0),
+            "residual_reduction_ratio": [None, 0.05, None, None],
+            "transition_verification": [],
+        }
+
+    monkeypatch.setattr(source_bridge, "_warp_suffix", fake_warp)
+    monkeypatch.setattr(source_bridge, "_verify_source_warp", fake_verify)
+
+    corrected, report = source_bridge.apply_source_trajectory_bridge(video, prefix_t, requested=True)
+    assert verification_masks == [[True, True, False, False], [False, True, False, False]]
+    assert report["source_trajectory_bridge_accepted"] is True
+    assert report["source_trajectory_axis_authorized"] == [True, True, False, False]
+    assert report["source_trajectory_axis_post_verified"] == [False, True, False, False]
+    assert report["source_trajectory_axis_pruned_post_verification"] == [True, False, False, False]
+    assert len(report["source_trajectory_post_verification_rounds"]) == 2
+    assert not torch.equal(corrected[:, :, prefix_t : prefix_t + 1], video[:, :, prefix_t : prefix_t + 1])
+    assert torch.equal(corrected[:, :, prefix_t + 1 :], video[:, :, prefix_t + 1 :])
+
+
+def test_failed_trailing_transition_backs_off_axis_horizon_before_pruning(monkeypatch):
+    video = torch.zeros(1, 24, 8, 8, 8)
+    prefix_t = 3
+    motion = {
+        "accepted": True,
+        "reason": "robust_recent_motion",
+        "expected_transform": (1.0, 1.0, 0.0, 0.0),
+    }
+    boundary = {"aligned_error": 0.1, "transform": (1.0, 1.0, 0.0, 0.0)}
+    candidate = {
+        "accepted": True,
+        "reason": "provisional_motion_residual",
+        "axis_applied": [False, False, True, False],
+        "raw_signed_residual": (0.0, 0.0, 0.5, 0.0),
+        "transform": (1.0, 1.0, 0.5, 0.0),
+        "axis_estimator_floor": (0.005, 0.005, 0.25, 0.25),
+    }
+    profile = {
+        "accepted": True,
+        "reason": "source_evidence_and_temporal_state_authorized",
+        "axis_accepted": [False, False, True, False],
+        "axis_mode": ["inactive", "inactive", "measured_drift", "inactive"],
+        "axis": [
+            {"accepted": False, "mode": "inactive"},
+            {"accepted": False, "mode": "inactive"},
+            {
+                "accepted": True,
+                "mode": "measured_drift",
+                "active_tokens": 4,
+                "applied_envelope": {
+                    "kind": "measured_cumulative",
+                    "signed_states": [0.5, 0.6, 0.7, 0.8],
+                    "active_tokens": 4,
+                },
+            },
+            {"accepted": False, "mode": "inactive"},
+        ],
+        "transitions": [],
+    }
+    monkeypatch.setattr(source_bridge, "_motion_model", lambda *args, **kwargs: motion)
+    monkeypatch.setattr(source_bridge, "register_pair", lambda *args, **kwargs: boundary)
+    monkeypatch.setattr(source_bridge, "_motion_residual_candidate", lambda *args, **kwargs: candidate)
+    monkeypatch.setattr(source_bridge, "_temporal_profile", lambda *args, **kwargs: profile)
+
+    seen_limits = []
+
+    def fake_warp(source, p, base_transform, attempt_profile):
+        active = int(attempt_profile["axis"][2]["active_tokens"])
+        seen_limits.append(active)
+        corrected = source.clone()
+        corrected[:, :, p : p + active] += 0.001
+        return corrected, {
+            "tokens_corrected": active,
+            "effective_active_temporal_length": active,
+            "applied_transforms": [base_transform] * active,
+            "applied_transform_sequence_length": active,
+            "applied_transforms_compact": active > 1,
+            "out_of_bounds_fraction": 0.0,
+        }
+
+    def fake_verify(source, corrected, p, motion_arg, candidate_arg, attempt_profile, axis_mask, warp):
+        active = int(attempt_profile["axis"][2]["active_tokens"])
+        ok = active <= 2
+        return {
+            "ok": ok,
+            "axis_verified": [False, False, ok, False],
+            "boundary_axis_verified": [None, None, True, None],
+            "boundary_after": boundary,
+            "post_signed_residual": (0.0, 0.0, 0.1, 0.0),
+            "residual_reduction_ratio": [None, None, 0.2, None],
+            "transition_verification": [],
+        }
+
+    monkeypatch.setattr(source_bridge, "_warp_suffix", fake_warp)
+    monkeypatch.setattr(source_bridge, "_verify_source_warp", fake_verify)
+
+    corrected, report = source_bridge.apply_source_trajectory_bridge(video, prefix_t, requested=True)
+    assert seen_limits == [4, 3, 2]
+    assert report["source_trajectory_bridge_accepted"] is True
+    assert report["source_trajectory_axis_active_tokens_authorized"] == [0, 0, 4, 0]
+    assert report["source_trajectory_axis_active_tokens_post_verified"] == [0, 0, 2, 0]
+    assert report["source_trajectory_axis_post_verified"] == [False, False, True, False]
+    assert [item["axis_active_tokens"] for item in report["source_trajectory_post_verification_rounds"]] == [
+        [0, 0, 4, 0],
+        [0, 0, 3, 0],
+        [0, 0, 2, 0],
+    ]
+    assert torch.equal(corrected[:, :, :prefix_t], video[:, :, :prefix_t])
+    assert not torch.equal(corrected[:, :, prefix_t : prefix_t + 2], video[:, :, prefix_t : prefix_t + 2])
+    assert torch.equal(corrected[:, :, prefix_t + 2 :], video[:, :, prefix_t + 2 :])
+
+
+def test_rejected_source_attempt_reports_zero_applied_tokens(monkeypatch):
+    video = torch.zeros(1, 24, 6, 8, 8)
+    prefix_t = 3
+    motion = {"accepted": True, "reason": "robust_recent_motion", "expected_transform": (1.0, 1.0, 0.0, 0.0)}
+    boundary = {"aligned_error": 0.1, "transform": (1.0, 1.0, 0.0, 0.0)}
+    candidate = {
+        "accepted": True,
+        "reason": "provisional_motion_residual",
+        "axis_applied": [True, False, False, False],
+        "raw_signed_residual": (0.02, 0.0, 0.0, 0.0),
+        "transform": (float(torch.exp(torch.tensor(0.02))), 1.0, 0.0, 0.0),
+        "axis_estimator_floor": (0.005, 0.005, 0.25, 0.25),
+    }
+    profile = {
+        "accepted": True,
+        "reason": "source_evidence_and_temporal_state_authorized",
+        "axis_accepted": [True, False, False, False],
+        "axis_mode": ["measured_drift", "inactive", "inactive", "inactive"],
+        "axis": [
+            {
+                "accepted": True,
+                "mode": "measured_drift",
+                "active_tokens": 1,
+                "applied_envelope": {"kind": "measured_cumulative", "signed_states": [0.02], "active_tokens": 1},
+            },
+            {"accepted": False},
+            {"accepted": False},
+            {"accepted": False},
+        ],
+        "transitions": [],
+    }
+    monkeypatch.setattr(source_bridge, "_motion_model", lambda *args, **kwargs: motion)
+    monkeypatch.setattr(source_bridge, "register_pair", lambda *args, **kwargs: boundary)
+    monkeypatch.setattr(source_bridge, "_motion_residual_candidate", lambda *args, **kwargs: candidate)
+    monkeypatch.setattr(source_bridge, "_temporal_profile", lambda *args, **kwargs: profile)
+
+    def fake_warp(source, p, base_transform, attempt_profile):
+        corrected = source.clone()
+        corrected[:, :, p : p + 1] += 0.001
+        return corrected, {
+            "tokens_corrected": 1,
+            "effective_active_temporal_length": 1,
+            "applied_transforms": [base_transform],
+            "applied_transform_sequence_length": 1,
+            "applied_transforms_compact": False,
+            "out_of_bounds_fraction": 0.01,
+        }
+
+    monkeypatch.setattr(source_bridge, "_warp_suffix", fake_warp)
+    monkeypatch.setattr(
+        source_bridge,
+        "_verify_source_warp",
+        lambda *args, **kwargs: {
+            "ok": False,
+            "axis_verified": [False, False, False, False],
+            "boundary_axis_verified": [False, None, None, None],
+            "boundary_after": boundary,
+            "post_signed_residual": (0.03, 0.0, 0.0, 0.0),
+            "residual_reduction_ratio": [1.5, None, None, None],
+            "transition_verification": [],
+        },
+    )
+
+    corrected, report = source_bridge.apply_source_trajectory_bridge(video, prefix_t, requested=True)
+    assert corrected is video
+    assert report["source_trajectory_bridge_accepted"] is False
+    assert report["source_trajectory_bridge_attempted_tokens_corrected"] == 1
+    assert report["source_trajectory_bridge_tokens_corrected"] == 0
+    assert report["source_trajectory_bridge_applied_transforms"] == []
+    assert report["source_trajectory_bridge_out_of_bounds_fraction"] == 0.0


### PR DESCRIPTION
## Scope

Releases the completed Mixed-Grid Continuum framing-seam fix as **v0.3.3**. The feature remains Mixed-Grid-only and `suffix_geometric_bridge=false` remains the default.

Companion Sol-H3 release PR: https://github.com/xmarre/ComfyUI-Sol-H3/pull/2

Current coordinated heads:

```text
Flow PR #24  d2bbebcaeac235cd3a61d41213a58263c0257aa9
Sol PR #2    49c588c80b0609393e493d2ebda5ed3dab9f4b0b
```

## Root cause and implementation

Mixed-Grid keeps the authoritative protected prefix on the target grid and the generated suffix on the lower source grid. The validated geometry has `1064` protected-prefix K/V rows/frame versus `540` source-suffix rows/frame (`1.97037x`). RoPE coordinates were already correct; ordinary softmax was over-weighting the denser prefix in discrete K/V measure.

When `suffix_geometric_bridge=true`, Flow publishes `h3_flow_mixed_grid_attention_measure_v1` / `prefix_kv_stratified_subsample`. The coordinated Sol-H3 backend preserves every Q row and all non-video/source-suffix K/V rows, while reducing only protected-prefix K/V to source-grid spatial density using native `_frame_grid` coordinates.

```text
Q:   56029 -> 56029
K/V: 56029 -> 49741
removed protected-prefix K/V rows: 6288 per call
```

VDN API 2 and learned-gate ownership remain unchanged.

## Final runtime and media acceptance

`00324` on real SM120:

```text
external_mixed_measure_calls          = 192
external_mixed_measure_removed_rows   = 1,207,296
compatibility fallbacks               = 0
numerical backend transitions         = 0

18 logical calls
13 actual transformer NFE
5 Spectrum forecasts
low:   7A / 3F
high:  4A / 2F
probe: 2A
```

The audited `sol_external_mixed_measure` receipt is history-compatible without weakening unknown-route rejection. Final protected-prefix canonicalization remains exact.

Decoded-media acceptance passed: the previous whole-frame shrink/zoom-out/top-edge reveal is absent at the old problematic join, registration stays approximately unit-scale with the surrounding camera motion, and no delayed framing pulse was introduced. A separate Sol `dense_evaluations=1` follow-up keeps the same seam clean.

No additional render is required.

## Retired source-warp path

The source affine/trajectory correction family is permanently retired after `00318`; finite horizons only moved the discontinuity to their termination boundary. Runtime reports `retired_source_warp_family`, zero corrected tokens and `learned_upscaler_input_modified=false`. No temporal fade/crossfade, decode-space repair or unmeasured extrapolation is introduced.

## Preserved contracts

- authoritative target-grid protected prefix is never warped and final prefix remains exact;
- no handcrafted fade/crossfade or decode-space correction;
- no extra H3 transformer NFE, VAE/model or optical-flow call from the measure path;
- no audio, caller-noise, mask or conditioning changes;
- no VDN API2 semantic or learned-gate ownership change;
- no Spectrum history-safety weakening;
- released `suffix_dc_bridge` arithmetic remains unchanged;
- generic Progressive and Target-Sparse nodes do not receive this Mixed-Grid-only option;
- `suffix_geometric_bridge` remains `false` by default.

## Validation / release

Exact Flow head CI `34379823338` on `d2bbebcaeac235cd3a61d41213a58263c0257aa9` passed. `pyproject.toml` and release notes target v0.3.3. Companion Sol-H3 PR #2 has also passed exact-head CI on its v0.1.4 release head.

Ready for squash merge after the Sol companion is released; the existing main-CI-gated GitHub/registry release workflows will publish the tested main commit.