### PR TITLE
Fix joint-AV Continuum decode context and correct three-run benchmark

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       - name: Fetch pinned integration sources
         run: |
           git clone --filter=blob:none https://github.com/Comfy-Org/ComfyUI.git .contracts/ComfyUI
-          git -C .contracts/ComfyUI checkout 1af040bf022569d7a890241c8dd79b296cda483f
+          git -C .contracts/ComfyUI checkout 1d48d9cf7bcecb6022a87b3cb13e0fb435bf9b8a
           git clone --filter=blob:none https://github.com/xmarre/ComfyUI-Spectrum-MiniMax-H3.git .contracts/Spectrum
           git -C .contracts/Spectrum checkout beb32dd210ef9e95520453107f158241d4f2ecf3
           git clone --filter=blob:none https://github.com/xmarre/ComfyUI-H3-Continuum.git .contracts/Continuum

--- a/docs/CONTINUUM_DECODE_CONTEXT.md
+++ b/docs/CONTINUUM_DECODE_CONTEXT.md
@@ -3,18 +3,49 @@
 Use **MiniMax H3 Continuum Decode Context** immediately before the video VAE
 decoder, after the final sampling, refinement, or latent-upscale operation:
 
-1. Final `video_latents` list → Decode Context `video_latents`.
+1. Final `video_latents` list, or a final native joint H3 AV LATENT list, → Decode Context `video_latents`.
 2. Corresponding Continuum `assembly_plan` → Decode Context `assembly_plan`.
 3. Decode Context `video_latents` → existing **Video VAE Decode**.
 4. Decoded images → existing **Continuum Assemble**.
 
-Keep the original assembly plan connected to Assemble. Keep the audio path
-unchanged. The context node's output is **decode-only**: do not feed it back into
-sampling, latent refinement/upscaling, Run Storage, or continuation state.
+The input can therefore be either of the representations used by the coordinated
+Continuum/refinement stack:
+
+- Continuum's split video LATENTs with plain `samples: [1,24,T,H,W]`; or
+- native joint H3 sampler output with `samples = NestedTensor([video, audio])`,
+  including the output of **MiniMax H3 Latent Upscaler + Refine (3D)**.
+
+For native joint AV input, Decode Context validates both members and exposes only
+the existing video tensor through a decode-only LATENT view. It does not copy or
+modify the accepted audio member, sampling state, or source LATENT. The normal
+Continuum audio path stays unchanged.
+
+Keep the original assembly plan connected to Assemble. The context node's output
+is **decode-only**: do not feed it back into sampling, latent refinement/upscaling,
+Run Storage, continuation state, or the audio path.
 
 This works independently of the progressive node: conservative Target Input,
-target-sparse, and mixed-grid can all produce exact-prefix continuation chunks.
-No H3 transformer evaluation is added. The selected VAE remains external.
+target-sparse, mixed-grid, and an external learned-upscale/refine second pass can
+all feed the same decode boundary. No H3 transformer evaluation is added. The
+selected VAE remains external.
+
+## Ownership and migration
+
+This Flow node is the current compatibility adapter for the released external
+Video VAE Decode + Continuum Assemble topology. The canonical long-term owner of
+physical-group decode views is Continuum itself, as specified by Flow design PR
+#29. Once supported Continuum releases expose the shared decode-view contract,
+this node should delegate to that implementation while keeping the existing node
+ID loadable for saved workflows. Do not duplicate or double-extend an already
+prepared Continuum decode view.
+
+The present adapter deliberately does **not** claim the complete future Continuum
+cache/revision contract from that design. It handles the released schema-1
+assembly-plan boundary, exact adjacent physical overlaps, and native joint-AV to
+video-only normalization described below. Review/reroll neighbor invalidation,
+short-group forward gathering, decoder-capability discovery, and integrated
+decode receipts belong to the Continuum-owned implementation rather than being
+silently approximated here.
 
 ## Boundary defect
 
@@ -42,15 +73,21 @@ preceding chunk. The VAE can now evaluate the formerly missing window. Assemble
 already trims each decoded result to its original `total_frames`, so the 17
 extra output frames are discarded and the timeline length stays unchanged.
 
-The final chunk is unchanged. Accepted latents, masks, original dictionaries,
-the plan, and audio remain unchanged. Existing physical `decode_groups` take
-precedence over logical chunk entries, including terminal-merged plans.
+For existing split-video input, a terminal or otherwise unextended chunk keeps
+its original LATENT dictionary identity. For native joint AV input, even an
+unextended chunk is returned as a minimal zero-copy video-only decode view so a
+video VAE never receives the AV `NestedTensor`. Accepted source latents, masks,
+the source AV wrapper, audio tensors, and the plan remain unchanged. Existing
+physical `decode_groups` take precedence over logical chunk entries, including
+terminal-merged plans.
 
 Non-exact overlaps (for example, independently upscaled/refined duplicate
-prefixes or Guide-mode regeneration) remain unchanged and are identified in
-the report. No approximate equality, implicit resizing, color matching, or
-replacement of generated suffix latents is used. Such boundaries require a
-different correction; a `0/N` report means this fix did not activate.
+prefixes or Guide-mode regeneration) remain unextended and are identified in
+the report. Native joint AV input is still normalized to its video member so it
+remains a valid video-decode input. No approximate equality, implicit resizing,
+color matching, or replacement of generated suffix latents is used. Such
+boundaries require a different correction; a `0/N` report means the temporal
+right-context fix did not activate.
 
 ## Evidence and limits
 
@@ -63,17 +100,26 @@ learned pixel decoder. Four-chunk tests with 5-, 22-, and 39-frame overlaps:
   right context;
 - preserve accepted latent values, plan contents, and output duration.
 
+Additional contract tests feed the native joint `NestedTensor([video, audio])`
+shape produced by the integrated H3 refiner and verify that Decode Context:
+
+- returns plain 24-channel video LATENTs suitable for Video VAE Decode;
+- keeps terminal video extraction zero-copy;
+- leaves the source AV wrapper, audio values, masks, and assembly plan untouched;
+- fails closed on malformed AV member counts or audio shape.
+
 Source: ComfyUI `1af040bf022569d7a890241c8dd79b296cda483f`,
 `comfy/ldm/minimax/vae.py`; Continuum
 `bf25353d8bec44afea22c89717c4301ce13c2036`, `v3/assembly.py`, `hardening.py`,
 and `temporal.py`. The native source oracle runs in CI.
 
-The structural decode-context correction is proven by that oracle. Actual
+The structural decode-context correction is proven by those oracles. Actual
 checkpoint media and speed are not established by a synthetic pixel decoder.
 There is one extra seven-token VAE window and 17 discarded decoded frames per
-corrected boundary, plus temporary extended latent storage. The implementation
-does not combine the entire sequence into a single large decode call. TRT or
-other replacement VAEs must preserve native H3 temporal window semantics for
-the equivalence argument to apply. Inspect decoded media with the actual VAE;
-remaining generation-domain flashing and the learned-prefix splice remain
-separate research questions. Both integration PRs remain draft.
+corrected boundary, plus temporary extended latent storage. Joint-AV
+normalization itself adds no H3 sampling or VAE work and does not copy the
+terminal video tensor. The implementation does not combine the entire sequence
+into a single large decode call. TRT or other replacement VAEs must preserve
+native H3 temporal window semantics for the equivalence argument to apply.
+Inspect decoded media with the actual VAE; remaining generation-domain flashing
+and learned-prefix splice behavior remain separate questions.

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,8 +1,98 @@
-# Performance evidence: progressive learned handoff vs two-pass upscale + refine
+# Performance evidence: native, progressive Flow, and standalone two-pass H3 paths
 
 ## Evidence status
 
-This document records the current **observed workflow-level timing reference** around a ~1 MP final target. It is not a formal same-seed microbenchmark and it is not a universal speed claim.
+This document records observed workflow-level timing references around a ~1.1 MP final target. They are not universal speed claims. Comparisons are only treated as controlled when their seed, prompt, references, sampling settings, workflow structure, and resolved geometry are known. Decoded media remains the quality gate when denoising budgets change.
+
+The September 9 runs below predate the v0.3.4 shipped-default/workflow alignment. They document the settings and geometry actually measured; current defaults are not retroactively projected onto historical benchmark evidence.
+
+## Current controlled three-run comparison
+
+The September 9 hot comparison contains **three distinct workflows**. They must not be collapsed into one another:
+
+1. **Native direct target-grid generation** — the control.
+2. **Flow progressive Mixed-Grid learned handoff** — low-grid work and target-grid continuation occur inside the progressive sampler path; the learned 3D upscaler is used only as the spatial handoff transform.
+3. **Standalone learned upscale + refine** — a complete lower-resolution Continuum sampling pass is followed by the separate `MinimaxH3LatentUpscaler3DRefineHandoff` node and a second high-resolution H3 sampler lifetime.
+
+The third workflow is **not Flow progressive sampling**. The Flow learned-handoff contract explicitly avoids `low sample -> complete Latent Upscaler + Refine -> second independent H3 pass`; that would defeat the progressive architecture.
+
+### Run identity and wall time
+
+| Path | Resolved generation geometry | H3 sampling/refine node wall | Prompt result |
+|---|---|---:|---|
+| Native direct | 1184×896 = 1.060864 MP | 290.41 s `H3ContinuumSamplerV34` | complete, 338.50 s |
+| Flow progressive | private first-chunk grid 832×640 -> target 1184×896 | **247.63 s** `H3ContinuumSamplerV34` | complete, **298.59 s** |
+| Standalone learned upscale + refine | base 992×736 -> final 1216×896 = 1.089536 MP | **341.36 s** = 188.57 s base sampler + 152.79 s refine | sampling/refine complete; decode failed at 342.71 s |
+
+The standalone run cannot be compared to the other two by completed end-to-end wall time because it failed immediately after refinement at `H3ContinuumDecodeContext`, before video decode and assembly. Its sampler/refine wall remains valid for the sampling-cost comparison.
+
+Direct deltas from the completed node walls:
+
+- **Flow progressive vs native sampler:** 247.63 s vs 290.41 s = **-42.78 s / -14.73%**.
+- **Flow progressive vs native prompt:** 298.59 s vs 338.50 s = **-39.91 s / -11.79%** end-to-end.
+- **Standalone two-pass vs native sampler:** 341.36 s vs 290.41 s = **+50.95 s / +17.54%**.
+- **Standalone two-pass vs Flow progressive sampler:** 341.36 s vs 247.63 s = **+93.73 s / +37.85%**.
+
+The standalone final grid has about **2.7% more pixels** than the native/Flow target. That is a small adverse bias against the standalone run and should be retained when interpreting its timing, but it does not erase the large difference between the architectures.
+
+### Model-call topology
+
+| Path / stage | Logical calls | Actual H3 NFEs | Spectrum forecasts |
+|---|---:|---:|---:|
+| Native direct | 16 | 11 | 5 |
+| Flow low/private | 10 | 8 | 2 |
+| Flow exact handoff probes | 2 | 2 | 0 |
+| Flow high/target | 6 | 4 | 2 |
+| **Flow progressive total** | **18** | **14** | **4** |
+| Standalone base pass | 16 | 11 | 5 |
+| Standalone high-res refine | +8 | +6 | +2 |
+| **Standalone two-pass total** | **24** | **17** | **7** |
+
+The raw NFE count alone does not predict wall time because the calls occur on different geometries. Flow performs most of its trajectory work on the cheaper private grid, pays two explicit exact handoff probes, then performs only the remaining target-grid continuation. The learned handoff itself adds no H3 NFE.
+
+The standalone path instead finishes a complete 8-logical-call-per-chunk lower-resolution trajectory and then launches a separate four-step high-resolution refinement sampler. That additive second sampler lifetime is the source of its extra cost.
+
+### Standalone two-pass stage decomposition
+
+The following stage table applies **only to native vs the standalone learned upscale+refine run**. It is not a decomposition of the Flow progressive run.
+
+| Stage | Native direct | Standalone two-pass | Delta |
+|---|---:|---:|---:|
+| First/native base chunk | 116.84 s | 74.90 s | -41.93 s (-35.9%) |
+| Later/native base chunk | 165.27 s | 107.97 s | -57.30 s (-34.7%) |
+| Native/base Spectrum subtotal | 282.11 s | 182.88 s | -99.23 s (-35.2%) |
+| Standalone high-res refine, first | — | 67.75 s | +67.75 s |
+| Standalone high-res refine, later | — | 82.59 s | +82.59 s |
+| Spectrum-stage total | 282.11 s | 333.22 s | +51.11 s (+18.1%) |
+| Sampler/refine node total | 290.41 s | 341.36 s | +50.95 s (+17.5%) |
+
+This shows two separate facts:
+
+- moving the complete base pass to ~0.73 MP is effective by itself, saving about **99.23 s / 35.2%** at the Spectrum-stage boundary;
+- the **standalone** four-step high-resolution refine costs about **150.34 s**, more than the base-pass saving, so that particular two-pass configuration loses to native overall.
+
+It says nothing negative about the current Flow progressive path; that path is the 247.63 s sampler run above and is faster than native in this controlled comparison.
+
+### Geometry and architectural interpretation
+
+```text
+native target:          74 x 56 latent -> 1184 x 896 = 1.060864 MP
+Flow private (chunk 1): 52 x 40 latent ->  832 x 640 = 0.532480 MP
+Flow target:            74 x 56 latent -> 1184 x 896 = 1.060864 MP
+standalone base:        62 x 46 latent ->  992 x 736 = 0.730112 MP
+standalone final:       76 x 56 latent -> 1216 x 896 = 1.089536 MP
+```
+
+The architectures therefore answer different questions:
+
+- **Flow progressive:** can early target-trajectory work be executed on a cheaper grid and handed off inside the same progressive denoising process? In this run, yes: it reduced sampler wall by ~14.7% and end-to-end wall by ~11.8% relative to native.
+- **Standalone upscale + refine:** can a complete cheaper base generation plus a second learned upscale/refine pass outperform native wall time? In this 8+4 configuration, no: the second high-resolution sampler costs more than the base pass saves.
+
+Do not silently reduce standalone refine steps to manufacture a speed claim. A lower standalone refine budget changes the empirical quality point and requires matched decoded-media validation.
+
+The failed standalone run also exposed a separate decode-boundary bug: the integrated refiner returns valid native joint H3 AV samples, while Continuum Decode Context historically accepted only a split plain-video tensor. This PR fixes that representation boundary without changing either sampling architecture.
+
+## Historical proper two-pass baseline
 
 The useful legacy baseline is the established proper learned upscale + H3 refine workflow:
 
@@ -14,9 +104,7 @@ The useful legacy baseline is the established proper learned upscale + H3 refine
 
 Old 3-step high-ratio refine experiments are excluded from performance claims because three refine steps were a legacy under-refined setting and are not a quality-equivalent comparison.
 
-## Compared runs
-
-### Historical proper two-pass baseline
+### Historical proper two-pass timing
 
 At the higher nominal 0.7 MP setting, the recorded workflow resolved approximately:
 
@@ -27,11 +115,11 @@ sampling:    7 base + 6 learned-refine outer steps
 workflow:    ~777 s end-to-end (~12:57)
 ```
 
-This is the proper 6-step-refine baseline used for the timing comparison. The historical 7+7 workflow remains the fuller refine budget, but an equally clean ~1 MP raw timing for that exact case has not been recovered, so no exact 7+7 speedup is claimed.
+This is the proper 6-step-refine baseline used for the historical timing comparison below. The historical 7+7 workflow remains the fuller refine budget, but an equally clean ~1 MP raw timing for that exact case has not been recovered, so no exact 7+7 speedup is claimed.
 
-### Progressive learned-handoff final gate
+## Historical progressive learned-handoff gate
 
-The final learned-transfer gate resolved:
+An earlier progressive learned-transfer gate resolved:
 
 ```text
 private/source: 832 x 640 = 0.532480 MP
@@ -60,11 +148,11 @@ Exact H3/Spectrum telemetry across the two physical chunks:
 
 The run also recorded 6 progressive sampler invocations, 4 history boundaries, copied audio, rebuilt high-grid conditioning, and an actual first high-grid H3 call in both chunks.
 
-## Observed wall-time comparison
+## Observed historical wall-time comparison
 
 | Path | Base/private grid | Final grid | Sampling structure | Full workflow |
 |---|---:|---:|---|---:|
-| Proper two-pass upscale + refine | 960×704 (0.676 MP) | 1184×864 (1.023 MP) | 7 base + 6 refine | ~777 s |
+| Proper standalone two-pass upscale + refine | 960×704 (0.676 MP) | 1184×864 (1.023 MP) | 7 base + 6 refine | ~777 s |
 | Progressive + `learned_3d` | 832×640 (0.532 MP) | 1184×896 (1.061 MP) | 10 progressive outer steps | 621.63 s |
 
 Derived from the actual resolved geometries and observed wall times:
@@ -79,7 +167,7 @@ The final output is therefore slightly larger, not smaller, despite the lower to
 
 ## Learned-transfer overhead
 
-The learned 3D CNN itself is not responsible for the speedup. Its measured BF16 CUDA costs were:
+The learned 3D CNN itself is not responsible for most of the speedup. In the historical progressive gate its measured BF16 CUDA costs were:
 
 ```text
 chunk 1 learned inference: 602.1 ms
@@ -93,7 +181,7 @@ sum transfer wall:         ~1.430 s
 
 It added **zero H3 NFEs**.
 
-The architectural saving comes from carrying one progressive trajectory across the spatial handoff: more H3 work remains on the cheaper private grid, then the sampler performs only the required exact probe/high-grid continuation instead of finishing a complete low-resolution generation and launching a separate low-sigma H3 refine pass.
+The architectural saving comes from carrying a progressive trajectory across the spatial handoff: more H3 work remains on the cheaper private grid, then the sampler performs only the required exact probe/high-grid continuation instead of finishing a complete lower-resolution generation and launching a separate low-sigma H3 refine pass.
 
 ## Model-call accounting relative to the old 7+6 path
 
@@ -101,8 +189,8 @@ The ~777 s historical run predates the current combined metrics artifact, so its
 
 - 7-step base: later validated telemetry shows 9 actual + 4 Spectrum forecast calls per physical chunk (13 logical);
 - 6-step refine: the established baseline contract is 11 logical calls per chunk, approximately 7 actual + 4 Spectrum forecasts;
-- across two physical chunks, that reconstructs approximately **48 logical / 32 actual / 16 forecast** calls for a 7+6 two-pass workflow;
-- the new progressive learned run directly measured **38 logical / 28 actual / 10 forecast**.
+- across two physical chunks, that reconstructs approximately **48 logical / 32 actual / 16 forecast** calls for a 7+6 standalone two-pass workflow;
+- the historical progressive learned run directly measured **38 logical / 28 actual / 10 forecast**.
 
 At target resolution specifically, the old 6-step refine budget implies about 14 actual H3 evaluations across two chunks. The progressive run directly measured 10 high-stage actual evaluations plus 2 exact target-grid probes = 12 target-resolution actual H3 evaluations. Treat the old totals as reconstructed accounting, not as exact counters from the ~777 s run.
 
@@ -110,20 +198,26 @@ At target resolution specifically, the old 6-step refine budget implies about 14
 
 Do not use the old ~1.75x / 3-step refine experiments as the headline baseline. They can be useful for implementation archaeology, but three refine steps are not enough for the established quality target and make the progressive path look artificially expensive.
 
-Likewise, the repeated ~0.6 MP -> ~0.79 MP two-pass runs around 544-546 s are useful scaling context but are not directly comparable to the ~1.06 MP final progressive gate because their final target is substantially smaller.
+Likewise, the repeated ~0.6 MP -> ~0.79 MP standalone two-pass runs around 544-546 s are useful scaling context but are not directly comparable to the ~1.06 MP final progressive gates because their final target is substantially smaller.
 
 ## Interpretation and limits
 
-The defensible statement is:
+The current controlled evidence supports three separate statements:
 
-> In the observed ~1 MP workflow, the 10-step progressive learned-handoff path completed in 621.63 s versus about 777 s for the proper historical 7+6 two-pass upscale/refine workflow, an observed ~20% end-to-end wall-time reduction while producing ~3.7% more final pixels.
+> The September 9 Flow progressive run completed at 247.63 s sampler wall and 298.59 s prompt wall versus 290.41 s and 338.50 s for the native control: about **14.7% less sampler time** and **11.8% less end-to-end time** at the same 1184×896 target.
 
-Do **not** turn this into:
+> The separate September 9 standalone 992×736 -> 1216×896 learned upscale + four-step refine path cost 341.36 s in sampler/refine nodes, about **17.5% more than native**. Its final decode failed, so no completed end-to-end or decoded-quality comparison is claimed for that run.
 
-- a universal 20% speedup claim;
+> In an earlier ~1 MP workflow, the progressive learned-handoff path completed in 621.63 s versus about 777 s for the proper historical 7+6 standalone upscale/refine workflow, an observed ~20% end-to-end wall-time reduction while producing ~3.7% more final pixels.
+
+Do **not** turn these results into:
+
+- a universal Flow speedup percentage;
+- a universal standalone two-pass slowdown percentage;
 - a claim that progressive output is universally higher quality;
 - a matched-A/B quality percentage;
 - an exact speedup over the historical 7+7 workflow without a comparable raw timing;
-- evidence that acceleration guidance is better.
+- evidence that acceleration guidance is better;
+- evidence that a reduced standalone refine budget preserves quality without a decoded-media test.
 
 Runtime depends on target geometry, private/source geometry, reference-conditioning load, model residency/loading, VAE/decode cost, sampler/Spectrum policy, chunk lengths, and hardware state. Decoded media remains the quality gate.

--- a/h3_flow_regenerate/decode_context.py
+++ b/h3_flow_regenerate/decode_context.py
@@ -7,17 +7,70 @@ frames. No sampler input, saved chunk, or audio tensor is changed.
 
 from __future__ import annotations
 
+from typing import Any
+
 import torch
 
 _CYCLE = 5
 _CYCLE_FRAMES = 17
 _PREFIX_REMAINDER = 2
+_H3_VIDEO_CHANNELS = 24
+_H3_AUDIO_CHANNELS = 32
+_H3_AUDIO_CHANNELS_PER_SAMPLE = 2
 
 
 def _frames(tokens: int) -> int:
     if tokens < 2 or tokens % _CYCLE != _PREFIX_REMAINDER:
         raise ValueError("Continuum decode context requires H3 video lengths of 5k+2 latents")
     return ((tokens - 2) // _CYCLE) * _CYCLE_FRAMES + 5
+
+
+def _extract_decode_video(samples: Any, index: int) -> tuple[torch.Tensor, bool]:
+    """Resolve split video or native joint H3 AV samples for decode-only use.
+
+    Continuum itself exposes split video/audio LATENTs, while the integrated
+    learned-upscale/refine node must rebuild native ``NestedTensor([video, audio])``
+    samples for sampler 2. Decode Context is intentionally the adapter between
+    those contracts: it accepts either representation and returns video-only
+    decode views without mutating or rewriting the source AV state.
+    """
+    unbind = getattr(samples, "unbind", None)
+    if bool(getattr(samples, "is_nested", False)) and callable(unbind):
+        members = list(unbind())
+        if len(members) != 2:
+            raise ValueError(f"decode group {index + 1} native H3 AV samples require exactly [video, audio]")
+        video, audio = members
+        if (
+            not torch.is_tensor(audio)
+            or audio.ndim != 4
+            or tuple(audio.shape[:3])
+            != (
+                1,
+                _H3_AUDIO_CHANNELS,
+                _H3_AUDIO_CHANNELS_PER_SAMPLE,
+            )
+        ):
+            raise ValueError(f"decode group {index + 1} native H3 AV audio must be [1,32,2,T]")
+        if not audio.is_floating_point():
+            raise ValueError("H3 decode-context audio member must be floating point")
+        joint_av = True
+    else:
+        video = samples
+        joint_av = False
+
+    if (
+        not torch.is_tensor(video)
+        or video.ndim != 5
+        or tuple(video.shape[:2])
+        != (
+            1,
+            _H3_VIDEO_CHANNELS,
+        )
+    ):
+        raise ValueError(f"decode group {index + 1} requires native [1,24,T,H,W] video")
+    if not video.is_floating_point():
+        raise ValueError("H3 decode-context video latents must be floating point")
+    return video, joint_av
 
 
 def prepare_decode_context(latents: list[dict], plan: dict) -> tuple[list[dict], str]:
@@ -40,13 +93,13 @@ def prepare_decode_context(latents: list[dict], plan: dict) -> tuple[list[dict],
     if not isinstance(groups, list) or not groups or len(groups) != len(latents):
         raise ValueError("decode-context latent count must match physical assembly groups")
 
-    videos = []
+    videos: list[torch.Tensor] = []
+    decode_views: list[dict] = []
+    joint_av_inputs = 0
     for index, (latent, group) in enumerate(zip(latents, groups, strict=True)):
-        video = latent.get("samples") if isinstance(latent, dict) else None
-        if not torch.is_tensor(video) or video.ndim != 5 or tuple(video.shape[:2]) != (1, 24):
-            raise ValueError(f"decode group {index + 1} requires native [1,24,T,H,W] video")
-        if not video.is_floating_point():
-            raise ValueError("H3 decode-context latents must be floating point")
+        samples = latent.get("samples") if isinstance(latent, dict) else None
+        video, joint_av = _extract_decode_video(samples, index)
+        joint_av_inputs += int(joint_av)
         total = _frames(int(video.shape[2]))
         trim = int(group["trim_frames"])
         if total != int(group["total_frames"]) or total - trim != int(group["net_frames"]):
@@ -54,8 +107,12 @@ def prepare_decode_context(latents: list[dict], plan: dict) -> tuple[list[dict],
         if int(group["expected_video_latent_t"]) != video.shape[2] or trim < 0:
             raise ValueError(f"decode group {index + 1} has stale assembly metadata")
         videos.append(video)
+        # Split Continuum video LATENTs keep their historical identity when no
+        # extension is required. Joint AV sampler outputs cannot be sent to the
+        # video VAE, so expose a minimal decode-only video view instead.
+        decode_views.append({"samples": video} if joint_av else latent)
 
-    output = list(latents)
+    output = list(decode_views)
     reports = []
     joined = 0
     for index in range(len(videos) - 1):
@@ -77,14 +134,20 @@ def prepare_decode_context(latents: list[dict], plan: dict) -> tuple[list[dict],
         if not torch.equal(left[:, :, -prefix:], right[:, :, :prefix]):
             reports.append(f"boundary {index + 1}: unchanged (protected overlap is not exact)")
             continue
-        # New allocation: accepted CPU chunks remain immutable. Do not forward
-        # stale noise masks or sampling metadata on an extended decode-only tensor.
+        # New allocation: accepted chunks remain immutable. Do not forward stale
+        # noise masks, joint AV wrappers, or sampling metadata on an extended
+        # decode-only tensor.
         output[index] = {"samples": torch.cat((left, right[:, :, prefix : prefix + _CYCLE]), dim=2)}
         joined += 1
         reports.append(f"boundary {index + 1}: supplied 5 real future latents (17 decode-only frames)")
+    representation = (
+        f" Native joint AV inputs normalized for video decode: {joint_av_inputs}/{len(videos)}."
+        if joint_av_inputs
+        else ""
+    )
     report = (
-        f"H3 Continuum decode context: {joined}/{max(0, len(videos) - 1)} exact boundaries. "
-        "Use the original assembly plan; added frames are trimmed by Assemble.\n" + "\n".join(reports)
+        f"H3 Continuum decode context: {joined}/{max(0, len(videos) - 1)} exact boundaries."
+        f"{representation} Use the original assembly plan; added frames are trimmed by Assemble.\n" + "\n".join(reports)
     )
     return output, report
 
@@ -93,9 +156,11 @@ class H3ContinuumDecodeContext:
     CATEGORY = "MiniMax H3/flow regenerate"
     DESCRIPTION = (
         "Place immediately before Video VAE Decode, after all sampling/refinement/upscaling. "
-        "Supplies the next chunk's real decoder context at exact Continuum overlaps. "
-        "Connect the unchanged assembly plan to Assemble; it trims the extra decode-only frames. "
-        "Works with any progressive sampler. Output is for decoding only, not sampling or storage."
+        "Accepts either Continuum split video LATENTs or native joint H3 AV sampler output, "
+        "normalizing the latter to a decode-only video view. Supplies the next chunk's real "
+        "decoder context at exact Continuum overlaps. Connect the unchanged assembly plan to "
+        "Assemble; it trims the extra decode-only frames. Output is for decoding only, not "
+        "sampling or storage."
     )
     INPUT_IS_LIST = True
     RETURN_TYPES = ("LATENT", "STRING")

--- a/tests/test_decode_context.py
+++ b/tests/test_decode_context.py
@@ -45,6 +45,18 @@ def sequence(prefix=12, count=4):
     )
 
 
+class FakeNestedAV:
+    """Minimal Comfy NestedTensor-compatible AV wrapper for contract tests."""
+
+    is_nested = True
+
+    def __init__(self, video, audio):
+        self._members = [video, audio]
+
+    def unbind(self):
+        return tuple(self._members)
+
+
 @pytest.mark.parametrize("prefix", [2, 7, 12])
 def test_exact_context_is_bounded_and_does_not_mutate_accepted_latents(prefix):
     _, latents, plan = sequence(prefix)
@@ -60,6 +72,67 @@ def test_exact_context_is_bounded_and_does_not_mutate_accepted_latents(prefix):
     assert result[-1] is latents[-1]
     assert plan == old_plan
     assert all(torch.equal(x["samples"], v) for x, v in zip(latents, before, strict=True))
+
+
+def test_joint_av_refine_output_is_normalized_to_video_decode_views_without_mutation():
+    _, latents, plan = sequence(count=2)
+    original_videos = [latent["samples"] for latent in latents]
+    audios = [torch.randn(1, 32, 2, 64), torch.randn(1, 32, 2, 64)]
+    audio_before = [audio.clone() for audio in audios]
+    for latent, video, audio in zip(latents, original_videos, audios, strict=True):
+        latent["samples"] = FakeNestedAV(video, audio)
+        latent["noise_mask"] = object()
+    old_plan = copy.deepcopy(plan)
+
+    result, report = prepare_decode_context(latents, plan)
+
+    assert "1/1 exact boundaries" in report
+    assert "Native joint AV inputs normalized for video decode: 2/2" in report
+    assert torch.is_tensor(result[0]["samples"])
+    assert result[0]["samples"].shape[2] == original_videos[0].shape[2] + 5
+    assert torch.equal(result[0]["samples"][:, :, :-5], original_videos[0])
+    assert torch.equal(result[0]["samples"][:, :, -5:], original_videos[1][:, :, 12:17])
+    assert set(result[0]) == {"samples"}
+
+    # The terminal joint-AV chunk needs no extension, but it still must become a
+    # plain video-only LATENT for Video VAE Decode. The tensor view is zero-copy.
+    assert result[1] is not latents[1]
+    assert result[1]["samples"] is original_videos[1]
+    assert set(result[1]) == {"samples"}
+
+    assert plan == old_plan
+    for latent, video, audio, before in zip(latents, original_videos, audios, audio_before, strict=True):
+        members = latent["samples"].unbind()
+        assert members[0] is video
+        assert members[1] is audio
+        assert torch.equal(audio, before)
+        assert "noise_mask" in latent
+
+
+@pytest.mark.parametrize("members", [1, 3])
+def test_malformed_joint_av_member_count_fails_closed(members):
+    _, latents, plan = sequence(count=1)
+    video = latents[0]["samples"]
+    audio = torch.randn(1, 32, 2, 64)
+
+    class BadNested:
+        is_nested = True
+
+        def unbind(self):
+            values = [video, audio, audio]
+            return tuple(values[:members])
+
+    latents[0]["samples"] = BadNested()
+    with pytest.raises(ValueError, match=r"exactly \[video, audio\]"):
+        prepare_decode_context(latents, plan)
+
+
+def test_malformed_joint_av_audio_fails_closed():
+    _, latents, plan = sequence(count=1)
+    video = latents[0]["samples"]
+    latents[0]["samples"] = FakeNestedAV(video, torch.randn(1, 31, 2, 64))
+    with pytest.raises(ValueError, match=r"\[1,32,2,T\]"):
+        prepare_decode_context(latents, plan)
 
 
 def test_nonexact_or_guide_boundary_is_not_silently_replaced():

--- a/tests/test_mixed_grid.py
+++ b/tests/test_mixed_grid.py
@@ -369,7 +369,7 @@ def test_native_forward_uses_authoritative_prefix_and_real_suffix(monkeypatch, n
     seen = []
 
     class MixingBlock(torch.nn.Module):
-        def forward(self, h, t_emb, segments, rope, transformer_options):
+        def forward(self, h, t_emb, segments, rope, transformer_options, attention=None):
             seen.append((h.clone(), segments, rope.shape[1]))
             # Deliberate global dependence proves which prefix conditions the suffix.
             return h + h.mean(0)


### PR DESCRIPTION
## Summary

Fix the decode failure exposed after a successful **standalone learned-upscale/refine** pass, correct the September 9 performance documentation so three different workflows remain strictly separate, and keep the native Mixed-Grid source oracle aligned with the current ComfyUI H3 block-call contract.

The three workflows remain distinct:

1. native direct target-grid generation;
2. Flow progressive Mixed-Grid learned handoff;
3. standalone learned upscale + refine with a second H3 sampler lifetime.

The standalone two-pass run is **not** the Flow run.

## Reconciliation with current main

This PR is rebuilt on current `main` head `970396db839ae7ab431b9718859f6d48a2e5019b` (v0.3.4), preserving merged #26 Mixed-Grid layout propagation and #28 learned-3D/default-workflow changes.

Current reconciled head:

```text
d4df5d18d467ca3e81eecd107805c3f5b10f6150
```

Topology is **one implementation commit, 1 ahead / 0 behind**, and the PR is mergeable. Six files differ from current main:

- `.github/workflows/ci.yml`
- `docs/CONTINUUM_DECODE_CONTEXT.md`
- `docs/PERFORMANCE.md`
- `h3_flow_regenerate/decode_context.py`
- `tests/test_decode_context.py`
- `tests/test_mixed_grid.py`

The stale PR-local v0.3.4 `RELEASE_NOTES.md` and `pyproject.toml` changes remain deliberately removed. v0.3.4 is already owned by merged #28; this PR does not rewrite that release or invent a second v0.3.4.

Pre-reconcile state is preserved at `checkpoint/pr25-before-20260911-reconcile`. The current-Core test reconciliation is separately checkpointed before its fixture adjustment and was validated first on `mirror/pr25-current-core-test-fixture-20260911` before consolidating back to this one-commit PR head.

## Decode root cause

The current learned-upscaler/refiner still intentionally returns native MiniMax-H3 joint AV state after sampler 2. Source audit against `xmarre/Comfyui_Minimax_h3_latent_Upscaler-Plus@620165a311de9b28a36260219fb5cd370a304e3c` confirms that `run_h3_refinement()` validates the sampled `[video, audio]` members and returns the resulting native NestedTensor through `latent["samples"]`; split Continuum inputs are explicitly rebuilt into the same native joint representation before refinement.

`H3ContinuumDecodeContext`, however, historically accepted only Continuum's split plain-video `LATENT` representation. A valid post-refine result could therefore fail immediately before Video VAE Decode with:

```text
decode group 1 requires native [1,24,T,H,W] video
```

This is a decode-boundary representation mismatch after the standalone refiner, not a Flow sampling failure.

## Decode fix

`H3ContinuumDecodeContext` now accepts both currently valid upstream representations:

- split Continuum video `samples: [1,24,T,H,W]`;
- native joint H3 `NestedTensor([video, audio])` sampler output.

For joint AV input it:

- requires exactly `[video, audio]`;
- validates video as floating `[1,24,T,H,W]`;
- validates audio as floating `[1,32,2,T]`;
- exposes only the existing video tensor through a minimal decode-only LATENT;
- keeps terminal/unextended video extraction zero-copy;
- never mutates the source AV wrapper, audio, masks, or assembly plan.

The existing exact-overlap temporal right-context rule remains unchanged: when an adjacent physical overlap is bit-identical and on the native H3 temporal lattice, the preceding decode-only view borrows exactly five real future video latent tokens. Plain split-video inputs retain their previous identity behavior when no extension is required.

The producer contract is deliberately unchanged. Native joint AV output after H3 sampler 2 is valid; changing the refiner's output representation would create a larger and unnecessary compatibility surface.

## Current ComfyUI native block-call contract

Local production-stack validation against the current Patcher-managed ComfyUI installation exposed one source-oracle compatibility failure unrelated to the decode implementation:

```text
TypeError: MixingBlock.forward() got an unexpected keyword argument 'attention'
```

Current ComfyUI `MiniMaxH3Model._forward` now forwards the optional `attention=` override through the replacement-block call, matching the native H3 block signature. The test-only `MixingBlock` fixture still modeled the older five-argument signature.

The fix is intentionally narrow:

```python
def forward(self, h, t_emb, segments, rope, transformer_options, attention=None):
```

It uses the explicit current native argument rather than accepting arbitrary `**kwargs`, so unrelated native API changes still fail closed. No Flow production behavior changes for this compatibility update.

Source-contract CI now pins current ComfyUI `1d48d9cf7bcecb6022a87b3cb13e0fb435bf9b8a` instead of the older pre-`attention=` source, ensuring this exact native contract is exercised in CI.

Post-fix validation against the user's actual Patcher-managed production ComfyUI installation confirms that this was the only local test incompatibility: the formerly failing native Mixed-Grid oracle passes, decode-context tests pass, the combined native-contract set passes, and the complete local suite is green.

## Coordination with design PR #29

PR #25 remains the compatibility adapter for the **currently released external Video VAE Decode + Continuum Assemble topology**. Design PR #29 assigns the eventual canonical physical-group decode-view/cache contract to Continuum. Once supported Continuum releases provide that shared implementation, this Flow node should become a deprecated delegating adapter while keeping its existing node ID loadable.

This PR therefore does **not** pretend to implement the complete future Continuum contract. Review/reroll neighbor invalidation, short-group forward gathering/coalescing, decoder-capability discovery, integrated decode receipts and shared cache ownership remain Continuum work. The documentation calls this out explicitly and warns against double-extending an already prepared Continuum decode view.

## Regression coverage

The tests reproduce the real representation boundary and verify:

- valid joint AV output becomes video-only decode views;
- exact right-context extension still appends only the required five video latent tokens;
- terminal joint-AV extraction is zero-copy;
- source video/audio members, masks and assembly plan remain unchanged;
- malformed joint member counts fail closed;
- malformed audio geometry fails closed;
- physical `decode_groups` take precedence over logical chunks;
- non-exact overlaps remain unmodified;
- all existing split-video identity, stale-plan and native temporal-VAE window oracles remain in place;
- the native Mixed-Grid forward oracle executes against the current optional H3 `attention=` block contract.

## Corrected September 9 three-run benchmark

These are historical measured configurations. They predate the v0.3.4 shipped-default/workflow alignment and are not rewritten to current defaults.

| Path | Geometry | H3 sampling/refine wall | Prompt result |
|---|---|---:|---|
| Native direct | 1184×896 | 290.41 s | complete, 338.50 s |
| **Flow progressive Mixed-Grid** | private first chunk 832×640 → target 1184×896 | **247.63 s** | complete, **298.59 s** |
| Standalone learned upscale + refine | base 992×736 → final 1216×896 | **341.36 s** = 188.57 + 152.79 | sampling/refine complete; decode failed at 342.71 s |

The standalone run stopped before video VAE decode/assembly, so its 342.71 s prompt wall is **not** a completed end-to-end timing and is not used as one.

Correct deltas:

- Flow progressive vs native sampler: **-42.78 s / -14.73%**.
- Flow progressive vs native completed prompt: **-39.91 s / -11.79%**.
- standalone two-pass vs native sampler/refine: **+50.95 s / +17.54%**.
- standalone two-pass vs Flow sampler/refine: **+93.73 s / +37.85%**.

### Correct topology

| Path / stage | Logical | Actual | Forecast |
|---|---:|---:|---:|
| Native direct | 16 | 11 | 5 |
| Flow low/private | 10 | 8 | 2 |
| Flow exact probes | 2 | 2 | 0 |
| Flow high/target | 6 | 4 | 2 |
| **Flow total** | **18** | **14** | **4** |
| Standalone base | 16 | 11 | 5 |
| Standalone refine | +8 | +6 | +2 |
| **Standalone total** | **24** | **17** | **7** |

Raw NFE count does not directly predict wall time because the calls occur at different grids. Flow keeps most work on the cheaper private/mixed grid, performs the required exact probes, uses learned 3D only as the spatial handoff transform, then continues the remaining high-grid trajectory. The standalone path completes its lower-resolution trajectory and launches a separate high-resolution H3 refinement sampler.

The `182.88 s` base subtotal plus `150.34 s` high-resolution refinement therefore belongs only to the standalone two-sampler run. It is not a Flow stage decomposition.

## Validation state

Exact clean PR head `d4df5d18d467ca3e81eecd107805c3f5b10f6150` passed PR Actions run `34567998101` **5/5 jobs**:

- Python 3.10, 3.11, 3.12 and 3.13 test/build/package lanes all passed;
- `source-contracts` passed against current ComfyUI `1d48d9cf7bcecb6022a87b3cb13e0fb435bf9b8a`;
- the exact source-contract command `python -m pytest tests/test_mixed_grid.py tests/test_decode_context.py -q` passed **43/43** against that current native source;
- Ruff, format, compileall, package build, license metadata and isolated wheel imports passed in the versioned lanes.

The same tree had already passed mirror Actions run `34567750504` before the one-commit consolidation, so the rewrite did not alter the validated tree.

The updated PR was then validated directly inside the user's actual Patcher-managed production ComfyUI environment (`comfy312`, `COMFYUI_ROOT=/home/toor/ComfyUI`):

- formerly failing `test_native_forward_uses_authoritative_prefix_and_real_suffix`: **1 passed**;
- `tests/test_decode_context.py`: **17 passed**;
- `tests/test_mixed_grid.py tests/test_decode_context.py`: **46 passed**;
- full Flow suite: **283 passed, 0 failed**.

Only unrelated environment deprecation warnings remain (`pynvml` and Triton autotuner arguments); there are no Flow test failures.

A real decoded standalone upscale/refine rerun remains the empirical end-to-end gate. CI and the local production-stack suite prove the representation/lattice/contracts, but they cannot prove actual checkpoint decode success or decoded media quality. This PR therefore remains **draft** until that rerun reaches Video VAE Decode and Continuum assembly successfully.