### PR TITLE
Implement Mixed-Grid measure and controlled handoff state transport

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,10 +99,13 @@ jobs:
             --continuum .contracts/Continuum \
             --diffaid .contracts/DiffAid \
             --vdn .contracts/VDN
+          python tools/check_state_transport_contracts.py \
+            --comfy .contracts/ComfyUI \
+            --spectrum .contracts/Spectrum
       - name: Execute mixed-grid and temporal VAE native source oracles
         env:
           COMFYUI_ROOT: ${{ github.workspace }}/.contracts/ComfyUI
         run: |
           python -m pip install --index-url https://download.pytorch.org/whl/cpu torch
           python -m pip install pytest numpy scipy einops psutil safetensors tqdm pillow comfy-kitchen comfy-aimdo
-          python -m pytest tests/test_mixed_grid.py tests/test_decode_context.py -q
+          python -m pytest tests/test_mixed_grid.py tests/test_state_transport_native.py tests/test_decode_context.py -q

--- a/h3_flow_regenerate/attention_measure.py
+++ b/h3_flow_regenerate/attention_measure.py
@@ -1,0 +1,337 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import math
+from collections.abc import Mapping, Sequence
+from math import gcd
+from typing import Any
+
+import torch
+
+ATTENTION_MEASURE_KEY = "attention_measure_v1"
+ATTENTION_MEASURE_API = 1
+ATTENTION_MEASURE_OPERATOR = "key_log_measure"
+ATTENTION_MEASURE_NORMALIZATION = "h3_native_source_carrier_v1"
+ATTENTION_MEASURE_TOPOLOGY = "mixed_grid_low_suffix"
+ATTENTION_MEASURE_COORDINATE_POLICY = "minimax_h3_native_frame_grid_v1"
+
+
+def _require_int(name: str, value: Any, *, minimum: int | None = None) -> int:
+    if type(value) is not int:
+        raise TypeError(f"{name} must be an integer")
+    if minimum is not None and value < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return value
+
+
+def _require_grid(name: str, value: Any) -> tuple[int, int]:
+    if not isinstance(value, (list, tuple)) or len(value) != 2:
+        raise TypeError(f"{name} must be a two-element integer grid")
+    return (
+        _require_int(f"{name}[0]", value[0], minimum=1),
+        _require_int(f"{name}[1]", value[1], minimum=1),
+    )
+
+
+def _normalize_ratio(num: Any, den: Any, *, name: str) -> tuple[int, int]:
+    num = _require_int(f"{name}.mass_num", num, minimum=1)
+    den = _require_int(f"{name}.mass_den", den, minimum=1)
+    common = gcd(num, den)
+    num //= common
+    den //= common
+    log_mass = math.log(num) - math.log(den)
+    if not math.isfinite(log_mass):
+        raise ValueError(f"{name} derives a non-finite key-log-measure")
+    return num, den
+
+
+def _canonical_segments(raw_segments: Sequence[Mapping[str, Any]], *, kv_rows: int) -> list[dict[str, int]]:
+    if not raw_segments:
+        raise TypeError("attention_measure_v1 segments must be a nonempty list")
+    segments: list[dict[str, int]] = []
+    cursor = 0
+    for index, raw in enumerate(raw_segments):
+        if not isinstance(raw, Mapping):
+            raise TypeError(f"segments[{index}] must be a mapping")
+        start = _require_int(f"segments[{index}].start", raw.get("start"), minimum=0)
+        stop = _require_int(f"segments[{index}].stop", raw.get("stop"), minimum=0)
+        if start != cursor or stop <= start or stop > kv_rows:
+            raise ValueError("attention_measure_v1 segments must be sorted, contiguous, nonempty, and in range")
+        mass_num, mass_den = _normalize_ratio(raw.get("mass_num"), raw.get("mass_den"), name=f"segments[{index}]")
+        if segments and (segments[-1]["mass_num"], segments[-1]["mass_den"]) == (mass_num, mass_den):
+            segments[-1]["stop"] = stop
+        else:
+            segments.append({"start": start, "stop": stop, "mass_num": mass_num, "mass_den": mass_den})
+        cursor = stop
+    if cursor != kv_rows:
+        raise ValueError("attention_measure_v1 segments must cover every key row exactly once")
+    return segments
+
+
+def build_attention_measure_request(
+    *,
+    q_rows: int,
+    kv_rows: int,
+    video_start: int,
+    temporal: int,
+    prefix_t: int,
+    source_grid: Sequence[int],
+    prefix_grid: Sequence[int],
+) -> dict[str, Any]:
+    """Build the schema-v1 Mixed-Grid key-measure request.
+
+    The request describes measure only. It never changes Q/K/V topology: all
+    rows remain present and the protected target-grid prefix receives a
+    per-key mass of ``source_rows / prefix_rows`` so one protected frame has
+    the same total spatial softmax measure as one native low-grid suffix frame.
+    """
+
+    source_h, source_w = _require_grid("source_grid", source_grid)
+    prefix_h, prefix_w = _require_grid("prefix_grid", prefix_grid)
+    source_rows = source_h * source_w
+    prefix_rows = prefix_h * prefix_w
+    prefix_stop = video_start + prefix_t * prefix_rows
+    raw_segments = []
+    if video_start:
+        raw_segments.append({"start": 0, "stop": video_start, "mass_num": 1, "mass_den": 1})
+    raw_segments.append(
+        {
+            "start": video_start,
+            "stop": prefix_stop,
+            "mass_num": source_rows,
+            "mass_den": prefix_rows,
+        }
+    )
+    if prefix_stop < kv_rows:
+        raw_segments.append({"start": prefix_stop, "stop": kv_rows, "mass_num": 1, "mass_den": 1})
+    return validate_attention_measure_request(
+        {
+            "api": ATTENTION_MEASURE_API,
+            "operator": ATTENTION_MEASURE_OPERATOR,
+            "normalization": ATTENTION_MEASURE_NORMALIZATION,
+            "topology": ATTENTION_MEASURE_TOPOLOGY,
+            "q_rows": q_rows,
+            "kv_rows": kv_rows,
+            "video_start": video_start,
+            "temporal": temporal,
+            "prefix_t": prefix_t,
+            "source_grid": [source_h, source_w],
+            "prefix_grid": [prefix_h, prefix_w],
+            "segments": raw_segments,
+            "coordinate_policy": ATTENTION_MEASURE_COORDINATE_POLICY,
+        }
+    )
+
+
+def validate_attention_measure_request(request: Mapping[str, Any]) -> dict[str, Any]:
+    """Validate and canonicalize ``attention_measure_v1`` without mutating it."""
+
+    if not isinstance(request, Mapping):
+        raise TypeError("attention_measure_v1 must be a mapping")
+    expected_literals = {
+        "api": ATTENTION_MEASURE_API,
+        "operator": ATTENTION_MEASURE_OPERATOR,
+        "normalization": ATTENTION_MEASURE_NORMALIZATION,
+        "topology": ATTENTION_MEASURE_TOPOLOGY,
+        "coordinate_policy": ATTENTION_MEASURE_COORDINATE_POLICY,
+    }
+    for key, expected in expected_literals.items():
+        if request.get(key) != expected:
+            raise ValueError(f"attention_measure_v1 {key} must be {expected!r}")
+
+    q_rows = _require_int("q_rows", request.get("q_rows"), minimum=1)
+    kv_rows = _require_int("kv_rows", request.get("kv_rows"), minimum=1)
+    if q_rows != kv_rows:
+        raise ValueError("Mixed-Grid attention measure retains all self-attention rows, so q_rows must equal kv_rows")
+    video_start = _require_int("video_start", request.get("video_start"), minimum=0)
+    if video_start >= kv_rows:
+        raise ValueError("video_start must identify a nonempty video suffix inside the sequence")
+    temporal = _require_int("temporal", request.get("temporal"), minimum=2)
+    prefix_t = _require_int("prefix_t", request.get("prefix_t"), minimum=1)
+    if prefix_t >= temporal:
+        raise ValueError("prefix_t must leave a nonempty generated suffix")
+    source_grid = _require_grid("source_grid", request.get("source_grid"))
+    prefix_grid = _require_grid("prefix_grid", request.get("prefix_grid"))
+    source_rows = math.prod(source_grid)
+    prefix_rows = math.prod(prefix_grid)
+    if source_rows > prefix_rows:
+        raise ValueError("Mixed-Grid source spatial measure cannot exceed the protected-prefix grid")
+    expected_rows = video_start + prefix_t * prefix_rows + (temporal - prefix_t) * source_rows
+    if q_rows != expected_rows:
+        raise ValueError(
+            "attention_measure_v1 row count does not match video_start + protected-prefix rows + low-grid suffix rows"
+        )
+
+    raw_segments = request.get("segments")
+    if not isinstance(raw_segments, (list, tuple)):
+        raise TypeError("attention_measure_v1 segments must be a nonempty list")
+    segments = _canonical_segments(raw_segments, kv_rows=kv_rows)
+
+    weighted_start = video_start
+    weighted_stop = video_start + prefix_t * prefix_rows
+    expected_ratio = _normalize_ratio(source_rows, prefix_rows, name="expected_prefix")
+    for segment in segments:
+        overlap = max(segment["start"], weighted_start) < min(segment["stop"], weighted_stop)
+        ratio = (segment["mass_num"], segment["mass_den"])
+        if overlap and ratio != expected_ratio:
+            raise ValueError("every protected-prefix key row must use source_rows/prefix_rows spatial measure")
+        if not overlap and ratio != (1, 1):
+            raise ValueError("non-prefix conditioning and generated-suffix key rows must retain unit measure")
+        if (
+            segment["start"] < weighted_start < segment["stop"] or segment["start"] < weighted_stop < segment["stop"]
+        ) and expected_ratio != (1, 1):
+            raise ValueError("measure segment boundaries must align with the protected-prefix key interval")
+
+    return {
+        "api": ATTENTION_MEASURE_API,
+        "operator": ATTENTION_MEASURE_OPERATOR,
+        "normalization": ATTENTION_MEASURE_NORMALIZATION,
+        "topology": ATTENTION_MEASURE_TOPOLOGY,
+        "q_rows": q_rows,
+        "kv_rows": kv_rows,
+        "video_start": video_start,
+        "temporal": temporal,
+        "prefix_t": prefix_t,
+        "source_grid": list(source_grid),
+        "prefix_grid": list(prefix_grid),
+        "segments": segments,
+        "coordinate_policy": ATTENTION_MEASURE_COORDINATE_POLICY,
+    }
+
+
+def attention_measure_semantic_digest(request: Mapping[str, Any]) -> str:
+    canonical = validate_attention_measure_request(request)
+    encoded = json.dumps(canonical, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("ascii")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def materialize_key_log_measure(
+    request: Mapping[str, Any],
+    *,
+    device: torch.device | str | None = None,
+    dtype: torch.dtype = torch.float64,
+) -> torch.Tensor:
+    """Materialize the O(T) natural-log key measure described by the request."""
+
+    canonical = validate_attention_measure_request(request)
+    if not dtype.is_floating_point:
+        raise TypeError("key log measure requires a floating-point dtype")
+    bias = torch.empty(canonical["kv_rows"], device=device, dtype=dtype)
+    for segment in canonical["segments"]:
+        value = math.log(segment["mass_num"]) - math.log(segment["mass_den"])
+        bias[segment["start"] : segment["stop"]] = value
+    return bias
+
+
+def nonunit_exact_key_ranges(request: Mapping[str, Any], *, block_size: int = 64) -> tuple[tuple[int, int], ...]:
+    """Return token ranges for every physical key block touching non-unit measure."""
+
+    canonical = validate_attention_measure_request(request)
+    block_size = _require_int("block_size", block_size, minimum=1)
+    blocks: set[int] = set()
+    for segment in canonical["segments"]:
+        if (segment["mass_num"], segment["mass_den"]) == (1, 1):
+            continue
+        first = segment["start"] // block_size
+        last = (segment["stop"] - 1) // block_size
+        blocks.update(range(first, last + 1))
+    if not blocks:
+        return ()
+    ranges: list[tuple[int, int]] = []
+    run_start = run_last = min(blocks)
+    for block in sorted(blocks)[1:]:
+        if block == run_last + 1:
+            run_last = block
+            continue
+        ranges.append((run_start * block_size, min((run_last + 1) * block_size, canonical["kv_rows"])))
+        run_start = run_last = block
+    ranges.append((run_start * block_size, min((run_last + 1) * block_size, canonical["kv_rows"])))
+    return tuple(ranges)
+
+
+def _apply_mask(scores: torch.Tensor, mask: torch.Tensor | None) -> torch.Tensor:
+    if mask is None:
+        return scores
+    if mask.device != scores.device:
+        raise ValueError("attention mask and scores must be on the same device")
+    if mask.dtype == torch.bool:
+        return scores.masked_fill(~mask, float("-inf"))
+    if not mask.dtype.is_floating_point:
+        raise TypeError("attention mask must be boolean or floating point")
+    if torch.isnan(mask).any() or torch.isposinf(mask).any():
+        raise ValueError("additive attention mask cannot contain NaN or +inf")
+    return scores + mask.to(dtype=scores.dtype)
+
+
+def dense_weighted_attention_reference(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    *,
+    key_log_measure: torch.Tensor,
+    scale: float | None = None,
+    mask: torch.Tensor | None = None,
+    key_chunk_size: int | None = None,
+) -> torch.Tensor:
+    """FP64 dense/streaming oracle for key-log-measure attention.
+
+    Q/K/V use ``(..., Tq|Tk, D)``. ``key_log_measure`` is a natural-log bias
+    over Tk and is added *after* QK score scaling. ``mask`` follows SDPA-style
+    boolean semantics (True = allowed) or additive logit-mask semantics.
+    Supplying ``key_chunk_size`` exercises the same online-softmax algebra in
+    bounded key chunks without materializing the complete score matrix.
+    """
+
+    if q.ndim < 2 or k.ndim != q.ndim or v.ndim != q.ndim:
+        raise ValueError("q, k, and v must have matching rank >= 2")
+    if q.shape[:-2] != k.shape[:-2] or q.shape[:-2] != v.shape[:-2]:
+        raise ValueError("q, k, and v batch/head dimensions must match")
+    if q.shape[-1] != k.shape[-1] or k.shape[-2] != v.shape[-2]:
+        raise ValueError("incompatible q/k/v attention dimensions")
+    if key_log_measure.device != q.device or key_log_measure.ndim != 1 or key_log_measure.shape[0] != k.shape[-2]:
+        raise ValueError("key_log_measure must be a device-matched vector with one entry per K/V row")
+    if not key_log_measure.dtype.is_floating_point or not torch.isfinite(key_log_measure).all():
+        raise ValueError("key_log_measure must be finite floating point")
+    if scale is None:
+        scale = q.shape[-1] ** -0.5
+    scale = float(scale)
+    if not math.isfinite(scale) or scale <= 0.0:
+        raise ValueError("attention scale must be finite and positive")
+
+    q64, k64, v64 = q.to(torch.float64), k.to(torch.float64), v.to(torch.float64)
+    bias64 = key_log_measure.to(torch.float64)
+    tk = k.shape[-2]
+    if key_chunk_size is None:
+        scores = torch.matmul(q64, k64.transpose(-1, -2)) * scale
+        scores = scores + bias64
+        scores = _apply_mask(scores, mask)
+        row_max = scores.amax(dim=-1, keepdim=True)
+        safe_max = torch.where(torch.isfinite(row_max), row_max, torch.zeros_like(row_max))
+        p = torch.exp(scores - safe_max)
+        p = torch.where(torch.isfinite(scores), p, torch.zeros_like(p))
+        den = p.sum(dim=-1, keepdim=True)
+        return torch.matmul(p, v64) / den.clamp_min(torch.finfo(torch.float64).tiny)
+
+    key_chunk_size = _require_int("key_chunk_size", key_chunk_size, minimum=1)
+    out_shape = (*q64.shape[:-1], v64.shape[-1])
+    row_max = torch.full((*q64.shape[:-1], 1), float("-inf"), dtype=torch.float64, device=q.device)
+    row_sum = torch.zeros_like(row_max)
+    numerator = torch.zeros(out_shape, dtype=torch.float64, device=q.device)
+    for start in range(0, tk, key_chunk_size):
+        stop = min(start + key_chunk_size, tk)
+        scores = torch.matmul(q64, k64[..., start:stop, :].transpose(-1, -2)) * scale
+        scores = scores + bias64[start:stop]
+        chunk_mask = None if mask is None else mask[..., start:stop]
+        scores = _apply_mask(scores, chunk_mask)
+        chunk_max = scores.amax(dim=-1, keepdim=True)
+        new_max = torch.maximum(row_max, chunk_max)
+        safe_old = torch.where(torch.isfinite(row_max), row_max, torch.zeros_like(row_max))
+        safe_new = torch.where(torch.isfinite(new_max), new_max, torch.zeros_like(new_max))
+        old_scale = torch.where(torch.isfinite(row_max), torch.exp(safe_old - safe_new), torch.zeros_like(row_sum))
+        p = torch.exp(scores - safe_new)
+        p = torch.where(torch.isfinite(scores), p, torch.zeros_like(p))
+        numerator = numerator * old_scale + torch.matmul(p, v64[..., start:stop, :])
+        row_sum = row_sum * old_scale + p.sum(dim=-1, keepdim=True)
+        row_max = new_max
+    return numerator / row_sum.clamp_min(torch.finfo(torch.float64).tiny)

--- a/h3_flow_regenerate/handoff.py
+++ b/h3_flow_regenerate/handoff.py
@@ -10,6 +10,10 @@ import torch
 from .geometry import normalize_target_geometry, pack_streams, unpack_streams, validate_av
 from .guidance import conditional_renoise_alignment, conditional_renoise_target
 from .sigma import H3_VIDEO_SHIFT, normalized_coordinate
+from .state_transport import (
+    HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    resolve_handoff_state_policy,
+)
 
 H3_LATENT_UPSCALER_API_VERSION = 1
 H3_LATENT_UPSCALER_KIND = "minimax_h3_learned_latent_upscaler"
@@ -54,6 +58,62 @@ def validate_learned_upscaler_provider(provider: Any) -> dict[str, Any]:
         "offload_after_upscale": offload,
         "upscale": upscale,
     }
+
+
+def upscale_learned_clean_video(
+    x0_video: torch.Tensor,
+    *,
+    target_h: int,
+    target_w: int,
+    learned_upscaler: Any,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Run and validate the learned clean-video transfer exactly once."""
+
+    provider = validate_learned_upscaler_provider(learned_upscaler)
+    learned_started = time.perf_counter()
+    learned_x0 = provider["upscale"](
+        x0_video,
+        target_h=int(target_h),
+        target_w=int(target_w),
+    )
+    learned_elapsed_ms = (time.perf_counter() - learned_started) * 1000.0
+    if not isinstance(learned_x0, torch.Tensor):
+        raise TypeError("H3 latent-upscaler provider returned a non-tensor value")
+    expected_shape = (
+        int(x0_video.shape[0]),
+        int(x0_video.shape[1]),
+        int(x0_video.shape[2]),
+        int(target_h),
+        int(target_w),
+    )
+    if tuple(learned_x0.shape) != expected_shape:
+        raise RuntimeError(
+            f"H3 latent-upscaler provider returned shape {tuple(learned_x0.shape)}; expected {expected_shape}"
+        )
+    if not learned_x0.is_floating_point():
+        raise TypeError("H3 latent-upscaler provider returned a non-floating tensor")
+    if not bool(torch.isfinite(learned_x0).all().item()):
+        raise RuntimeError("H3 latent-upscaler provider returned NaN or Inf values")
+    report = {
+        "transfer_mode": "learned_3d",
+        "provider_api_version": provider["api_version"],
+        "provider_kind": provider["kind"],
+        "model_name": provider["model_name"],
+        "source_hw": tuple(int(value) for value in x0_video.shape[-2:]),
+        "target_hw": (int(target_h), int(target_w)),
+        "temporal_length": int(x0_video.shape[2]),
+        "input_dtype": str(x0_video.dtype),
+        "input_device": str(x0_video.device),
+        "inference_precision": provider["precision"],
+        "configured_device": provider["device"],
+        "inference_device": provider["inference_device"],
+        "learned_upscale_elapsed_ms": learned_elapsed_ms,
+        "offload_after_upscale": provider["offload_after_upscale"],
+        "offloaded_after_upscale": bool(provider["offload_after_upscale"] and provider["inference_device"] == "cuda"),
+        "output_dtype": str(learned_x0.dtype),
+        "output_device": str(learned_x0.device),
+    }
+    return learned_x0, report
 
 
 @dataclass(frozen=True, slots=True)
@@ -151,6 +211,8 @@ class ProgressiveTargetInputConfig:
     suffix_dc_bridge: bool = False
     learned_upscaler: Any | None = field(default=None, repr=False, compare=False)
     suffix_geometric_bridge: bool = False
+    attention_measure_profile: str | None = None
+    handoff_state_policy: str | None = None
 
     def __post_init__(self) -> None:
         explicit = self.source_latent_h is not None or self.source_latent_w is not None
@@ -187,6 +249,16 @@ class ProgressiveTargetInputConfig:
             raise TypeError("suffix_geometric_bridge must be boolean")
         if self.suffix_geometric_bridge and self.exact_prefix_mode != "mixed_grid_low_suffix":
             raise ValueError("suffix_geometric_bridge requires mixed-grid Continuum")
+        measure_profiles = {None, "off", "legacy_representative_v1", "weighted_measure_v1"}
+        if self.attention_measure_profile not in measure_profiles:
+            raise ValueError("unsupported attention_measure_profile")
+        if self.attention_measure_profile is not None and self.exact_prefix_mode != "mixed_grid_low_suffix":
+            raise ValueError("attention_measure_profile is only supported by mixed-grid Continuum")
+        state_policy = resolve_handoff_state_policy(self.handoff_state_policy)
+        if self.handoff_state_policy is not None and self.exact_prefix_mode != "mixed_grid_low_suffix":
+            raise ValueError("handoff_state_policy is only supported by mixed-grid Continuum")
+        if state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1 and self.transfer_mode != "learned_3d":
+            raise ValueError("velocity_bicubic_v1 requires learned_3d clean transfer")
         if self.min_high_steps < 1:
             raise ValueError("min_high_steps must be positive")
 
@@ -292,57 +364,17 @@ def build_handoff_state(
         )
         report = {"transfer_mode": "bicubic"}
     elif transfer_mode == "learned_3d":
-        provider = validate_learned_upscaler_provider(learned_upscaler)
-        learned_started = time.perf_counter()
-        learned_x0 = provider["upscale"](
+        learned_x0, report = upscale_learned_clean_video(
             x0_video,
             target_h=int(target_h),
             target_w=int(target_w),
+            learned_upscaler=learned_upscaler,
         )
-        learned_elapsed_ms = (time.perf_counter() - learned_started) * 1000.0
-        if not isinstance(learned_x0, torch.Tensor):
-            raise TypeError("H3 latent-upscaler provider returned a non-tensor value")
-        expected_shape = (
-            int(x0_video.shape[0]),
-            int(x0_video.shape[1]),
-            int(x0_video.shape[2]),
-            int(target_h),
-            int(target_w),
-        )
-        if tuple(learned_x0.shape) != expected_shape:
-            raise RuntimeError(
-                f"H3 latent-upscaler provider returned shape {tuple(learned_x0.shape)}; expected {expected_shape}"
-            )
-        if not learned_x0.is_floating_point():
-            raise TypeError("H3 latent-upscaler provider returned a non-floating tensor")
-        if not bool(torch.isfinite(learned_x0).all().item()):
-            raise RuntimeError("H3 latent-upscaler provider returned NaN or Inf values")
         target_video = conditional_renoise_target(
             learned_x0,
             sigma=float(sigma),
             noise=noise,
         )
-        report = {
-            "transfer_mode": "learned_3d",
-            "provider_api_version": provider["api_version"],
-            "provider_kind": provider["kind"],
-            "model_name": provider["model_name"],
-            "source_hw": tuple(int(value) for value in x0_video.shape[-2:]),
-            "target_hw": (int(target_h), int(target_w)),
-            "temporal_length": int(x0_video.shape[2]),
-            "input_dtype": str(x0_video.dtype),
-            "input_device": str(x0_video.device),
-            "inference_precision": provider["precision"],
-            "configured_device": provider["device"],
-            "inference_device": provider["inference_device"],
-            "learned_upscale_elapsed_ms": learned_elapsed_ms,
-            "offload_after_upscale": provider["offload_after_upscale"],
-            "offloaded_after_upscale": bool(
-                provider["offload_after_upscale"] and provider["inference_device"] == "cuda"
-            ),
-            "output_dtype": str(learned_x0.dtype),
-            "output_device": str(learned_x0.device),
-        }
     else:
         raise ValueError(f"unsupported progressive handoff transfer mode {transfer_mode!r}")
     if transfer_metrics is not None:

--- a/h3_flow_regenerate/mixed_grid.py
+++ b/h3_flow_regenerate/mixed_grid.py
@@ -19,12 +19,16 @@ from dataclasses import dataclass
 
 import torch
 
+from .attention_measure import ATTENTION_MEASURE_KEY, build_attention_measure_request
 from .geometry import unpack_streams
 
 MIXED_GRID_KEY = "h3_flow_mixed_grid_v1"
 MIXED_WRAPPER_KEY = "h3_flow_regenerate.mixed_grid.v1"
 MIXED_GRID_MEASURE_KEY = "h3_flow_mixed_grid_attention_measure_v1"
 MIXED_GRID_MEASURE_MODE = "prefix_kv_stratified_subsample"
+MIXED_GRID_MEASURE_PROFILE_OFF = "off"
+MIXED_GRID_MEASURE_PROFILE_LEGACY = "legacy_representative_v1"
+MIXED_GRID_MEASURE_PROFILE_WEIGHTED = "weighted_measure_v1"
 
 
 @dataclass(frozen=True, slots=True)
@@ -35,6 +39,7 @@ class MixedGridPlan:
     source_w: int
     prefix_noise: torch.Tensor | None = None
     attention_measure: bool = False
+    measure_profile: str | None = None
 
     @property
     def prefix_t(self):
@@ -78,6 +83,7 @@ def build_mixed_grid_plan(
     source_h,
     source_w,
     attention_measure=False,
+    measure_profile=None,
 ):
     video_mask, _ = unpack_streams(mask, shapes)
     video, _ = unpack_streams(internal_latent, shapes)
@@ -110,26 +116,52 @@ def build_mixed_grid_plan(
         source_w,
         video_noise[:, :, :prefix_t].detach().clone(),
         bool(attention_measure),
+        measure_profile,
     )
 
 
-def mixed_attention_measure_contract(plan: MixedGridPlan, *, video_start: int, sequence_rows: int):
-    """Describe an optional uniform-measure K/V domain without changing VDN API 2.
+def mixed_attention_measure_profile(plan: MixedGridPlan) -> str:
+    """Resolve explicit profiles without reinterpreting serialized legacy graphs."""
+    if plan.measure_profile is None:
+        # ``attention_measure`` is the pre-profile control. Preserve its released
+        # representative semantics only when the new field is genuinely absent.
+        return MIXED_GRID_MEASURE_PROFILE_LEGACY if plan.attention_measure else MIXED_GRID_MEASURE_PROFILE_OFF
+    profile = str(plan.measure_profile)
+    if profile not in {
+        MIXED_GRID_MEASURE_PROFILE_OFF,
+        MIXED_GRID_MEASURE_PROFILE_LEGACY,
+        MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    }:
+        raise ValueError(f"unsupported Mixed-Grid measure profile {profile!r}")
+    return profile
 
-    The mixed hidden stream has target-grid prefix frames and source-grid suffix
-    frames. Equal softmax weight per row therefore gives every protected prefix
-    frame ``target_rows/source_rows`` times as much spatial measure as a suffix
-    frame. A compatible attention backend can remove that representation-density
-    artifact by retaining all Q rows while selecting one target-prefix K/V row
-    nearest each source-grid spatial coordinate. The suffix K/V domain is already
-    at source density and is copied unchanged.
+
+def mixed_attention_measure_contract(plan: MixedGridPlan, *, video_start: int, sequence_rows: int):
+    """Build the selected Mixed-Grid measure contract without changing VDN API 2.
+
+    ``legacy_representative_v1`` preserves the released deterministic reduced-K/V
+    contract for migrated graphs. ``weighted_measure_v1`` publishes the generic
+    all-row key-log-measure operator: Q/K/V topology stays unchanged and only the
+    protected-prefix key counting measure changes.
     """
-    if not plan.attention_measure:
+    profile = mixed_attention_measure_profile(plan)
+    if profile == MIXED_GRID_MEASURE_PROFILE_OFF:
         return None
     if type(video_start) is not int or type(sequence_rows) is not int:
         raise TypeError("mixed-grid attention-measure row counts must be integers")
     if video_start <= 0 or sequence_rows != video_start + plan.mixed_rows:
         raise ValueError("mixed-grid attention-measure rows do not match the mixed sequence")
+    if profile == MIXED_GRID_MEASURE_PROFILE_WEIGHTED:
+        return build_attention_measure_request(
+            q_rows=sequence_rows,
+            kv_rows=sequence_rows,
+            video_start=video_start,
+            temporal=plan.temporal,
+            prefix_t=plan.prefix_t,
+            source_grid=plan.source_grid,
+            prefix_grid=plan.target_grid,
+        )
+
     source_grid_h, source_grid_w = plan.source_grid
     prefix_grid_h, prefix_grid_w = plan.target_grid
     expected_kv_rows = video_start + plan.temporal * plan.source_rows
@@ -150,6 +182,13 @@ def mixed_attention_measure_contract(plan: MixedGridPlan, *, video_start: int, s
         "exact_prefix_queries_preserved": True,
         "suffix_kv_unchanged": True,
     }
+
+
+def _mixed_attention_measure_key(plan: MixedGridPlan) -> str:
+    profile = mixed_attention_measure_profile(plan)
+    if profile == MIXED_GRID_MEASURE_PROFILE_WEIGHTED:
+        return ATTENTION_MEASURE_KEY
+    return MIXED_GRID_MEASURE_KEY
 
 
 def carrier_layout(native, plan, text_len, audio_t, payload):
@@ -278,13 +317,24 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
                     mixed_sequence_rows=mixed_layout.seq_len,
                     vdn_external_sequence_mode="dense_gate_no_linear",
                     vdn_external_sequence_api=2,
-                    attention_measure_requested=bool(plan.attention_measure),
-                    attention_measure_mode=(MIXED_GRID_MEASURE_MODE if measure_contract is not None else "disabled"),
+                    attention_measure_requested=measure_contract is not None,
+                    attention_measure_profile=mixed_attention_measure_profile(plan),
+                    attention_measure_mode=(
+                        measure_contract.get("operator", MIXED_GRID_MEASURE_MODE)
+                        if measure_contract is not None
+                        else "disabled"
+                    ),
                     attention_measure_prefix_kv_rows_before=plan.prefix_rows,
-                    attention_measure_prefix_kv_rows_after=plan.prefix_t * plan.source_rows,
+                    attention_measure_prefix_kv_rows_after=(
+                        plan.prefix_t * plan.source_rows
+                        if mixed_attention_measure_profile(plan) == MIXED_GRID_MEASURE_PROFILE_LEGACY
+                        else plan.prefix_rows
+                    ),
                     attention_measure_kv_rows_before=mixed_layout.seq_len,
                     attention_measure_kv_rows_after=(
-                        layout.seq_len if measure_contract is not None else mixed_layout.seq_len
+                        layout.seq_len
+                        if mixed_attention_measure_profile(plan) == MIXED_GRID_MEASURE_PROFILE_LEGACY
+                        else mixed_layout.seq_len
                     ),
                     attention_measure_prefix_density_ratio=plan.target_rows / plan.source_rows,
                     prefix_exact_latent_resized=False,
@@ -319,9 +369,10 @@ def mixed_diffusion_wrapper(executor, x, timestep, context, transformer_options=
                 "prefix_rows_per_frame": plan.target_rows,
             }
             if measure_contract is not None:
-                if MIXED_GRID_MEASURE_KEY in block_options:
+                measure_key = _mixed_attention_measure_key(plan)
+                if ATTENTION_MEASURE_KEY in block_options or MIXED_GRID_MEASURE_KEY in block_options:
                     raise RuntimeError("mixed-grid found an already-owned attention-measure contract")
-                block_options[MIXED_GRID_MEASURE_KEY] = measure_contract
+                block_options[measure_key] = measure_contract
             forwarded["transformer_options"] = block_options
             output = previous(forwarded, extra) if previous else extra["original_block"](forwarded)
             result = output["img"]

--- a/h3_flow_regenerate/runtime.py
+++ b/h3_flow_regenerate/runtime.py
@@ -12,6 +12,7 @@ from typing import Any
 
 import torch
 
+from .attention_measure import ATTENTION_MEASURE_KEY
 from .contracts import H3FlowTrajectory, TrajectorySample
 from .geometry import geometry_from_video, pack_streams, resize_spatial_5d, unpack_streams
 from .guidance import GuidanceConfig, GuidanceState, apply_guidance
@@ -21,9 +22,18 @@ from .handoff import (
     build_handoff_state,
     deterministic_video_noise,
     select_handoff_index,
+    upscale_learned_clean_video,
 )
 from .metrics import H3FlowMetrics
-from .mixed_grid import MIXED_GRID_KEY, build_mixed_grid_plan
+from .mixed_grid import (
+    MIXED_GRID_KEY,
+    MIXED_GRID_MEASURE_KEY,
+    MIXED_GRID_MEASURE_PROFILE_LEGACY,
+    MIXED_GRID_MEASURE_PROFILE_OFF,
+    MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    build_mixed_grid_plan,
+    mixed_attention_measure_profile,
+)
 from .representation_bridge import (
     apply_suffix_representation_bridge,
     disabled_suffix_representation_bridge_metrics,
@@ -35,6 +45,12 @@ from .seam_diagnostics import (
 )
 from .sigma import H3_AUDIO_SHIFT, H3_VIDEO_SHIFT, audio_sigma, normalized_coordinate
 from .source_trajectory_bridge import disabled_source_trajectory_bridge_metrics
+from .state_transport import (
+    HANDOFF_STATE_POLICY_LEGACY,
+    HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    resolve_handoff_state_policy,
+    transport_velocity_bicubic_v1,
+)
 from .target_sparse import TARGET_SPARSE_CONTRACT_KEY, build_target_sparse_plan, target_sparse_contract
 from .tone_bridge import (
     apply_suffix_dc_bridge,
@@ -1269,6 +1285,10 @@ def _run_progressive(
         and _has_exact_video_protection(denoise_mask, input_shapes)
     )
     mixed_plan = None
+    requested_state_policy = HANDOFF_STATE_POLICY_LEGACY
+    if isinstance(config, ProgressiveTargetInputConfig) and config.exact_prefix_mode == "mixed_grid_low_suffix":
+        requested_state_policy = resolve_handoff_state_policy(getattr(config, "handoff_state_policy", None))
+    effective_state_policy = requested_state_policy if mixed else HANDOFF_STATE_POLICY_LEGACY
     if (
         not mixed
         and isinstance(config, ProgressiveTargetInputConfig)
@@ -1365,7 +1385,9 @@ def _run_progressive(
                 source_h=source_h,
                 source_w=source_w,
                 attention_measure=bool(getattr(config, "suffix_geometric_bridge", False)),
+                measure_profile=getattr(config, "attention_measure_profile", None),
             )
+            measure_profile = mixed_attention_measure_profile(mixed_plan)
             binding.metrics.event(
                 "mixed_grid_plan",
                 input_mode="mixed_grid_low_suffix",
@@ -1384,9 +1406,14 @@ def _run_progressive(
                 suffix_source_grid_rope=True,
                 continuous_temporal_rope=True,
                 low_suffix_real_latent=True,
-                attention_measure_requested=bool(mixed_plan.attention_measure),
+                handoff_state_policy_requested=requested_state_policy,
+                handoff_state_policy=effective_state_policy,
+                attention_measure_requested=measure_profile != MIXED_GRID_MEASURE_PROFILE_OFF,
+                attention_measure_profile=measure_profile,
                 attention_measure_contract=(
-                    "h3_flow_mixed_grid_attention_measure_v1" if mixed_plan.attention_measure else None
+                    ATTENTION_MEASURE_KEY
+                    if measure_profile == MIXED_GRID_MEASURE_PROFILE_WEIGHTED
+                    else (MIXED_GRID_MEASURE_KEY if measure_profile == MIXED_GRID_MEASURE_PROFILE_LEGACY else None)
                 ),
             )
         source_shapes = list(target_shapes)
@@ -1438,6 +1465,8 @@ def _run_progressive(
         input_mode="mixed_grid_low_suffix" if mixed else ("target_grid" if target_input else "source_grid"),
         source_shape=source_shapes[0],
         target_hw=(target_h, target_w),
+        handoff_state_policy_requested=(requested_state_policy if target_input else None),
+        handoff_state_policy=(effective_state_policy if target_input else None),
     )
 
     sampler_invocation_count = 0
@@ -1532,6 +1561,11 @@ def _run_progressive(
     binding.metrics.increment("handoff_exact_probe_nfe")
     try:
         source_x0 = _process_latent_in(base_model, source_x0, source_shapes)
+        accepted_source_x0 = (
+            source_x0.detach().clone()
+            if mixed_plan is not None and effective_state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+            else None
+        )
         if mixed_plan is not None:
             # Use all prefix frames as transient upscaler context. Its 3D attention
             # has no proven finite temporal receptive field permitting truncation.
@@ -1565,32 +1599,54 @@ def _run_progressive(
         transfer_started = time.perf_counter()
         transfer_metrics: dict[str, Any] = {}
         splice_diagnostics: dict[str, Any] = {}
-        target_raw, target_shapes = build_handoff_state(
-            source_packed_state=source_raw,
-            source_x0_packed=source_x0,
-            source_shapes=source_shapes,
-            sigma=sigma,
-            target_h=target_h,
-            target_w=target_w,
-            seed=int(seed or 0) + config.seed_offset,
-            transfer_mode=config.transfer_mode,
-            learned_upscaler=getattr(config, "learned_upscaler", None),
-            transfer_metrics=transfer_metrics,
-        )
-        if mixed_plan is not None:
-            target_video, target_audio = unpack_streams(target_raw, target_shapes)
-            diagnostic_started = time.perf_counter()
-            diagnostic_noise = deterministic_video_noise(
-                tuple(target_video.shape),
-                seed=int(seed or 0) + config.seed_offset,
-                device=target_video.device,
-                dtype=target_video.dtype,
+        state_transport_metrics: dict[str, Any] = {
+            "handoff_state_policy": effective_state_policy,
+            "state_transport_applied": False,
+        }
+        diagnostic_noise = None
+
+        if mixed_plan is not None and effective_state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1:
+            if accepted_source_x0 is None:
+                raise RuntimeError("velocity state transport lost the immutable accepted probe clean")
+            provider_video, _provider_audio = unpack_streams(source_x0, source_shapes)
+            learned_clean, transfer_metrics = upscale_learned_clean_video(
+                provider_video,
+                target_h=target_h,
+                target_w=target_w,
+                learned_upscaler=getattr(config, "learned_upscaler", None),
             )
-            learned_clean = recover_conditional_clean_for_diagnostics(
-                target_video,
-                diagnostic_noise,
+            source_state_video, source_audio = unpack_streams(source_raw, source_shapes)
+            accepted_clean_video, _accepted_clean_audio = unpack_streams(accepted_source_x0, source_shapes)
+            target_audio = source_audio.clone()
+        else:
+            target_raw, target_shapes = build_handoff_state(
+                source_packed_state=source_raw,
+                source_x0_packed=source_x0,
+                source_shapes=source_shapes,
                 sigma=sigma,
+                target_h=target_h,
+                target_w=target_w,
+                seed=int(seed or 0) + config.seed_offset,
+                transfer_mode=config.transfer_mode,
+                learned_upscaler=getattr(config, "learned_upscaler", None),
+                transfer_metrics=transfer_metrics,
             )
+            if mixed_plan is not None:
+                target_video, target_audio = unpack_streams(target_raw, target_shapes)
+                diagnostic_noise = deterministic_video_noise(
+                    tuple(target_video.shape),
+                    seed=int(seed or 0) + config.seed_offset,
+                    device=target_video.device,
+                    dtype=target_video.dtype,
+                )
+                learned_clean = recover_conditional_clean_for_diagnostics(
+                    target_video,
+                    diagnostic_noise,
+                    sigma=sigma,
+                )
+
+        if mixed_plan is not None:
+            diagnostic_started = time.perf_counter()
             exact_prefix = mixed_plan.prefix.to(device=learned_clean.device, dtype=learned_clean.dtype)
             representation_requested = bool(getattr(config, "suffix_geometric_bridge", False))
             if representation_requested:
@@ -1620,30 +1676,32 @@ def _run_progressive(
                 int(representation_metrics["suffix_representation_bridge_corrected_tokens"]),
                 int(bridge_metrics["suffix_dc_bridge_corrected_tokens"]),
             )
-            if corrected_tokens:
-                target_video = map_clean_bridge_to_conditional_state(
-                    target_video,
-                    learned_clean,
-                    corrected_clean,
-                    sigma=sigma,
-                    prefix_t=mixed_plan.prefix_t,
-                    corrected_tokens=corrected_tokens,
-                )
             splice_diagnostics = measure_exact_prefix_splice(
                 learned_clean,
                 exact_prefix,
                 corrected_clean_video=corrected_clean,
             )
             splice_diagnostics["splice_diagnostic_elapsed_ms"] = (time.perf_counter() - diagnostic_started) * 1000.0
-            splice_diagnostics["splice_recovery"] = "inverse_conditional_renoise"
-            splice_diagnostics["suffix_dc_bridge_state_mapping"] = (
-                "affine_equivalent_pre_renoise" if dc_enabled else "disabled"
-            )
-            splice_diagnostics["suffix_representation_bridge_state_mapping"] = (
-                "affine_equivalent_pre_renoise"
-                if representation_metrics["suffix_representation_bridge_accepted"]
-                else "disabled_or_noop"
-            )
+            if effective_state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1:
+                splice_diagnostics["splice_recovery"] = "retained_learned_clean"
+                splice_diagnostics["suffix_dc_bridge_state_mapping"] = (
+                    "clean_reanchor_velocity_bicubic_v1" if dc_enabled else "disabled"
+                )
+                splice_diagnostics["suffix_representation_bridge_state_mapping"] = (
+                    "clean_reanchor_velocity_bicubic_v1"
+                    if representation_metrics["suffix_representation_bridge_accepted"]
+                    else "disabled_or_noop"
+                )
+            else:
+                splice_diagnostics["splice_recovery"] = "inverse_conditional_renoise"
+                splice_diagnostics["suffix_dc_bridge_state_mapping"] = (
+                    "affine_equivalent_pre_renoise" if dc_enabled else "disabled"
+                )
+                splice_diagnostics["suffix_representation_bridge_state_mapping"] = (
+                    "affine_equivalent_pre_renoise"
+                    if representation_metrics["suffix_representation_bridge_accepted"]
+                    else "disabled_or_noop"
+                )
             binding.metrics.increment("mixed_grid_splice_diagnostic_runs")
             binding.metrics.event(
                 "mixed_grid_representation_bridge",
@@ -1653,10 +1711,30 @@ def _run_progressive(
                 **representation_metrics,
             )
 
-            if not corrected_tokens:
-                target_video = target_video.clone()
+            if effective_state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1:
+                target_video, state_transport_metrics = transport_velocity_bicubic_v1(
+                    source_state_video,
+                    accepted_clean_video,
+                    corrected_clean,
+                    prefix_t=mixed_plan.prefix_t,
+                )
+                binding.metrics.increment("mixed_grid_state_transport_runs")
+                binding.metrics.event("mixed_grid_state_transport", **state_transport_metrics)
+            else:
+                if corrected_tokens:
+                    target_video = map_clean_bridge_to_conditional_state(
+                        target_video,
+                        learned_clean,
+                        corrected_clean,
+                        sigma=sigma,
+                        prefix_t=mixed_plan.prefix_t,
+                        corrected_tokens=corrected_tokens,
+                    )
+                else:
+                    target_video = target_video.clone()
+
             target_video[:, :, : mixed_plan.prefix_t] = mixed_plan.prefix.to(target_video)
-            target_raw = pack_streams((target_video, target_audio))[0]
+            target_raw, target_shapes = pack_streams((target_video, target_audio))
             binding.metrics.event(
                 "mixed_grid_transfer",
                 learned_transfer_performed=True,
@@ -1664,6 +1742,7 @@ def _run_progressive(
                 upscaler_prefix_output_discarded=True,
                 final_original_prefix_restored=True,
                 transfer_mode="learned_3d_suffix",
+                handoff_state_policy_requested=requested_state_policy,
                 source_trajectory_bridge_requested=source_trajectory_metrics["source_trajectory_bridge_requested"],
                 source_trajectory_bridge_accepted=source_trajectory_metrics["source_trajectory_bridge_accepted"],
                 source_trajectory_bridge_reason=source_trajectory_metrics["source_trajectory_bridge_reason"],
@@ -1676,11 +1755,16 @@ def _run_progressive(
                 source_trajectory_residual_reduction_ratio=source_trajectory_metrics.get(
                     "source_trajectory_residual_reduction_ratio", [None] * 4
                 ),
+                **state_transport_metrics,
                 **representation_metrics,
                 **bridge_metrics,
                 **splice_diagnostics,
             )
-            del diagnostic_noise, learned_clean, corrected_clean
+            if diagnostic_noise is not None:
+                del diagnostic_noise
+            del learned_clean, corrected_clean
+        if accepted_source_x0 is not None:
+            del accepted_source_x0
         if config.transfer_mode == "learned_3d":
             binding.metrics.event(
                 "handoff_learned_upscale_wall",
@@ -1779,6 +1863,7 @@ def _run_progressive(
                 "mixed_grid_complete",
                 final_prefix_exact=True,
                 high_stage_first_call_actual=first_high_actual,
+                handoff_state_policy=effective_state_policy,
                 total_chunk_sampler_elapsed_ms=(time.perf_counter() - chunk_started) * 1000.0,
                 final_seam_lowpass_kernel=final_boundary["lowpass_kernel"],
                 final_seam_rms=final_boundary["seam_rms"],
@@ -1812,6 +1897,8 @@ def _run_progressive(
             conditioning_rebuilt_for_high_grid=True,
             transfer_mode=config.transfer_mode,
             input_mode="mixed_grid_low_suffix" if mixed else ("target_grid" if target_input else "source_grid"),
+            handoff_state_policy_requested=(requested_state_policy if target_input else None),
+            handoff_state_policy=(effective_state_policy if target_input else None),
         )
         return result
 

--- a/h3_flow_regenerate/state_transport.py
+++ b/h3_flow_regenerate/state_transport.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+from typing import Any
+
+import torch
+import torch.nn.functional as F
+
+from .geometry import resize_spatial_5d, validate_video
+
+HANDOFF_STATE_POLICY_LEGACY = "legacy_renoise"
+HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1 = "velocity_bicubic_v1"
+HANDOFF_STATE_POLICIES = frozenset(
+    {
+        HANDOFF_STATE_POLICY_LEGACY,
+        HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    }
+)
+
+
+def resolve_handoff_state_policy(policy: str | None) -> str:
+    """Resolve serialized/omitted state policy without changing legacy graphs."""
+
+    if policy is None:
+        return HANDOFF_STATE_POLICY_LEGACY
+    if not isinstance(policy, str):
+        raise TypeError("handoff_state_policy must be a string or None")
+    if policy not in HANDOFF_STATE_POLICIES:
+        raise ValueError(f"unsupported handoff_state_policy {policy!r}")
+    return policy
+
+
+def _transport_compute_dtype(*tensors: torch.Tensor) -> torch.dtype:
+    # Keep algebraic FP64 fixtures genuinely FP64. Production half/BF16/FP32
+    # inputs use FP32 for subtraction/interpolation/addition, then cast back.
+    if tensors and all(tensor.dtype == torch.float64 for tensor in tensors):
+        return torch.float64
+    return torch.float32
+
+
+def _resize_displacement(
+    displacement: torch.Tensor,
+    target_h: int,
+    target_w: int,
+) -> torch.Tensor:
+    """Apply the fixed framewise bicubic state lift from the design contract."""
+
+    source_h, source_w = map(int, displacement.shape[-2:])
+    if target_h < source_h or target_w < source_w:
+        raise ValueError("state transport must not shrink either video axis")
+    if target_h == source_h and target_w == source_w:
+        return displacement.clone()
+
+    if displacement.dtype != torch.float64:
+        # geometry.resize_spatial_5d already fixes align_corners=False and sets
+        # antialias=False for non-shrinking geometry.
+        return resize_spatial_5d(displacement, target_h, target_w, mode="bicubic")
+
+    # resize_spatial_5d deliberately computes production dtypes in FP32. Keep a
+    # narrow FP64 oracle path here rather than changing geometry semantics.
+    b, c, t, h, w = displacement.shape
+    work = displacement.permute(0, 2, 1, 3, 4).reshape(b * t, c, h, w)
+    out = F.interpolate(
+        work,
+        size=(int(target_h), int(target_w)),
+        mode="bicubic",
+        align_corners=False,
+        antialias=False,
+    )
+    return out.reshape(b, t, c, int(target_h), int(target_w)).permute(0, 2, 1, 3, 4)
+
+
+def transport_velocity_bicubic_v1(
+    source_state_video: torch.Tensor,
+    source_clean_video: torch.Tensor,
+    target_clean_video: torch.Tensor,
+    *,
+    prefix_t: int,
+) -> tuple[torch.Tensor, dict[str, Any]]:
+    """Re-anchor the generated suffix while preserving source flow displacement.
+
+    For generated suffix frames this implements exactly
+
+        X_target = C_target + U(X_source - C_source)
+
+    where U is a fixed framewise bicubic spatial lift. Protected target-prefix
+    rows are copied from ``target_clean_video`` only as staging values; caller
+    ownership is restored by the runtime before high-stage sampling.
+    """
+
+    source_state_video = validate_video(source_state_video)
+    source_clean_video = validate_video(source_clean_video)
+    target_clean_video = validate_video(target_clean_video)
+
+    if source_state_video.shape != source_clean_video.shape:
+        raise ValueError("source sampler state and accepted clean prediction must have identical video geometry")
+    if source_state_video.device != source_clean_video.device:
+        raise ValueError("source sampler state and accepted clean prediction must share a device")
+    if source_state_video.shape[:3] != target_clean_video.shape[:3]:
+        raise ValueError("state transport cannot change batch, channel, or temporal geometry")
+    if target_clean_video.device != source_state_video.device:
+        raise ValueError("source and target state-transport videos must share a device")
+
+    temporal = int(source_state_video.shape[2])
+    if type(prefix_t) is not int or not 0 < prefix_t < temporal:
+        raise ValueError("state transport requires a nonempty exact prefix and generated suffix")
+
+    source_h, source_w = map(int, source_state_video.shape[-2:])
+    target_h, target_w = map(int, target_clean_video.shape[-2:])
+    if target_h < source_h or target_w < source_w:
+        raise ValueError("state transport target must not shrink either video axis")
+    if target_h == source_h and target_w == source_w:
+        raise ValueError("velocity_bicubic_v1 is only defined for a changed spatial geometry")
+
+    for name, tensor in (
+        ("source sampler state", source_state_video),
+        ("source accepted clean", source_clean_video),
+        ("target corrected clean", target_clean_video),
+    ):
+        if not bool(torch.isfinite(tensor).all().item()):
+            raise ValueError(f"{name} contains NaN or Inf")
+
+    compute_dtype = _transport_compute_dtype(source_state_video, source_clean_video, target_clean_video)
+    source_suffix_state = source_state_video[:, :, prefix_t:].to(dtype=compute_dtype)
+    source_suffix_clean = source_clean_video[:, :, prefix_t:].to(dtype=compute_dtype)
+    target_suffix_clean = target_clean_video[:, :, prefix_t:].to(dtype=compute_dtype)
+
+    displacement = source_suffix_state - source_suffix_clean
+    source_roundtrip_error = source_suffix_clean + displacement - source_suffix_state
+    lifted_displacement = _resize_displacement(displacement, target_h, target_w)
+    if lifted_displacement.dtype != compute_dtype:
+        lifted_displacement = lifted_displacement.to(dtype=compute_dtype)
+    if not bool(torch.isfinite(lifted_displacement).all().item()):
+        raise RuntimeError("lifted state displacement contains NaN or Inf")
+
+    target_video = target_clean_video.clone()
+    reconstructed_suffix = target_suffix_clean + lifted_displacement
+    if not bool(torch.isfinite(reconstructed_suffix).all().item()):
+        raise RuntimeError("reconstructed target sampler state contains NaN or Inf")
+    target_video[:, :, prefix_t:] = reconstructed_suffix.to(dtype=target_video.dtype)
+
+    realized_suffix = target_video[:, :, prefix_t:].to(dtype=compute_dtype)
+    closure_error = realized_suffix - target_suffix_clean - lifted_displacement
+    source_rms = float(displacement.square().mean().sqrt().item())
+    lifted_rms = float(lifted_displacement.square().mean().sqrt().item())
+    metrics = {
+        "handoff_state_policy": HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+        "state_transport_applied": True,
+        "state_transport_prefix_t": prefix_t,
+        "state_transport_source_hw": (source_h, source_w),
+        "state_transport_target_hw": (target_h, target_w),
+        "state_transport_compute_dtype": str(compute_dtype),
+        "state_transport_source_displacement_rms": source_rms,
+        "state_transport_lifted_displacement_rms": lifted_rms,
+        "state_transport_lifted_over_source_rms_ratio": lifted_rms / max(source_rms, 1e-30),
+        "state_transport_source_roundtrip_max_abs": float(source_roundtrip_error.abs().max().item()),
+        "state_transport_source_roundtrip_rms": float(source_roundtrip_error.square().mean().sqrt().item()),
+        "state_transport_target_closure_max_abs": float(closure_error.abs().max().item()),
+        "state_transport_target_closure_rms": float(closure_error.square().mean().sqrt().item()),
+        "state_transport_added_rng": False,
+        "state_transport_temporal_mixing": False,
+        "state_transport_amplitude_normalization": False,
+    }
+    return target_video, metrics

--- a/h3_flow_regenerate/target_sparse_node.py
+++ b/h3_flow_regenerate/target_sparse_node.py
@@ -67,6 +67,8 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
         learned_upscaler=None,
         suffix_dc_bridge=True,
         suffix_geometric_bridge=None,
+        attention_measure_profile=None,
+        handoff_state_policy=None,
     ):
         # Keep direct Python calls consistent with the inherited Target Input
         # handoff default. Mixed-Grid additionally enables its validated seam
@@ -85,6 +87,8 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
                 exact_prefix_mode=self.EXACT_PREFIX_MODE,
                 suffix_dc_bridge=bool(suffix_dc_bridge),
                 suffix_geometric_bridge=bool(suffix_geometric_bridge),
+                attention_measure_profile=attention_measure_profile,
+                handoff_state_policy=handoff_state_policy,
                 learned_upscaler=learned_upscaler,
             )
         else:
@@ -98,6 +102,8 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
                 exact_prefix_mode=self.EXACT_PREFIX_MODE,
                 suffix_dc_bridge=bool(suffix_dc_bridge),
                 suffix_geometric_bridge=bool(suffix_geometric_bridge),
+                attention_measure_profile=attention_measure_profile,
+                handoff_state_policy=handoff_state_policy,
                 learned_upscaler=learned_upscaler,
             )
         guidance = GuidanceConfig(
@@ -126,11 +132,11 @@ class H3ProgressiveTargetSparseHandoff(H3ProgressiveTargetInputHandoff):
 class H3ProgressiveMixedGridHandoff(H3ProgressiveTargetSparseHandoff):
     EXACT_PREFIX_MODE = "mixed_grid_low_suffix"
     DESCRIPTION = (
-        "Recommended accelerated exact-prefix Continuum path. It keeps the authoritative target-grid "
-        "protected-prefix conditioning, generates a genuine low-grid suffix, performs learned 3D latent "
-        "transfer, restores the exact prefix, and starts fresh target-grid refinement. Requires an H3 "
-        "latent-upscaler provider and VDN external-sequence API v2 when VDN is enabled. The validated "
-        "one-token DC bridge and Mixed-Grid seam-repair path are enabled by default."
+        "Accelerated exact-prefix Continuum path. It keeps the authoritative target-grid protected-prefix "
+        "conditioning, generates a genuine low-grid suffix, performs learned 3D clean-latent transfer, "
+        "restores the exact prefix, and starts fresh target-grid refinement. Requires an H3 latent-upscaler "
+        "provider and VDN external-sequence API v2 when VDN is enabled. State transport is an explicit "
+        "experimental policy and remains legacy re-noise by default until matched media acceptance."
     )
 
     @classmethod
@@ -171,20 +177,43 @@ class H3ProgressiveMixedGridHandoff(H3ProgressiveTargetSparseHandoff):
                 "default": True,
                 "tooltip": (
                     "One-token suffix-only per-channel DC bridge. Uses the discarded learned prefix as "
-                    "calibration while keeping the authoritative Continuum prefix bit-exact. Enabled by "
-                    "default after matched multi-boundary decoded-media validation removed the handoff flash."
+                    "calibration while keeping the authoritative Continuum prefix bit-exact."
                 ),
             },
         )
-        inputs.setdefault("optional", {})["suffix_geometric_bridge"] = (
+        optional = inputs.setdefault("optional", {})
+        optional["suffix_geometric_bridge"] = (
             "BOOLEAN",
             {
                 "default": True,
                 "tooltip": (
-                    "Enable the validated Mixed-Grid seam-repair path. It publishes the protected-prefix K/V "
-                    "measure contract for compatible Sol-H3 backends and applies the independent target "
-                    "exact-overlap representation reconciliation after learned transfer. The authoritative "
-                    "prefix, generated suffix ownership, audio, masks, conditioning and H3 NFE count are preserved."
+                    "Enable the target-side exact-overlap representation reconciliation after learned transfer. "
+                    "This control is independent of the explicit attention measure profile. For serialized "
+                    "pre-profile workflows only, its historical true value still selects the released legacy "
+                    "representative-K/V measure so old graphs do not silently change numerical semantics."
+                ),
+            },
+        )
+        optional["attention_measure_profile"] = (
+            ["weighted_measure_v1", "legacy_representative_v1", "off"],
+            {
+                "default": "weighted_measure_v1",
+                "tooltip": (
+                    "Mixed-Grid attention measure. weighted_measure_v1 is the canonical all-Q/K/V operator and "
+                    "publishes attention_measure_v1 independently of seam controls. legacy_representative_v1 "
+                    "keeps the released reduced-K/V comparator; off is an explicit unweighted diagnostic control."
+                ),
+            },
+        )
+        optional["handoff_state_policy"] = (
+            ["legacy_renoise", "velocity_bicubic_v1"],
+            {
+                "default": "legacy_renoise",
+                "tooltip": (
+                    "Mixed-Grid handoff state policy. legacy_renoise preserves released behavior. "
+                    "velocity_bicubic_v1 re-anchors the learned corrected clean suffix while transporting "
+                    "the source sampler displacement X-C with a fixed framewise bicubic lift. This is an "
+                    "experimental controlled candidate until matched CUDA/media validation is accepted."
                 ),
             },
         )

--- a/tests/test_attention_measure.py
+++ b/tests/test_attention_measure.py
@@ -1,0 +1,161 @@
+import pytest
+import torch
+
+from h3_flow_regenerate import attention_measure as m
+
+
+def request(**overrides):
+    args = dict(
+        q_rows=30,
+        kv_rows=30,
+        video_start=6,
+        temporal=3,
+        prefix_t=1,
+        source_grid=(2, 3),
+        prefix_grid=(3, 4),
+    )
+    args.update(overrides)
+    return m.build_attention_measure_request(**args)
+
+
+def test_schema_is_complete_normalized_and_deterministic():
+    r = request()
+    assert r["segments"] == [
+        {"start": 0, "stop": 6, "mass_num": 1, "mass_den": 1},
+        {"start": 6, "stop": 18, "mass_num": 1, "mass_den": 2},
+        {"start": 18, "stop": 30, "mass_num": 1, "mass_den": 1},
+    ]
+    assert m.attention_measure_semantic_digest(r) == m.attention_measure_semantic_digest(
+        dict(reversed(list(r.items())))
+    )
+
+    # Segment spelling is not numerical identity. Equivalent adjacent segments
+    # canonicalize before hashing so receipt/history identity stays stable.
+    subdivided = {
+        **r,
+        "segments": [
+            {"start": 0, "stop": 2, "mass_num": 7, "mass_den": 7},
+            {"start": 2, "stop": 6, "mass_num": 1, "mass_den": 1},
+            {"start": 6, "stop": 12, "mass_num": 2, "mass_den": 4},
+            {"start": 12, "stop": 18, "mass_num": 1, "mass_den": 2},
+            {"start": 18, "stop": 30, "mass_num": 1, "mass_den": 1},
+        ],
+    }
+    assert m.validate_attention_measure_request(subdivided)["segments"] == r["segments"]
+    assert m.attention_measure_semantic_digest(subdivided) == m.attention_measure_semantic_digest(r)
+
+
+def test_measure_equalizes_per_frame_spatial_mass_and_preserves_unit_regions():
+    b = m.materialize_key_log_measure(request())
+    w = b.exp()
+    assert torch.equal(b[:6], torch.zeros(6, dtype=torch.float64))
+    assert torch.equal(b[18:], torch.zeros(12, dtype=torch.float64))
+    assert float(w[6:18].sum()) == pytest.approx(6.0)
+    assert float(w[18:24].sum()) == pytest.approx(6.0)
+    assert float(w[24:30].sum()) == pytest.approx(6.0)
+
+
+def test_equal_grid_is_unit_measure_and_native_identity():
+    r = m.build_attention_measure_request(
+        q_rows=18,
+        kv_rows=18,
+        video_start=6,
+        temporal=2,
+        prefix_t=1,
+        source_grid=(2, 3),
+        prefix_grid=(2, 3),
+    )
+    assert r["segments"] == [
+        {"start": 0, "stop": 18, "mass_num": 1, "mass_den": 1},
+    ]
+    assert m.nonunit_exact_key_ranges(r) == ()
+    assert torch.equal(m.materialize_key_log_measure(r), torch.zeros(18, dtype=torch.float64))
+
+
+def test_subdivision_invariance_and_post_scale_bias():
+    torch.manual_seed(7)
+    q = torch.randn(2, 3, 5, 4, dtype=torch.float64)
+    k = torch.randn(2, 3, 30, 4, dtype=torch.float64)
+    v = torch.randn(2, 3, 30, 6, dtype=torch.float64)
+    bias = m.materialize_key_log_measure(request())
+    dense = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, scale=0.37)
+    for chunk in (1, 2, 7, 16, 29, 64):
+        streamed = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, scale=0.37, key_chunk_size=chunk)
+        torch.testing.assert_close(streamed, dense, rtol=1e-12, atol=1e-12)
+
+    q0 = torch.zeros(1, 1, 1, 2, dtype=torch.float64)
+    k0 = torch.zeros(1, 1, 30, 2, dtype=torch.float64)
+    v0 = torch.eye(30, dtype=torch.float64).reshape(1, 1, 30, 30)
+    out = m.dense_weighted_attention_reference(q0, k0, v0, key_log_measure=bias, scale=9.0)
+    assert out[0, 0, 0, 6].item() / out[0, 0, 0, 0].item() == pytest.approx(0.5)
+
+
+def test_ragged_weighted_interval_forces_every_intersecting_key_block_exact():
+    r = m.build_attention_measure_request(
+        q_rows=303,
+        kv_rows=303,
+        video_start=63,
+        temporal=3,
+        prefix_t=1,
+        source_grid=(8, 8),
+        prefix_grid=(8, 14),
+    )
+    assert m.nonunit_exact_key_ranges(r, block_size=64) == ((0, 192),)
+
+
+def test_boolean_integer_and_nonfinite_inputs_rejected():
+    r = request()
+    bad = dict(r)
+    bad["q_rows"] = True
+    with pytest.raises(TypeError):
+        m.validate_attention_measure_request(bad)
+    bad = {**r, "segments": [dict(s) for s in r["segments"]]}
+    bad["segments"][1]["mass_num"] = False
+    with pytest.raises(TypeError):
+        m.validate_attention_measure_request(bad)
+    with pytest.raises(TypeError):
+        m.materialize_key_log_measure(r, dtype=torch.int64)
+    bias = m.materialize_key_log_measure(r)
+    bias[0] = float("nan")
+    q = torch.zeros(1, 1, 1, 2)
+    k = torch.zeros(1, 1, 30, 2)
+    v = torch.zeros(1, 1, 30, 2)
+    with pytest.raises(ValueError):
+        m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias)
+
+
+def test_masks_and_all_masked_rows_are_stable_and_chunk_invariant():
+    torch.manual_seed(3)
+    q = torch.randn(1, 2, 4, 8, dtype=torch.float64)
+    k = torch.randn(1, 2, 30, 8, dtype=torch.float64)
+    v = torch.randn(1, 2, 30, 5, dtype=torch.float64)
+    bias = m.materialize_key_log_measure(request())
+    mask = torch.ones(1, 1, 4, 30, dtype=torch.bool)
+    mask[..., 1, :] = False
+    mask[..., 2, 9:] = False
+    dense = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, mask=mask)
+    streamed = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, mask=mask, key_chunk_size=7)
+    torch.testing.assert_close(streamed, dense, rtol=1e-12, atol=1e-12)
+    assert torch.count_nonzero(dense[..., 1, :]) == 0
+
+    additive = torch.zeros(1, 1, 4, 30, dtype=torch.float64)
+    additive[..., 3, 10:] = float("-inf")
+    dense = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, mask=additive)
+    streamed = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, mask=additive, key_chunk_size=11)
+    torch.testing.assert_close(streamed, dense, rtol=1e-12, atol=1e-12)
+
+    bad_additive = additive.clone()
+    bad_additive[..., 0, 0] = float("nan")
+    with pytest.raises(ValueError):
+        m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, mask=bad_additive)
+
+
+def test_equal_unit_measure_matches_unweighted_softmax():
+    q = torch.tensor([[[[1.0, 2.0]]]], dtype=torch.float64)
+    k = torch.tensor([[[[1.0, 0.0], [0.0, 1.0]]]], dtype=torch.float64)
+    v = torch.tensor([[[[2.0], [7.0]]]], dtype=torch.float64)
+    bias = torch.zeros(2, dtype=torch.float64)
+    got = m.dense_weighted_attention_reference(q, k, v, key_log_measure=bias, scale=0.5)
+    scores = (q @ k.transpose(-1, -2)) * 0.5
+    expected = torch.softmax(scores, dim=-1) @ v
+    torch.testing.assert_close(got, expected, rtol=1e-14, atol=1e-14)

--- a/tests/test_mixed_grid.py
+++ b/tests/test_mixed_grid.py
@@ -11,10 +11,14 @@ import torch
 
 from h3_flow_regenerate.geometry import pack_streams
 from h3_flow_regenerate.mixed_grid import (
+    MIXED_GRID_MEASURE_PROFILE_LEGACY,
+    MIXED_GRID_MEASURE_PROFILE_OFF,
+    MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
     MixedGridPlan,
     build_mixed_grid_plan,
     carrier_layout,
     mixed_attention_measure_contract,
+    mixed_attention_measure_profile,
     mixed_mod_segments,
     mixed_positions,
 )
@@ -179,6 +183,7 @@ def test_stage_lifetimes_learned_context_and_original_prefix(monkeypatch, fail_s
         exact_prefix_mode="mixed_grid_low_suffix",
         transfer_mode="learned_3d",
         learned_upscaler=provider,
+        attention_measure_profile=MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
     )
     calls = []
 
@@ -187,6 +192,8 @@ def test_stage_lifetimes_learned_context_and_original_prefix(monkeypatch, fail_s
         calls.append(stage)
         contract = guider.model_options["transformer_options"].get(MIXED_GRID_KEY)
         assert (contract is not None) == (stage != "high")
+        if contract is not None:
+            assert contract["plan"].measure_profile == MIXED_GRID_MEASURE_PROFILE_WEIGHTED
         if stage == fail_stage:
             raise RuntimeError("test stage failure")
         if stage == "high":
@@ -330,6 +337,103 @@ def test_mixed_attention_measure_contract_00318_geometry():
 def test_mixed_attention_measure_is_off_by_default():
     plan = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6)
     assert mixed_attention_measure_contract(plan, video_start=5, sequence_rows=83) is None
+
+
+def test_explicit_measure_profile_is_independent_of_legacy_seam_control():
+    prefix = torch.randn(1, 24, 2, 8, 12)
+    weighted = MixedGridPlan(
+        prefix, 7, 4, 6, attention_measure=False, measure_profile=MIXED_GRID_MEASURE_PROFILE_WEIGHTED
+    )
+    assert mixed_attention_measure_profile(weighted) == MIXED_GRID_MEASURE_PROFILE_WEIGHTED
+    assert mixed_attention_measure_contract(weighted, video_start=5, sequence_rows=83)["operator"] == "key_log_measure"
+
+    explicit_off = MixedGridPlan(
+        prefix, 7, 4, 6, attention_measure=True, measure_profile=MIXED_GRID_MEASURE_PROFILE_OFF
+    )
+    assert mixed_attention_measure_profile(explicit_off) == MIXED_GRID_MEASURE_PROFILE_OFF
+    assert mixed_attention_measure_contract(explicit_off, video_start=5, sequence_rows=83) is None
+
+    explicit_legacy = MixedGridPlan(
+        prefix, 7, 4, 6, attention_measure=False, measure_profile=MIXED_GRID_MEASURE_PROFILE_LEGACY
+    )
+    assert mixed_attention_measure_profile(explicit_legacy) == MIXED_GRID_MEASURE_PROFILE_LEGACY
+    legacy = mixed_attention_measure_contract(explicit_legacy, video_start=5, sequence_rows=83)
+    assert legacy["mode"] == "prefix_kv_stratified_subsample"
+
+    migrated = MixedGridPlan(prefix, 7, 4, 6, attention_measure=True)
+    assert mixed_attention_measure_profile(migrated) == MIXED_GRID_MEASURE_PROFILE_LEGACY
+
+
+def test_weighted_measure_profile_publishes_generic_all_row_contract():
+    from h3_flow_regenerate.attention_measure import ATTENTION_MEASURE_KEY
+    from h3_flow_regenerate.mixed_grid import (
+        MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+        _mixed_attention_measure_key,
+    )
+
+    plan = MixedGridPlan(
+        torch.randn(1, 24, 12, 56, 76),
+        62,
+        40,
+        54,
+        measure_profile=MIXED_GRID_MEASURE_PROFILE_WEIGHTED,
+    )
+    contract = mixed_attention_measure_contract(plan, video_start=16261, sequence_rows=56029)
+    assert contract == {
+        "api": 1,
+        "operator": "key_log_measure",
+        "normalization": "h3_native_source_carrier_v1",
+        "topology": "mixed_grid_low_suffix",
+        "q_rows": 56029,
+        "kv_rows": 56029,
+        "video_start": 16261,
+        "temporal": 62,
+        "prefix_t": 12,
+        "source_grid": [20, 27],
+        "prefix_grid": [28, 38],
+        "segments": [
+            {"start": 0, "stop": 16261, "mass_num": 1, "mass_den": 1},
+            {"start": 16261, "stop": 29029, "mass_num": 135, "mass_den": 266},
+            {"start": 29029, "stop": 56029, "mass_num": 1, "mass_den": 1},
+        ],
+        "coordinate_policy": "minimax_h3_native_frame_grid_v1",
+    }
+    assert _mixed_attention_measure_key(plan) == ATTENTION_MEASURE_KEY
+
+
+def test_released_attention_measure_flag_remains_legacy_representative_profile():
+    from h3_flow_regenerate.mixed_grid import (
+        MIXED_GRID_MEASURE_KEY,
+        MIXED_GRID_MEASURE_PROFILE_LEGACY,
+        _mixed_attention_measure_key,
+        mixed_attention_measure_profile,
+    )
+
+    plan = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6, attention_measure=True)
+    contract = mixed_attention_measure_contract(plan, video_start=5, sequence_rows=83)
+    assert mixed_attention_measure_profile(plan) == MIXED_GRID_MEASURE_PROFILE_LEGACY
+    assert contract["mode"] == "prefix_kv_stratified_subsample"
+    assert contract["expected_kv_rows"] == 47
+    assert _mixed_attention_measure_key(plan) == MIXED_GRID_MEASURE_KEY
+
+
+def test_invalid_or_ambiguous_measure_profile_fails_closed():
+    from h3_flow_regenerate.mixed_grid import (
+        MIXED_GRID_MEASURE_PROFILE_LEGACY,
+        mixed_attention_measure_profile,
+    )
+
+    bad = MixedGridPlan(torch.randn(1, 24, 2, 8, 12), 7, 4, 6, measure_profile="unknown")
+    with pytest.raises(ValueError, match="unsupported Mixed-Grid measure profile"):
+        mixed_attention_measure_profile(bad)
+    explicit_legacy = MixedGridPlan(
+        torch.randn(1, 24, 2, 8, 12),
+        7,
+        4,
+        6,
+        measure_profile=MIXED_GRID_MEASURE_PROFILE_LEGACY,
+    )
+    assert mixed_attention_measure_profile(explicit_legacy) == MIXED_GRID_MEASURE_PROFILE_LEGACY
 
 
 def test_native_forward_uses_authoritative_prefix_and_real_suffix(monkeypatch, native):

--- a/tests/test_state_transport.py
+++ b/tests/test_state_transport.py
@@ -1,0 +1,156 @@
+from __future__ import annotations
+
+import pytest
+import torch
+
+from h3_flow_regenerate.geometry import resize_spatial_5d
+from h3_flow_regenerate.state_transport import (
+    HANDOFF_STATE_POLICY_LEGACY,
+    HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    resolve_handoff_state_policy,
+    transport_velocity_bicubic_v1,
+)
+
+
+def _video(shape, *, dtype=torch.float32, seed=0):
+    generator = torch.Generator(device="cpu")
+    generator.manual_seed(seed)
+    return torch.randn(shape, generator=generator, dtype=dtype)
+
+
+def test_policy_resolution_preserves_omitted_legacy_behavior():
+    assert resolve_handoff_state_policy(None) == HANDOFF_STATE_POLICY_LEGACY
+    assert resolve_handoff_state_policy(HANDOFF_STATE_POLICY_LEGACY) == HANDOFF_STATE_POLICY_LEGACY
+    assert (
+        resolve_handoff_state_policy(HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1)
+        == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+    )
+    with pytest.raises(ValueError, match="unsupported handoff_state_policy"):
+        resolve_handoff_state_policy("unknown")
+    with pytest.raises(TypeError, match="string or None"):
+        resolve_handoff_state_policy(True)
+
+
+def test_velocity_transport_matches_bicubic_linear_state_lift():
+    prefix_t = 2
+    source_clean = _video((1, 24, 5, 4, 6), dtype=torch.float32, seed=1)
+    displacement = _video(source_clean.shape, dtype=torch.float32, seed=2) * 0.2
+    source_state = source_clean + displacement
+    target_clean = resize_spatial_5d(source_clean, 8, 10, mode="bicubic")
+
+    transported, metrics = transport_velocity_bicubic_v1(
+        source_state,
+        source_clean,
+        target_clean,
+        prefix_t=prefix_t,
+    )
+    expected = resize_spatial_5d(source_state, 8, 10, mode="bicubic")
+
+    # Prefix is staging clean and deliberately not source-state transported.
+    assert torch.equal(transported[:, :, :prefix_t], target_clean[:, :, :prefix_t])
+    torch.testing.assert_close(
+        transported[:, :, prefix_t:],
+        expected[:, :, prefix_t:],
+        rtol=2e-5,
+        atol=2e-5,
+    )
+    assert metrics["handoff_state_policy"] == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+    assert metrics["state_transport_added_rng"] is False
+
+
+def test_velocity_transport_preserves_reanchored_displacement_not_endpoint_policy():
+    prefix_t = 1
+    source_clean = torch.zeros((1, 24, 3, 4, 4), dtype=torch.float32)
+    source_state = source_clean.clone()
+    source_state[:, :, 1:] = 0.75
+    target_clean = torch.zeros((1, 24, 3, 6, 8), dtype=torch.float32)
+    target_clean[:, :, 1:] = 2.0
+
+    transported, _ = transport_velocity_bicubic_v1(
+        source_state,
+        source_clean,
+        target_clean,
+        prefix_t=prefix_t,
+    )
+
+    # U(X-C) is the constant 0.75 field, so velocity/displacement transport
+    # re-anchors that field on C_target and yields 2.75, not a re-noised state.
+    torch.testing.assert_close(
+        transported[:, :, 1:],
+        torch.full_like(transported[:, :, 1:], 2.75),
+        rtol=0,
+        atol=1e-6,
+    )
+
+
+def test_velocity_transport_preserves_fp64_oracle_and_one_axis_growth():
+    prefix_t = 1
+    source_clean = _video((1, 24, 3, 4, 6), dtype=torch.float64, seed=3)
+    source_state = source_clean + _video(source_clean.shape, dtype=torch.float64, seed=4) * 0.1
+    target_clean = (
+        torch.nn.functional.interpolate(
+            source_clean.permute(0, 2, 1, 3, 4).reshape(3, 24, 4, 6),
+            size=(4, 10),
+            mode="bicubic",
+            align_corners=False,
+            antialias=False,
+        )
+        .reshape(1, 3, 24, 4, 10)
+        .permute(0, 2, 1, 3, 4)
+    )
+
+    transported, metrics = transport_velocity_bicubic_v1(
+        source_state,
+        source_clean,
+        target_clean,
+        prefix_t=prefix_t,
+    )
+
+    assert transported.dtype == torch.float64
+    assert metrics["state_transport_compute_dtype"] == "torch.float64"
+    expected_displacement = (
+        torch.nn.functional.interpolate(
+            (source_state[:, :, prefix_t:] - source_clean[:, :, prefix_t:]).permute(0, 2, 1, 3, 4).reshape(2, 24, 4, 6),
+            size=(4, 10),
+            mode="bicubic",
+            align_corners=False,
+            antialias=False,
+        )
+        .reshape(1, 2, 24, 4, 10)
+        .permute(0, 2, 1, 3, 4)
+    )
+    torch.testing.assert_close(
+        transported[:, :, prefix_t:] - target_clean[:, :, prefix_t:],
+        expected_displacement,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+def test_velocity_transport_does_not_mutate_inputs():
+    source_clean = _video((1, 24, 4, 4, 4), seed=5)
+    source_state = source_clean + 0.1
+    target_clean = _video((1, 24, 4, 6, 6), seed=6)
+    snapshots = tuple(tensor.clone() for tensor in (source_state, source_clean, target_clean))
+
+    transport_velocity_bicubic_v1(source_state, source_clean, target_clean, prefix_t=2)
+
+    for tensor, snapshot in zip((source_state, source_clean, target_clean), snapshots, strict=True):
+        assert torch.equal(tensor, snapshot)
+
+
+def test_velocity_transport_rejects_invalid_geometry_and_nonfinite_state():
+    source_clean = torch.zeros((1, 24, 4, 6, 6), dtype=torch.float32)
+    source_state = source_clean.clone()
+    target_clean = torch.zeros((1, 24, 4, 4, 8), dtype=torch.float32)
+    with pytest.raises(ValueError, match="must not shrink"):
+        transport_velocity_bicubic_v1(source_state, source_clean, target_clean, prefix_t=2)
+
+    target_clean = torch.zeros((1, 24, 4, 8, 8), dtype=torch.float32)
+    source_state = source_state.clone()
+    source_state[0, 0, 2, 0, 0] = float("nan")
+    with pytest.raises(ValueError, match="NaN or Inf"):
+        transport_velocity_bicubic_v1(source_state, source_clean, target_clean, prefix_t=2)
+
+    with pytest.raises(ValueError, match="nonempty exact prefix"):
+        transport_velocity_bicubic_v1(source_clean, source_clean, target_clean, prefix_t=0)

--- a/tests/test_state_transport_config.py
+++ b/tests/test_state_transport_config.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+import torch
+from test_handoff import FakeLearnedProvider
+
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.state_transport import (
+    HANDOFF_STATE_POLICY_LEGACY,
+    HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    resolve_handoff_state_policy,
+)
+from h3_flow_regenerate.target_sparse_node import H3ProgressiveMixedGridHandoff, H3ProgressiveTargetSparseHandoff
+
+
+def test_omitted_policy_keeps_serialized_mixed_grid_legacy_behavior():
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_scale=0.7,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+    )
+    assert config.handoff_state_policy is None
+    assert resolve_handoff_state_policy(config.handoff_state_policy) == HANDOFF_STATE_POLICY_LEGACY
+
+
+def test_velocity_policy_is_restricted_to_mixed_grid_learned_transfer():
+    provider = FakeLearnedProvider()
+    config = ProgressiveTargetInputConfig(
+        source_scale=0.7,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        handoff_state_policy=HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    )
+    assert config.handoff_state_policy == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+
+    with pytest.raises(ValueError, match="only supported by mixed-grid Continuum"):
+        ProgressiveTargetInputConfig(
+            source_scale=0.7,
+            handoff_state_policy=HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+        )
+
+    with pytest.raises(ValueError, match="unsupported handoff_state_policy"):
+        ProgressiveTargetInputConfig(
+            source_scale=0.7,
+            exact_prefix_mode="mixed_grid_low_suffix",
+            transfer_mode="learned_3d",
+            learned_upscaler=provider,
+            handoff_state_policy="endpoint_residual_v1",
+        )
+
+
+def test_mixed_grid_ui_exposes_legacy_default_without_changing_target_sparse_ui():
+    mixed = H3ProgressiveMixedGridHandoff.INPUT_TYPES()
+    state_policy = mixed["optional"]["handoff_state_policy"]
+    assert state_policy[0] == [HANDOFF_STATE_POLICY_LEGACY, HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1]
+    assert state_policy[1]["default"] == HANDOFF_STATE_POLICY_LEGACY
+
+    sparse = H3ProgressiveTargetSparseHandoff.INPUT_TYPES()
+    assert "handoff_state_policy" not in sparse.get("required", {})
+    assert "handoff_state_policy" not in sparse.get("optional", {})
+
+
+def test_velocity_policy_does_not_require_or_create_random_state_at_configuration_time():
+    provider = FakeLearnedProvider(output=torch.zeros(1, 24, 2, 8, 8))
+    before = torch.random.get_rng_state().clone()
+    ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=4,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        handoff_state_policy=HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    )
+    assert torch.equal(torch.random.get_rng_state(), before)

--- a/tests/test_state_transport_native.py
+++ b/tests/test_state_transport_native.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import ast
+import os
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+import pytest
+import torch
+
+from h3_flow_regenerate.runtime import (
+    _exact_probe_function,
+    _merge_preserved_noise,
+    _noise_argument,
+    _raw_sampler_state,
+)
+
+
+@pytest.fixture(scope="module")
+def native_sampling():
+    root = Path(os.environ.get("COMFYUI_ROOT", Path(__file__).resolve().parents[2] / "comfy"))
+    path = root / "comfy/model_sampling.py"
+    if not path.is_file():
+        if os.environ.get("COMFYUI_ROOT"):
+            raise FileNotFoundError(path)
+        pytest.skip("native source oracle runs in source-contract CI with COMFYUI_ROOT")
+
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    wanted = {"reshape_sigma", "CONST"}
+    nodes = [node for node in tree.body if isinstance(node, (ast.FunctionDef, ast.ClassDef)) and node.name in wanted]
+    found = {node.name for node in nodes}
+    if found != wanted:
+        raise AssertionError(f"pinned ComfyUI sampling oracle changed: found {sorted(found)}")
+
+    module = ModuleType("native_h3_state_sampling_oracle")
+    module.__dict__["torch"] = torch
+    exec(compile(ast.Module(body=nodes, type_ignores=[]), str(path), "exec"), module.__dict__)
+    return module
+
+
+@pytest.mark.parametrize("noise_scale", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("sigma", [1.0e-5, 0.37, 0.99999])
+def test_runtime_noise_reconstruction_closes_over_pinned_comfy_const(native_sampling, noise_scale, sigma):
+    native = native_sampling.CONST()
+    native.noise_scale = noise_scale
+    noise = torch.linspace(-1.3, 1.7, steps=96, dtype=torch.float64).reshape(1, 1, 96)
+    latent = torch.linspace(0.8, -0.6, steps=96, dtype=torch.float64).reshape_as(noise)
+    state = native.noise_scaling(torch.tensor(sigma, dtype=torch.float64), noise, latent)
+
+    base = SimpleNamespace(model_sampling=SimpleNamespace(noise_scale=noise_scale))
+    recovered = _noise_argument(base, state, sigma, latent)
+    torch.testing.assert_close(recovered, noise, rtol=1e-10, atol=1e-10)
+
+
+def test_split_sampler_return_reconstructs_exact_raw_state_with_pinned_inverse(native_sampling):
+    sigma = 0.8780487775802612
+    native = native_sampling.CONST()
+    raw_state = torch.linspace(-0.9, 1.1, steps=120, dtype=torch.float64).reshape(1, 1, 120)
+    returned = native.inverse_noise_scaling(torch.tensor(sigma, dtype=torch.float64), raw_state)
+    base = SimpleNamespace(process_latent_in=lambda value: value, latent_shapes=None)
+
+    recovered = _raw_sampler_state(base, returned, [(1, 1, 120)], sigma)
+    torch.testing.assert_close(recovered, raw_state, rtol=1e-12, atol=1e-12)
+
+
+def test_exact_probe_return_closes_to_clean_under_pinned_inverse(native_sampling):
+    sigma = 0.8780487775802612
+    clean = torch.linspace(-0.4, 0.7, steps=120, dtype=torch.float64).reshape(1, 1, 120)
+    state = torch.linspace(0.6, -0.2, steps=120, dtype=torch.float64).reshape_as(clean)
+
+    def model(_x, _sigma, **_kwargs):
+        return clean
+
+    returned = _exact_probe_function(model, state, torch.tensor([sigma], dtype=torch.float64))
+    native = native_sampling.CONST()
+    accepted = native.inverse_noise_scaling(torch.tensor(sigma, dtype=torch.float64), returned)
+    torch.testing.assert_close(accepted, clean, rtol=1e-12, atol=1e-12)
+
+
+def test_protected_noise_merge_keeps_caller_owned_noise_exactly():
+    generated = torch.arange(12, dtype=torch.float32).reshape(1, 1, 12)
+    caller = -generated - 1.0
+    mask = torch.ones_like(generated)
+    mask[..., :5] = 0.0
+
+    merged = _merge_preserved_noise(generated, caller, mask)
+    assert torch.equal(merged[..., :5], caller[..., :5])
+    assert torch.equal(merged[..., 5:], generated[..., 5:])

--- a/tests/test_state_transport_runtime.py
+++ b/tests/test_state_transport_runtime.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType, SimpleNamespace
+
+import torch
+from test_handoff import FakeLearnedProvider
+from test_mixed_grid import inputs
+
+from h3_flow_regenerate.geometry import pack_streams, resize_spatial_5d, unpack_streams
+from h3_flow_regenerate.handoff import ProgressiveTargetInputConfig
+from h3_flow_regenerate.runtime import FlowBinding, _run_progressive
+from h3_flow_regenerate.state_transport import HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+
+
+def test_mixed_grid_velocity_transport_preserves_state_noise_audio_and_sampler_boundaries(monkeypatch):
+    fake = ModuleType("comfy")
+    fake.samplers = ModuleType("comfy.samplers")
+    fake.samplers.KSAMPLER = lambda function, **kw: SimpleNamespace(sampler_function=function, extra_options={})
+    monkeypatch.setitem(sys.modules, "comfy", fake)
+    monkeypatch.setitem(sys.modules, "comfy.samplers", fake.samplers)
+
+    caller_packed, target_shapes, mask = inputs(t=7, prefix=2, h=8, w=12)
+    caller_video, caller_audio = unpack_streams(caller_packed, target_shapes)
+    # Keep the runtime fixture in a realistic latent range. The generic mixed-grid
+    # helper intentionally uses a large arange tensor, which makes the native
+    # noise->state reconstruction lose precision through cancellation and tests
+    # float32 conditioning rather than state-transport semantics.
+    caller_video = torch.linspace(
+        -0.8,
+        0.8,
+        steps=caller_video.numel(),
+        dtype=caller_video.dtype,
+    ).reshape_as(caller_video)
+    caller_packed, _ = pack_streams((caller_video, caller_audio))
+    caller_noise = torch.randn_like(caller_packed)
+    source_shapes = list(target_shapes)
+    source_shapes[0] = (*source_shapes[0][:-2], 4, 6)
+
+    source_clean_video = torch.linspace(
+        -0.6,
+        0.9,
+        steps=24 * 7 * 4 * 6,
+        dtype=torch.float32,
+    ).reshape(1, 24, 7, 4, 6)
+    source_displacement = torch.linspace(
+        -0.2,
+        0.3,
+        steps=24 * 7 * 4 * 6,
+        dtype=torch.float32,
+    ).reshape_as(source_clean_video)
+    source_state_video = source_clean_video + source_displacement
+    realized_source_displacement = source_state_video - source_clean_video
+    source_audio_state = torch.linspace(
+        -0.4,
+        0.5,
+        steps=32 * 2 * 11,
+        dtype=torch.float32,
+    ).reshape(1, 32, 2, 11)
+    source_audio_clean = torch.zeros_like(source_audio_state)
+    source_state_packed, _ = pack_streams((source_state_video, source_audio_state))
+    source_clean_packed, _ = pack_streams((source_clean_video, source_audio_clean))
+
+    target_clean_video = torch.linspace(
+        -1.0,
+        1.2,
+        steps=24 * 7 * 8 * 12,
+        dtype=torch.float32,
+    ).reshape(1, 24, 7, 8, 12)
+    provider = FakeLearnedProvider(output=target_clean_video)
+    config = ProgressiveTargetInputConfig(
+        source_latent_h=4,
+        source_latent_w=6,
+        exact_prefix_mode="mixed_grid_low_suffix",
+        transfer_mode="learned_3d",
+        learned_upscaler=provider,
+        suffix_dc_bridge=False,
+        suffix_geometric_bridge=False,
+        handoff_state_policy=HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1,
+    )
+
+    base = SimpleNamespace(process_latent_in=lambda value: value, diffusion_model=SimpleNamespace(blocks=[]))
+    guider = SimpleNamespace(
+        model_options={"transformer_options": {}},
+        model_patcher=SimpleNamespace(model=base),
+        conds={"positive": []},
+    )
+    binding = FlowBinding()
+    sampler = SimpleNamespace(sampler_function=lambda: None, extra_options={})
+    calls: list[str] = []
+    observed = {}
+
+    import h3_flow_regenerate.runtime as runtime
+
+    real_deterministic_video_noise = runtime.deterministic_video_noise
+    deterministic_noise_calls = []
+
+    def counted_deterministic_video_noise(*args, **kwargs):
+        deterministic_noise_calls.append((args, kwargs))
+        return real_deterministic_video_noise(*args, **kwargs)
+
+    monkeypatch.setattr(runtime, "deterministic_video_noise", counted_deterministic_video_noise)
+
+    def execute(noise, latent, call_sampler, sigmas, call_mask, *args, latent_shapes):
+        stage = guider.model_options["transformer_options"]["h3_flow_stage"]
+        calls.append(stage)
+        if stage == "low":
+            sigma = float(sigmas[-1])
+            return source_state_packed.to(latent) / (1.0 - sigma)
+        if stage == "probe":
+            return source_clean_packed.to(latent)
+        if stage == "high":
+            sigma = float(sigmas[0])
+            assert torch.equal(latent, caller_packed)
+            assert torch.equal(call_mask, mask)
+            assert latent_shapes == target_shapes
+
+            input_video_noise, _ = unpack_streams(caller_noise, target_shapes)
+            high_video_noise, _ = unpack_streams(noise, target_shapes)
+            video_mask, _ = unpack_streams(mask, target_shapes)
+            protected = video_mask == 0
+            assert torch.equal(high_video_noise[protected], input_video_noise[protected])
+
+            initial_state = sigma * noise + (1.0 - sigma) * latent
+            initial_video, initial_audio = unpack_streams(initial_state, target_shapes)
+            lifted_displacement = resize_spatial_5d(realized_source_displacement, 8, 12, mode="bicubic")
+            expected_suffix = target_clean_video[:, :, 2:] + lifted_displacement[:, :, 2:]
+            torch.testing.assert_close(initial_video[:, :, 2:], expected_suffix, rtol=2e-5, atol=2e-5)
+            torch.testing.assert_close(initial_audio, source_audio_state, rtol=2e-5, atol=2e-5)
+            observed["initial_video"] = initial_video.clone()
+            binding.metrics.event("model_call", actual=True)
+            return caller_packed.clone()
+        raise AssertionError(stage)
+
+    result = _run_progressive(
+        execute,
+        guider,
+        binding,
+        config,
+        caller_noise,
+        caller_packed,
+        sampler,
+        torch.tensor([1.0, 0.9, 0.7, 0.4, 0.0]),
+        mask,
+        None,
+        True,
+        7,
+        list(target_shapes),
+    )
+
+    assert torch.equal(result, caller_packed)
+    assert calls == ["low", "probe", "high"]
+    assert len(provider.calls) == 1
+    # The only deterministic transfer-independent draw is the existing private
+    # low-grid source noise. velocity_bicubic_v1 adds no target-grid random field.
+    assert len(deterministic_noise_calls) == 1
+
+    original_video, _ = unpack_streams(caller_packed, target_shapes)
+    expected_provider_context = resize_spatial_5d(original_video[:, :, :2], 4, 6, mode="bicubic")
+    assert torch.equal(provider.calls[0][0][:, :, :2], expected_provider_context)
+
+    transport_events = [event for event in binding.metrics.events if event.kind == "mixed_grid_state_transport"]
+    assert len(transport_events) == 1
+    transport = transport_events[0].fields
+    assert transport["handoff_state_policy"] == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+    assert transport["state_transport_applied"] is True
+    assert transport["state_transport_added_rng"] is False
+    assert transport["state_transport_temporal_mixing"] is False
+    assert transport["state_transport_amplitude_normalization"] is False
+    assert transport["state_transport_source_roundtrip_max_abs"] <= 1e-6
+    assert transport["state_transport_target_closure_max_abs"] <= 2e-6
+
+    complete = [event for event in binding.metrics.events if event.kind == "handoff_complete"]
+    assert len(complete) == 1
+    assert complete[0].fields["sampler_invocation_count"] == 3
+    assert complete[0].fields["history_boundary_count"] == 2
+    assert complete[0].fields["exact_probe_performed"] is True
+    assert complete[0].fields["handoff_state_policy"] == HANDOFF_STATE_POLICY_VELOCITY_BICUBIC_V1
+    assert binding.metrics.counters["handoff_exact_probe_nfe"] == 1

--- a/tests/test_target_sparse_node.py
+++ b/tests/test_target_sparse_node.py
@@ -153,6 +153,9 @@ def test_mixed_grid_ui_defaults_match_canonical_workflow():
     assert required["handoff_transfer"][1]["default"] == "learned_3d"
     assert required["suffix_dc_bridge"][1]["default"] is True
     assert inputs["optional"]["suffix_geometric_bridge"][1]["default"] is True
+    profile = inputs["optional"]["attention_measure_profile"]
+    assert profile[0] == ["weighted_measure_v1", "legacy_representative_v1", "off"]
+    assert profile[1]["default"] == "weighted_measure_v1"
 
 
 def test_mixed_grid_direct_call_defaults_to_learned_transfer_and_seam_repair(monkeypatch):
@@ -179,7 +182,32 @@ def test_mixed_grid_direct_call_defaults_to_learned_transfer_and_seam_repair(mon
     assert progressive.transfer_mode == "learned_3d"
     assert progressive.suffix_dc_bridge is True
     assert progressive.suffix_geometric_bridge is True
+    # Direct calls that omit the new field intentionally retain serialized legacy semantics.
+    assert progressive.attention_measure_profile is None
     assert progressive.learned_upscaler is kwargs["learned_upscaler"]
+
+
+def test_mixed_grid_explicit_weighted_profile_reaches_runtime_config(monkeypatch):
+    captured = {}
+
+    def fake_patch_flow_model(model, **kwargs):
+        captured.update(kwargs)
+        return model, object()
+
+    monkeypatch.setattr("h3_flow_regenerate.target_sparse_node.patch_flow_model", fake_patch_flow_model)
+    kwargs = _patch_kwargs()
+    kwargs.update(
+        handoff_transfer="learned_3d",
+        learned_upscaler=_LearnedProvider(),
+        attention_measure_profile="weighted_measure_v1",
+    )
+
+    H3ProgressiveMixedGridHandoff().patch(**kwargs)
+
+    progressive = captured["progressive"]
+    assert progressive.exact_prefix_mode == "mixed_grid_low_suffix"
+    assert progressive.attention_measure_profile == "weighted_measure_v1"
+    assert progressive.suffix_geometric_bridge is True
 
 
 def test_suffix_dc_bridge_is_exposed_only_on_continuum_specific_progressive_nodes():
@@ -187,6 +215,9 @@ def test_suffix_dc_bridge_is_exposed_only_on_continuum_specific_progressive_node
     sparse_inputs = H3ProgressiveTargetSparseHandoff.INPUT_TYPES()
     mixed_inputs = H3ProgressiveMixedGridHandoff.INPUT_TYPES()
     assert "suffix_dc_bridge" not in target_inputs["required"]
+    assert "attention_measure_profile" not in target_inputs.get("optional", {})
+    assert "attention_measure_profile" not in sparse_inputs.get("optional", {})
+    assert "attention_measure_profile" in mixed_inputs["optional"]
     for inputs in (sparse_inputs, mixed_inputs):
         bridge = inputs["required"]["suffix_dc_bridge"]
         assert bridge[0] == "BOOLEAN"

--- a/tools/check_state_transport_contracts.py
+++ b/tools/check_state_transport_contracts.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+
+def require(path: Path, *needles: str) -> None:
+    text = path.read_text(encoding="utf-8")
+    missing = [needle for needle in needles if needle not in text]
+    if missing:
+        raise SystemExit(f"{path}: missing state-transport contract fragments: {missing}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Validate pinned ComfyUI state-transport assumptions")
+    parser.add_argument("--comfy", type=Path, required=True)
+    parser.add_argument("--spectrum", type=Path, required=True)
+    args = parser.parse_args()
+
+    require(
+        args.comfy / "comfy/model_sampling.py",
+        "class CONST:",
+        "return model_input - model_output * sigma",
+        's = getattr(self, "noise_scale", 1.0)',
+        "return sigma * (s * noise) + (1.0 - sigma) * latent_image",
+        "return latent / (1.0 - sigma)",
+    )
+    require(
+        args.comfy / "comfy/samplers.py",
+        "class KSamplerX0Inpaint:",
+        "latent_mask = 1. - denoise_mask",
+        "noise=self.noise, latent_image=self.latent_image, denoise_mask=denoise_mask",
+        "out = out * denoise_mask + self.latent_image * latent_mask",
+        "self.model_options = comfy.model_patcher.create_model_options_clone(self.model_options)",
+        "extra_model_options = comfy.model_patcher.create_model_options_clone(self.model_options)",
+        "WrappersMP.OUTER_SAMPLE",
+        "WrappersMP.PREDICT_NOISE",
+        "WrappersMP.SAMPLER_SAMPLE",
+    )
+    require(
+        args.comfy / "comfy/model_patcher.py",
+        "def create_model_options_clone(orig_model_options: dict):",
+        "return comfy.patcher_extension.copy_nested_dicts(orig_model_options)",
+    )
+    require(
+        args.comfy / "comfy/patcher_extension.py",
+        "def copy_nested_dicts(input_dict: dict):",
+        "new_dict[key] = copy_nested_dicts(value)",
+        "new_dict[key] = value.copy()",
+        "self.wrappers = wrappers.copy()",
+        "return self.wrappers[self.idx](self, *args, **kwargs)",
+        "for w in wrappers.get(wrapper_type, {}).values():",
+    )
+    require(
+        args.spectrum / "comfyui_spectrum_h3/sampling.py",
+        "def copy_model_options_with_step(",
+        'transformer_options[ACTUAL_KEY] = bool(decision["actual"])',
+        "return executor(x, timestep, patched, seed)",
+    )
+    print("Pinned state-transport sampler, mask, wrapper, and model-options contracts validated")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Implements the Flow-side contracts for the Progressive Mixed-Grid attention-measure architecture from design PR #29 and the controlled handoff state-transport design in `docs/MIXED_GRID_HANDOFF_STATE_TRANSPORT_DESIGN.md`.

## Mixed-Grid attention measure

- canonical `attention_measure_v1` construction and strict geometry validation;
- normalized positive-rational per-key measure with semantic digesting;
- O(T) natural-log key-measure materialization;
- exact physical K-block derivation for every non-unit-measure interval;
- FP64 dense/streaming reference operators;
- explicit `weighted_measure_v1` runtime profile;
- block-local propagation of the authoritative Mixed-Grid measure and VDN external-sequence API-2 geometry.

The weighted profile preserves all mixed Q/K/V rows. Protected-prefix spatial carrier density is represented as `log(measure_k)` in softmax semantics; Flow does not delete or representative-subsample rows on this path.

## Controlled handoff state transport

Mixed-Grid now exposes an explicit `handoff_state_policy`:

- `legacy_renoise` — existing behavior and the serialization/default-compatible path;
- `velocity_bicubic_v1` — opt-in experimental state transport.

The new policy transports the accepted low-grid sampler displacement around the accepted exact-probe clean state rather than discarding that state and re-noising only the learned clean endpoint:

```text
R_source = X_source - C_source
R_target = bicubic_spatial(R_source)
X_target = C_target_reconciled + R_target
```

The lift is framewise spatial bicubic only (`align_corners=False`, `antialias=False`): no temporal mixing, amplitude normalization, or added random field. FP16/BF16/FP32 production arithmetic is promoted to FP32; FP64 is retained only for exact algebraic oracle coverage.

The learned 3D upscaler still runs exactly once. Its clean target is reconciled by the existing target-side clean-space boundary logic before the transported displacement is re-anchored onto it.

## Preserved ownership and execution boundaries

The implementation preserves:

- the caller-owned exact target prefix;
- the caller's original sampler noise in protected mask regions;
- carried audio sampler state;
- final target latent geometry;
- the existing low / exact-probe / high sampler lifetimes and history boundaries;
- the existing guidance path;
- VDN external-sequence API 2;
- weighted-attention provider ownership;
- legacy handoff behavior when the new policy is not selected.

`velocity_bicubic_v1` adds no sampler invocation, exact probe, H3 transformer evaluation, corrective evaluation, or target-grid RNG field.

The existing Flow attention and Mixed-Grid source blobs used by Spectrum's source-gated weighted BSA audit remain unchanged by the state-transport work (`attention.py` blob `c58c652f7b7d6030a2311f4805c3443615e432eb`, `mixed_grid.py` blob `41586100e74e43e2efbfc3ef30a9540647f1c8f6`).

## Native/source verification

The new source-contract coverage verifies the pinned ComfyUI sampler and wrapper assumptions used at the handoff boundary, including:

- MiniMax-H3/flow `noise_scaling` and `inverse_noise_scaling` conversions;
- prepared denoise-mask ownership and exact protected-latent restoration;
- nested model-options cloning;
- wrapper ordering/insertion semantics;
- Spectrum per-step cloned model-options propagation.

The runtime tests additionally prove target prefix/noise preservation, audio carry, one learned-upscaler call, target geometry retention, and unchanged low/probe/high invocation/history cardinality.

## Validation

The final PR head is one implementation commit over `main`:

- head: `f6a940fdc2fb6d31249a487aff5e4a1297151e9c`
- base: `970396db839ae7ab431b9718859f6d48a2e5019b`
- CI: run `34637498912`

That exact head passes all repository lanes:

- source-contract/native-oracle lane: passed;
- Python 3.10: passed;
- Python 3.11: passed;
- Python 3.12: passed;
- Python 3.13: passed;
- Ruff, formatting, pytest, compileall, package build, license metadata, and isolated wheel import: passed in every applicable lane.

These results establish structural/source correctness only. They do not establish decoded-media seam improvement.

## 00383 production baseline reviewed

The matching 00383 metrics/log establish the existing production baseline that the new policy must preserve when promoted:

- 18 logical calls / 14 actual H3 NFE / 4 Spectrum forecasts;
- low: 10L / 8A / 2F;
- probes: 2L / 2A / 0F;
- high: 6L / 4A / 2F;
- handoff sigma: `0.8780487775802612`;
- source latent grid: `40x52`;
- target latent grid: `56x74`;
- learned upscaler: `minimax_h3_latent_upscaler_3d_bf16.safetensors`;
- weighted SM120 production route present: 200 weighted Mixed-Grid calls covering 8,991,600 Q rows and 8,991,600 KV rows with no compatibility fallback in that matched section.

That is baseline evidence, not a `velocity_bicubic_v1` result. The existing 00383 seam diagnostics also show that the discontinuity remains after the first high-grid actual/forecast sequence, which is why state transport is being tested; algebraic closure alone is not accepted as evidence of visual improvement.

The captured production log identifies ComfyUI as `v0.35.0-15-g7803b74e` on local Patcher integration branch `patcher/stack`. That synthetic local stack commit is not published in the public ComfyUI repositories, so the exact installed source/provenance still has to be collected from the production checkout before a result is called a matched rerun. The release workflow family is available, but its Image Conveyor intentionally ships without embedded reference assets, so it is not sufficient to reconstruct the exact 00383 input by itself.

## Cross-stack ownership

Flow publishes the measure/geometry/state contracts; numerical attention ownership remains with the existing companions:

- ComfyUI core #16239 — generic key-measure binding, dense/BSA execution and exact K-block enforcement;
- comfy-kitchen #171 — chunked Sol-Attn natural-log key bias;
- Sol-H3 #9 — SM120 provider ownership and weighted exact-block execution;
- VDN-H3-Plus #14 — owner-bound learned gate + native `out_proj` epilogue;
- Spectrum #110 — completed-receipt and calibration/history proof for forecast reuse.

API-2 Mixed-Grid geometry does not imply that VDN is installed; the concrete downstream attention owner remains authoritative.

## Remaining promotion gates

This PR remains draft. `velocity_bicubic_v1` is not promoted as a new default until a matched production A/B establishes all of the following:

- exact installed `patcher/stack` and companion revisions are captured and verified;
- original 00383 workflow state/reference assets are reproduced;
- the schedule remains exactly 18L / 14A / 4F with no hidden correction NFE;
- caller prefix/noise, audio, target geometry, VDN ownership and weighted receipts remain valid in CUDA execution;
- decoded video shows an actual boundary/seam improvement without regressions in framing/composition, motion, reference fidelity or audio;
- weighted-stack performance remains acceptable.

Algebraic closure, unit tests, source contracts and hosted CI do not satisfy the media gate.

Authoritative documents:

- `docs/MIXED_GRID_MEASURE_ARCHITECTURE.md` — design PR #29;
- `docs/MIXED_GRID_HANDOFF_STATE_TRANSPORT_DESIGN.md` — controlled state-transport specification.

PR #29 remains design-only. PR #32 remains temporary diagnostic evidence and its diagnostic-only implementation was not folded into this PR.