### PR TITLE
Propagate Mixed-Grid layout to downstream H3 attention providers

### DIFF
--- a/h3_flow_regenerate/mixed_grid.py
+++ b/h3_flow_regenerate/mixed_grid.py
@@ -199,6 +199,13 @@ def mixed_mod_segments(segments, plan, va, vb):
     return result
 
 
+def _mixed_transformer_options(options, mixed_layout):
+    """Publish the block's actual mixed layout without mutating carrier options."""
+    block_options = dict(options)
+    block_options["minimax_h3_layout"] = mixed_layout
+    return block_options
+
+
 def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=None, minimax_payload=None, **kwargs):
     options = transformer_options or {}
     contract = options.get(MIXED_GRID_KEY)
@@ -296,7 +303,7 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
                 rope_freqs=cached["rope"],
                 mod_segments=mixed_mod_segments(args["mod_segments"], plan, va, vb),
             )
-            block_options = dict(args["transformer_options"])
+            block_options = _mixed_transformer_options(args["transformer_options"], mixed_layout)
             if "vdn_h3_external_sequence_v1" in block_options:
                 raise RuntimeError("mixed-grid found an already-owned VDN external sequence")
             block_options["vdn_h3_external_sequence_v1"] = {

--- a/tests/test_mixed_grid_layout_propagation.py
+++ b/tests/test_mixed_grid_layout_propagation.py
@@ -1,0 +1,22 @@
+from types import SimpleNamespace
+
+from h3_flow_regenerate.mixed_grid import _mixed_transformer_options
+
+
+def test_mixed_transformer_options_publish_current_layout_without_mutating_carrier():
+    carrier = SimpleNamespace(seq_len=100, signature=("carrier",))
+    mixed = SimpleNamespace(seq_len=140, signature=("h3_flow_mixed_grid_v1",))
+    marker = object()
+    original = {
+        "minimax_h3_layout": carrier,
+        "optimized_attention_override": marker,
+        "uuids": ("cond",),
+    }
+
+    forwarded = _mixed_transformer_options(original, mixed)
+
+    assert forwarded is not original
+    assert forwarded["minimax_h3_layout"] is mixed
+    assert forwarded["optimized_attention_override"] is marker
+    assert forwarded["uuids"] == ("cond",)
+    assert original["minimax_h3_layout"] is carrier


### PR DESCRIPTION
## Problem

Mixed-Grid correctly builds a per-block `mixed_layout` and forwards it as the direct H3 block `layout`, but v0.3.3 leaves `transformer_options["minimax_h3_layout"]` on the low-grid carrier layout.

That violates the current MiniMax-H3 block-patch contract for downstream attention providers that consume the canonical layout from `transformer_options`. In particular, ComfyUI core BlockSparseAttention checks `minimax_h3_layout.seq_len == tokens` before enabling conditioning sinks. During Mixed-Grid, the stale carrier length does not match the actual mixed hidden sequence, so `sink_conditioning=exact_kv` silently collapses to zero sinks.

## Fix

Each Mixed-Grid block now publishes the exact same `mixed_layout` through both channels that describe the current transformer sequence:

- direct block argument: `args["layout"] = mixed_layout`;
- canonical transformer metadata: `transformer_options["minimax_h3_layout"] = mixed_layout`.

The transformer-options dict remains a per-block copy. The carrier layout stored by the outer/native call is not mutated or leaked into later stages.

The mixed layout deliberately retains its non-uniform `h3_flow_mixed_grid_v1` signature, so geometry-aware consumers can distinguish it from an ordinary uniform H3 grid rather than interpreting target-prefix/source-suffix rows as one regular spatial lattice.

## Why this belongs in Flow

Flow owns the topology change. Downstream providers should not need to infer that the direct block `layout` has superseded stale canonical transformer metadata. Publishing the actual current layout at the point where Flow creates the mixed sequence is the narrow ownership-correct fix.

## Regression coverage

Adds a focused regression proving the helper:

- returns a copied transformer-options dict;
- replaces only `minimax_h3_layout` with the mixed layout;
- preserves unrelated attention/conditioning metadata;
- leaves the original carrier options unchanged.

The companion Spectrum core-BSA audit recognizes this exact source separately from released v0.3.3 and derives Mixed-Grid BSA conditioning sinks from the propagated mixed layout rather than emulating the historical stale-layout behavior.

## Automated validation

GitHub Actions run `34420824221` passed all **5/5** jobs on this exact commit:

- Python 3.10;
- Python 3.11;
- Python 3.12;
- Python 3.13;
- `source-contracts`, including the mixed-grid/native source oracles.

The companion Spectrum PR #106 validation is also green on the pinned Flow commit.

## Real CUDA production validation

The coordinated Spectrum + core-BSA + VDN + Continuum + Progressive Mixed-Grid production workflow has now completed successfully with this exact Flow head.

The real mixed stage reported:

```text
native carrier seq_len: 37365
mixed seq_len:          43557
mixed signature:        h3_flow_mixed_grid_v1
flow_mixed:             True
```

Spectrum audited all five Mixed-Grid low-stage calls with `safe=True`, and every actual call produced `accepted=True receipts=50 expected=50`. There were no ownership, wrapper, layout or receipt fallbacks.

The Flow metrics sidecar confirms the real non-uniform mixed sequence and VDN external-sequence path:

```text
mixed_sequence_rows:       43557
native_sequence_rows:      37365
mixed_video_rows:          38432
vdn_external_sequence_api: 2
vdn_external_sequence_mode: dense_gate_no_linear
```

This is the production case that originally motivated the fix: a target-grid prefix plus source-grid suffix inside one H3 sequence, consumed by downstream core BlockSparseAttention through the canonical `minimax_h3_layout` metadata.

The run also completed the learned suffix transfer, exact protected-prefix restoration, target-grid high stage and final exact-mask canonicalization without a Mixed-Grid failure.

## Scope

No sampler equations, latent transfer, VDN API-2 semantics, attention-measure contract, source/suffix geometry, protected-prefix handling, decode behavior, release metadata, or benchmark documentation are changed.

This is intentionally separate from open PR #25, which addresses joint-AV decode context and benchmark documentation.

## Topology

```text
base:    d876590674b27c4410ef415ff605bc7d316dcdd8
head:    860f308cc4f84f920d0c1facd4ece028584a02a0
tree:    06b056bb26b64e57aadaf051c7891ffa4fcdcd2c
commits: 1
```

The coordinated real-CUDA validation gate is now satisfied.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mixed-grid layout propagation during transformer processing.
  * Preserved existing attention and identifier settings when applying mixed layouts.
  * Prevented configuration data from being modified unexpectedly when mixed-layout options are prepared.

* **Tests**
  * Added coverage validating mixed-layout propagation, preservation of related settings, and protection of the original configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->